### PR TITLE
Fix: qp-git validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,9 +145,8 @@ jobs:
       - name: Generate pkgver for qp-git
         run: |
           cd qp-git
-          rm -rf src pkg qp
-
-          makepkg --nodeps --nobuild --noconfirm
+         
+          makepkg --nobuild --nodeps --clean --cleanbuild --noconfirm
           echo "Updated qp-git/pkgver to $(grep '^pkgver=' PKGBUILD | cut -d'=' -f2)"
 
           rm -rf src pkg qp          


### PR DESCRIPTION
Now we have two git sources for qp-git. The old clean up technique will not work here.