### PR TITLE
Feature: String symbols from binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
             export GOARM=${{ matrix.goarm }}
           fi
           
-          go build -v -o qp-${{ matrix.arch }} ./cmd/qp
+          go build -ldflags="-s -w" -v -o qp-${{ matrix.arch }} ./cmd/qp
 
       - name: Upload built binary
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This is likely the cause of slower installations for binaries.