### PR TITLE
Feature: Add pkgbase field

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ qp [options]
   - `--where conflicts=sdl2`   -> query by packages that conflict with `sdl2`
   - `--where arch=x86_64`      -> query by packages that are built for `x86_64` CPUs
   - `--where license=GPL`      -> query by package licenses that contain `GPL`
-  - `--where description="linux kernel"` -> query by package descriptions that contain "linux kernel" 
+  - `--where description="linux kernel"` -> query by package descriptions that contain "linux kernel"
 - `-O <field>:<direction>` | `--order <field>:<direction>`: sort results ascending or descending (default sort is `date:asc`):
   - `date`    -> sort by installation date
   - `name`    -> sort alphabetically by package name
@@ -225,7 +225,7 @@ short-flag queries and long-flag queries can be combined.
 - `license` - package software license
 - `url` - the URL of the official site of the software being packaged
 - `description` - package description
-- `pkgbase` - for normal packages, this is the same as the package name. for split-packages, this name is what is used to refer to the group of packages. for more info, see the [documentation for package splitting](https://man.archlinux.org/man/PKGBUILD.5#PACKAGE_SPLITTING) 
+- `pkgbase` - name of the base package used to group split packages; for non-split packages, it is the same as the package name. 
 
 ### JSON output
 the `--json` flag outputs the package data as structured JSON instead of a table. this can be useful for scripts or automation.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ this package is compatible with the following distributions:
 
 ## features
 
-- list installed packages with date/timestamps, dependencies, provisions, requirements, size on disk, conflicts, architecture, license, description, and version
+- list installed packages with date/timestamps, dependencies, provisions, requirements, size on disk, conflicts, architecture, license, description, package, and version
 - query by explicitly installed packages
 - query by packages installed as dependencies
 - query by packages required by specified packages
@@ -109,11 +109,13 @@ this package is compatible with the following distributions:
 - [x] architecture query
 - [x] optimize query order (4% speed boost)
 - [ ] dependency count sort
+- [ ] replaces field
 - [x] license query
 - [ ] optional dependency field
 - [x] improve sorting efficiency (8% speed boost)
-- [ ] package base field
+- [x] package base field
 - [x] package description query
+- [ ] package base query
 
 ## installation
 
@@ -223,6 +225,7 @@ short-flag queries and long-flag queries can be combined.
 - `license` - package software license
 - `url` - the URL of the official site of the software being packaged
 - `description` - package description
+- `pkgbase` - for normal packages, this is the same as the package name. for split-packages, this name is what is used to refer to the group of packages. for more info, see the [documentation for package splitting](https://man.archlinux.org/man/PKGBUILD.5#PACKAGE_SPLITTING) 
 
 ### JSON output
 the `--json` flag outputs the package data as structured JSON instead of a table. this can be useful for scripts or automation.
@@ -238,15 +241,16 @@ output format:
 ```json
 [
   {
-    "timestamp": 1739294218,
-    "size": 4385422,
+    "timestamp": 1743448252,
+    "size": 4446373,
     "name": "tinysparql",
     "reason": "dependency",
-    "version": "3.8.2-2",
+    "version": "3.9.1-1",
     "arch": "aarch64",
     "license": "GPL-2.0-or-later",
     "url": "https://tinysparql.org/",
     "description": "Low-footprint RDF triple store with SPARQL 1.1 interface",
+    "pkgbase": "tinysparql",
     "depends": [
       "avahi",
       "gcc-libs",
@@ -259,8 +263,12 @@ output format:
       "libxml2",
       "sqlite"
     ],
+    "requiredBy": [
+      "gtk3",
+      "gtk4"
+    ],
     "provides": [
-      "tracker3=3.8.2",
+      "tracker3=3.9.1",
       "libtinysparql-3.0.so=0-64"
     ],
     "conflicts": [

--- a/internal/config/help.go
+++ b/internal/config/help.go
@@ -62,6 +62,8 @@ func PrintHelp() {
 	fmt.Println("  arch         Architecture the package was built for")
 	fmt.Println("  license      Package software license")
 	fmt.Println("  url          URL of the official site of the software being packaged")
+	fmt.Println("  description  Package description")
+	fmt.Println("  pkgbase      Name of the base package used to group split packages; for non-split packages, it is the same as the package name.")
 
 	fmt.Println("\nExamples:")
 	fmt.Println("  qp -l 10                      # Show the last 10 installed packages")

--- a/internal/consts/fields.go
+++ b/internal/consts/fields.go
@@ -8,6 +8,7 @@ const (
 	FieldArch
 	FieldLicense
 	FieldName
+	FieldPkgBase
 	FieldDescription
 	FieldUrl
 	FieldSize
@@ -26,6 +27,7 @@ const (
 	size        = "size"
 	version     = "version"
 	description = "description"
+	pkgBase     = "pkgbase"
 	depends     = "depends"
 	requiredBy  = "required-by"
 	provides    = "provides"
@@ -54,6 +56,7 @@ var FieldTypeLookup = map[string]FieldType{
 	license:     FieldLicense,
 	url:         FieldUrl,
 	description: FieldDescription,
+	pkgBase:     FieldPkgBase,
 	size:        FieldSize,
 	version:     FieldVersion,
 	depends:     FieldDepends,
@@ -63,18 +66,20 @@ var FieldTypeLookup = map[string]FieldType{
 }
 
 var FieldNameLookup = map[FieldType]string{
-	FieldDate:       date,
-	FieldName:       name,
-	FieldSize:       size,
-	FieldReason:     reason,
-	FieldVersion:    version,
-	FieldDepends:    depends,
-	FieldRequiredBy: requiredBy,
-	FieldProvides:   provides,
-	FieldConflicts:  conflicts,
-	FieldArch:       arch,
-	FieldLicense:    license,
-	FieldUrl:        url,
+	FieldDate:        date,
+	FieldName:        name,
+	FieldSize:        size,
+	FieldReason:      reason,
+	FieldVersion:     version,
+	FieldDepends:     depends,
+	FieldRequiredBy:  requiredBy,
+	FieldProvides:    provides,
+	FieldConflicts:   conflicts,
+	FieldArch:        arch,
+	FieldLicense:     license,
+	FieldUrl:         url,
+	FieldDescription: description,
+	FieldPkgBase:     pkgBase,
 }
 
 var (
@@ -98,5 +103,6 @@ var (
 		FieldLicense,
 		FieldUrl,
 		FieldDescription,
+		FieldPkgBase,
 	}
 )

--- a/internal/display/output_manager.go
+++ b/internal/display/output_manager.go
@@ -12,10 +12,9 @@ import (
 )
 
 type OutputManager struct {
-	mu             sync.Mutex
-	progressActive bool
-	lastMsgLength  int
-	terminalWidth  int
+	mu            sync.Mutex
+	lastMsgLength int
+	terminalWidth int
 }
 
 var manager = newOutputManager()

--- a/internal/display/render_json.go
+++ b/internal/display/render_json.go
@@ -90,6 +90,8 @@ func getJsonValues(pkg *pkgdata.PkgInfo, fields []consts.FieldType) *PkgInfoJson
 			filteredPackage.Url = pkg.Url
 		case consts.FieldDescription:
 			filteredPackage.Description = pkg.Description
+		case consts.FieldPkgBase:
+			filteredPackage.PkgBase = pkg.PkgBase
 		case consts.FieldDepends:
 			filteredPackage.Depends = flattenRelations(pkg.Depends)
 		case consts.FieldRequiredBy:

--- a/internal/display/render_json.go
+++ b/internal/display/render_json.go
@@ -18,6 +18,7 @@ type PkgInfoJson struct {
 	License     string   `json:"license,omitempty"`
 	Url         string   `json:"url,omitempty"`
 	Description string   `json:"description,omitempty"`
+	PkgBase     string   `json:"pkgbase,omitempty"`
 	Depends     []string `json:"depends,omitempty"`
 	RequiredBy  []string `json:"requiredBy,omitempty"`
 	Provides    []string `json:"provides,omitempty"`

--- a/internal/display/render_table.go
+++ b/internal/display/render_table.go
@@ -28,6 +28,7 @@ var columnHeaders = map[consts.FieldType]string{
 	consts.FieldLicense:     "LICENSE",
 	consts.FieldUrl:         "URL",
 	consts.FieldDescription: "DESCRIPTION",
+	consts.FieldPkgBase:     "PKGBASE",
 }
 
 // displays data in tab format
@@ -112,6 +113,8 @@ func getTableValue(pkg *pkgdata.PkgInfo, field consts.FieldType, ctx tableContex
 		return pkg.Url
 	case consts.FieldDescription:
 		return pkg.Description
+	case consts.FieldPkgBase:
+		return pkg.PkgBase
 	default:
 		return ""
 	}

--- a/internal/pipeline/phase/steps.go
+++ b/internal/pipeline/phase/steps.go
@@ -3,12 +3,10 @@ package phase
 import (
 	"fmt"
 	"qp/internal/config"
-	"qp/internal/consts"
 	out "qp/internal/display"
 	"qp/internal/pipeline/filtering"
 	"qp/internal/pipeline/meta"
 	"qp/internal/pkgdata"
-	"slices"
 )
 
 func LoadCacheStep(
@@ -48,19 +46,12 @@ func FetchStep(
 }
 
 func ReverseDepStep(
-	cfg config.Config,
+	_ config.Config,
 	pkgPtrs []*pkgdata.PkgInfo,
 	reportProgress ProgressReporter,
 	pipelineCtx *meta.PipelineContext,
 ) ([]*PkgInfo, error) {
 	if pipelineCtx.UsedCache {
-		return pkgPtrs, nil
-	}
-
-	_, hasRequiredByFilter := cfg.FilterQueries[consts.FieldRequiredBy]
-	hasRequiredByField := slices.Contains(cfg.Fields, consts.FieldRequiredBy)
-
-	if !hasRequiredByField && !hasRequiredByFilter {
 		return pkgPtrs, nil
 	}
 

--- a/internal/pkgdata/cache.go
+++ b/internal/pkgdata/cache.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	cachePath    = "/tmp/qp.cache"
-	cacheVersion = 2 // bump when updating structure of PkgInfo/Relation/pkginfo.proto
+	cacheVersion = 3 // bump when updating structure of PkgInfo/Relation/pkginfo.proto
 )
 
 func getDbModTime() (int64, error) {
@@ -98,6 +98,7 @@ func pkgsToProtos(pkgs []*PkgInfo) []*pb.PkgInfo {
 			License:     pkg.License,
 			Url:         pkg.Url,
 			Description: pkg.Description,
+			PkgBase:     pkg.PkgBase,
 			Depends:     relationsToProtos(pkg.Depends),
 			RequiredBy:  relationsToProtos(pkg.RequiredBy),
 			Provides:    relationsToProtos(pkg.Provides),
@@ -134,6 +135,7 @@ func protosToPkgs(pbPkgs []*pb.PkgInfo) []*PkgInfo {
 			License:     pbPkg.License,
 			Url:         pbPkg.Url,
 			Description: pbPkg.Description,
+			PkgBase:     pbPkg.PkgBase,
 			Depends:     protosToRelations(pbPkg.Depends),
 			RequiredBy:  protosToRelations(pbPkg.RequiredBy),
 			Provides:    protosToRelations(pbPkg.Provides),

--- a/internal/pkgdata/fetch.go
+++ b/internal/pkgdata/fetch.go
@@ -25,6 +25,7 @@ const (
 	fieldLicense     = "%LICENSE%"
 	fieldUrl         = "%URL%"
 	fieldDescription = "%DESC%"
+	fieldPkgBase     = "%BASE%"
 
 	PacmanDbPath = "/var/lib/pacman/local"
 )
@@ -134,8 +135,8 @@ func parseDescFile(descPath string) (*PkgInfo, error) {
 			line := string(bytes.TrimSpace(data[start:end]))
 
 			switch line {
-			case fieldName, fieldInstallDate, fieldSize, fieldReason,
-				fieldVersion, fieldArch, fieldLicense, fieldUrl, fieldDescription:
+			case fieldName, fieldInstallDate, fieldSize, fieldReason, fieldVersion,
+				fieldArch, fieldLicense, fieldUrl, fieldDescription, fieldPkgBase:
 				currentField = line
 
 			case fieldDepends, fieldProvides, fieldConflicts:
@@ -240,6 +241,9 @@ func applySingleLineField(pkg *PkgInfo, field string, value string) error {
 
 	case fieldDescription:
 		pkg.Description = value
+
+	case fieldPkgBase:
+		pkg.PkgBase = value
 
 	default:
 		// ignore unknown fields

--- a/internal/pkgdata/packageinfo.go
+++ b/internal/pkgdata/packageinfo.go
@@ -27,6 +27,7 @@ type PkgInfo struct {
 	License     string
 	Url         string
 	Description string
+	PkgBase     string
 	Depends     []Relation
 	RequiredBy  []Relation
 	Provides    []Relation

--- a/internal/protobuf/pkginfo.pb.go
+++ b/internal/protobuf/pkginfo.pb.go
@@ -9,11 +9,12 @@
 package protobuf
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -152,6 +153,7 @@ type PkgInfo struct {
 	License       string                 `protobuf:"bytes,7,opt,name=license,proto3" json:"license,omitempty"`
 	Url           string                 `protobuf:"bytes,8,opt,name=url,proto3" json:"url,omitempty"`
 	Description   string                 `protobuf:"bytes,13,opt,name=description,proto3" json:"description,omitempty"`
+	PkgBase       string                 `protobuf:"bytes,14,opt,name=pkg_base,json=pkgBase,proto3" json:"pkg_base,omitempty"`
 	Depends       []*Relation            `protobuf:"bytes,9,rep,name=depends,proto3" json:"depends,omitempty"`
 	RequiredBy    []*Relation            `protobuf:"bytes,10,rep,name=required_by,json=requiredBy,proto3" json:"required_by,omitempty"`
 	Provides      []*Relation            `protobuf:"bytes,11,rep,name=provides,proto3" json:"provides,omitempty"`
@@ -253,6 +255,13 @@ func (x *PkgInfo) GetDescription() string {
 	return ""
 }
 
+func (x *PkgInfo) GetPkgBase() string {
+	if x != nil {
+		return x.PkgBase
+	}
+	return ""
+}
+
 func (x *PkgInfo) GetDepends() []*Relation {
 	if x != nil {
 		return x.Depends
@@ -349,7 +358,7 @@ const file_protobuf_pkginfo_proto_rawDesc = "" +
 	"\bRelation\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\tR\aversion\x12/\n" +
-	"\boperator\x18\x03 \x01(\x0e2\x13.pkginfo.RelationOpR\boperator\"\xa4\x03\n" +
+	"\boperator\x18\x03 \x01(\x0e2\x13.pkginfo.RelationOpR\boperator\"\xbf\x03\n" +
 	"\aPkgInfo\x12\x1c\n" +
 	"\ttimestamp\x18\x01 \x01(\x03R\ttimestamp\x12\x12\n" +
 	"\x04size\x18\x02 \x01(\x03R\x04size\x12\x12\n" +
@@ -359,7 +368,8 @@ const file_protobuf_pkginfo_proto_rawDesc = "" +
 	"\x04arch\x18\x06 \x01(\tR\x04arch\x12\x18\n" +
 	"\alicense\x18\a \x01(\tR\alicense\x12\x10\n" +
 	"\x03url\x18\b \x01(\tR\x03url\x12 \n" +
-	"\vdescription\x18\r \x01(\tR\vdescription\x12+\n" +
+	"\vdescription\x18\r \x01(\tR\vdescription\x12\x19\n" +
+	"\bpkg_base\x18\x0e \x01(\tR\apkgBase\x12+\n" +
 	"\adepends\x18\t \x03(\v2\x11.pkginfo.RelationR\adepends\x122\n" +
 	"\vrequired_by\x18\n" +
 	" \x03(\v2\x11.pkginfo.RelationR\n" +
@@ -393,14 +403,16 @@ func file_protobuf_pkginfo_proto_rawDescGZIP() []byte {
 	return file_protobuf_pkginfo_proto_rawDescData
 }
 
-var file_protobuf_pkginfo_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_protobuf_pkginfo_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
-var file_protobuf_pkginfo_proto_goTypes = []any{
-	(RelationOp)(0),    // 0: pkginfo.RelationOp
-	(*Relation)(nil),   // 1: pkginfo.Relation
-	(*PkgInfo)(nil),    // 2: pkginfo.PkgInfo
-	(*CachedPkgs)(nil), // 3: pkginfo.CachedPkgs
-}
+var (
+	file_protobuf_pkginfo_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+	file_protobuf_pkginfo_proto_msgTypes  = make([]protoimpl.MessageInfo, 3)
+	file_protobuf_pkginfo_proto_goTypes   = []any{
+		(RelationOp)(0),    // 0: pkginfo.RelationOp
+		(*Relation)(nil),   // 1: pkginfo.Relation
+		(*PkgInfo)(nil),    // 2: pkginfo.PkgInfo
+		(*CachedPkgs)(nil), // 3: pkginfo.CachedPkgs
+	}
+)
 var file_protobuf_pkginfo_proto_depIdxs = []int32{
 	0, // 0: pkginfo.Relation.operator:type_name -> pkginfo.RelationOp
 	1, // 1: pkginfo.PkgInfo.depends:type_name -> pkginfo.Relation

--- a/protobuf/pkginfo.proto
+++ b/protobuf/pkginfo.proto
@@ -31,6 +31,7 @@ message PkgInfo {
   string license = 7;
   string url = 8;
   string description = 13;
+  string pkg_base = 14;
 
   repeated Relation depends = 9;
   repeated Relation required_by = 10;

--- a/qp.1
+++ b/qp.1
@@ -1,5 +1,5 @@
 .\" Man page for qp
-.TH qp 1 "April 2025" "qp 4.1.0" "User Commands"
+.TH qp 1 "April 2025" "qp 4.2.0" "User Commands"
 .SH NAME
 qp \- List and query installed packages on Arch-based systems.
 .SH SYNOPSIS
@@ -8,13 +8,7 @@ qp \- List and query installed packages on Arch-based systems.
 
 .SH DESCRIPTION
 .B qp
-is a standalone CLI utility for Arch and Arch-based Linux distributions to list and query installed packages. It works with any package manager that uses ALPM,
-including
-.B yay,
-.B paru,
-.B pamac,
-.B pacman,
-and others.
+is a standalone CLI utility for Arch and Arch-based Linux distributions to list and query installed packages. It works with any package manager that uses ALPM, like pacman and others.
 
 The utility provides powerful querying capabilities, including:
 - Installation date queries
@@ -28,6 +22,7 @@ The utility provides powerful querying capabilities, including:
 - Package name queries
 - Architecture queries
 - Description queries
+- Package base queries
 - Sorting and JSON output
 
 .SH OPTIONS
@@ -227,5 +222,4 @@ Report bugs at:
 
 .SH SEE ALSO
 .BR pacman(8),
-.BR yay(8)
 


### PR DESCRIPTION
Users can now list the base package of meta/split packages with `qp -s pkgbase` or `qp -S pkgbase` or `qp -A`.

Addresses #152 