### PR TITLE
Feature: Add replaces field

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ you can find installation instructions [here](#installation).
 
 `qp` supports querying/sorting for install date, package name, install reason (explicit/dependency), size on disk, reverse dependencies, dependency requirements, description, and more. check [usage](#usage) for all available options.
 
-![qp logo | query packages logo](https://github.com/user-attachments/assets/9e3c04b6-b467-4340-a03d-fb627eac567d)
+![qp logo | query packages logo](https://gistcdn.githack.com/Zweih/9009d5c74eab8a5515a8a64a0495df32/raw/ef8a8ac3655fd3dee24494a3403867919d806b63/qp-logo_clean.svg)
 
 [![AUR version - qp](https://img.shields.io/aur/version/qp?style=flat-square&logo=arch-linux&logoColor=1793d1&label=qp&color=1793d1)](https://aur.archlinux.org/packages/qp)
 [![AUR version - qp-bin](https://img.shields.io/aur/version/qp-bin?style=flat-square&logo=arch-linux&logoColor=1793d1&label=qp-bin&color=1793d1)](https://aur.archlinux.org/packages/qp-bin)
@@ -79,7 +79,7 @@ this package is compatible with the following distributions:
 - [x] add CI to release binaries
 - [x] remove go as a dependency
 - [x] query by range of size on disk
-- [x] user defined columns
+- [x] user defined field selection
 - [x] dependencies of each package (dependency field)
 - [x] reverse-dependencies of each package (required-by field)
 - [x] package description field
@@ -93,7 +93,7 @@ this package is compatible with the following distributions:
 - [x] no-headers option
 - [x] provides query
 - [x] depends query
-- [x] all-columns option
+- [x] all-fields option
 - [x] required-by query
 - [ ] key/value output
 - [x] list of packages for package queries
@@ -171,7 +171,7 @@ qp [options]
 ### options
 - `-l <number>` | `--limit <number>`: limit the amount of recent packages to display (default: 20)
 - `-a` | `all`: show all installed packages (ignores `-l`)
-- `-w <field>=<value>` | `--where <field>=<value>`: apply multiple queries for a flexible query system. can be used multiple times. example:
+- `-w <field>=<value>` | `--where <field>=<value>`: apply multiple queries for a flexible query system. they can be used multiple times command. examples:
   - `--where size=10MB:1GB`    -> query by size range
   - `--where date=2024-01-01:` -> query by installation date
   - `--where reason=explicit`  -> query by explicit installations
@@ -207,7 +207,7 @@ short-flag queries and long-flag queries can be combined.
 #### available queries
 | query type  | syntax | description |
 |-------------|--------|-------------|
-| **license** | `license=<license>` / <br> `license=<license-1>,<license-2>,<etc` | query by license name (substring match) |
+| **license** | `license=<license>` / <br> `license=<license-1>,<license-2>,<etc>` | query by license name (substring match) |
 | **date** | `date=<value>` | query by installation date. supports exact dates, ranges (`YYYY-MM-DD:YYYY-MM-DD`), and open-ended ranges (`YYYY-MM-DD:` or `:YYYY-MM-DD`) |
 | **required by** | `required-by=<package>` / <br> `required-by=<package-1>,<package-2>,<etc>` | query by packages that are required by the specified packages |
 | **depends** | `depends=<package>` / <br> `depends=<package-1>,<package-2>,<etc>` | query by packages that have the specified packages as dependencies |
@@ -219,7 +219,7 @@ short-flag queries and long-flag queries can be combined.
 | **size** | `size=<value>` | query by package size on disk. supports exact values (`10MB`), ranges (`10MB:1GB`), and open-ended ranges (`:500KB`, `1GB:`) |
 | **description** | `description=<string>` / <br> `description=<string-1>,<string-2>,<etc>` | query by package description (substring match) |
 
-### available fields
+### available fields for selection
 - `date` - installation date of the package
 - `name` - package name
 - `reason` - installation reason (explicit/dependency)
@@ -229,6 +229,7 @@ short-flag queries and long-flag queries can be combined.
 - `required-by` - list of packages required by the package and are dependent (output can be long) 
 - `provides` - list of alternative package names or shared libraries provided by package (output can be long)
 - `conflicts` - list of packages that conflict, or cause problems, with the package
+- `replaces` - list of packages that are replaced by the package
 - `arch` - architecture the package was built for (e.g., x86_64, aarch64, any)
 - `license` - package software license
 - `url` - the URL of the official site of the software being packaged
@@ -281,6 +282,9 @@ output format:
     ],
     "conflicts": [
       "tracker3<=3.7.3-2"
+    ],
+    "replaces": [
+      "tracker3<=3.7.3-2"
     ]
   }
 ]
@@ -288,8 +292,8 @@ output format:
 
 ### tips & tricks
 
-- when using multiple short flags, the -l flag must be last since it consumes the next argument.
-this follows standard unix-style flag parsing, where positional arguments (like numbers)
+- when using multiple short flags at once (e.g. `-aw` or `-Al`), the flags like `-w`, `-l`, and `-s` must be last as they consume the next argument.
+this follows standard unix-style flag parsing, where positional arguments (like numbers and strings)
 are treated as separate parameters.
   
   invalid:
@@ -301,7 +305,7 @@ are treated as separate parameters.
   qp -aw name=yay  # correct usage
   ```
 
-- the `depends`, `provides`, `required-by` columns output can be lengthy, packages like `glibc` are required by thousands of packages. to improve readability, pipe the output to tools like `moar` or `less` (i prefer `moar`, but `less` is usually pre-installed):
+- the `depends`, `provides`, and `required-by` table columns can be lengthy. packages like `glibc` are required by thousands of packages. to improve readability, pipe the output to tools like `moar` or `less` (i prefer `moar`, but `less` is usually pre-installed):
   ```bash
   qp -s name,depends | less
   ```
@@ -325,7 +329,7 @@ are treated as separate parameters.
 
 - the `--no-headers` flag is useful when processing output in scripts. It removes the header row, making it easier to parse package lists with tools like `awk`, `sed`, or `cut`:
   ```bash
-  qp --no-headers --columns name,size | awk '{print $1, $2}'
+  qp --no-headers --select name,size | awk '{print $1, $2}'
   ```
 
 ### examples
@@ -414,7 +418,7 @@ are treated as separate parameters.
    ```bash
    qp -aA
    ```
-22. output all packages with all columns/fields in JSON format
+22. output all packages with all fields in JSON format
    ```bash
    qp -aA --json
    ```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -144,7 +144,7 @@ func ParseFlags(args []string) (Config, error) {
 		count = 0
 	}
 
-	fieldsParsed, err := parseFields(fieldInput, addFieldInput, hasAllFields)
+	fieldsParsed, err := parseSelection(fieldInput, addFieldInput, hasAllFields)
 	if err != nil {
 		return Config{}, err
 	}

--- a/internal/config/field.go
+++ b/internal/config/field.go
@@ -6,19 +6,19 @@ import (
 	"strings"
 )
 
-func parseFields(
+func parseSelection(
 	fieldInput string,
 	addFieldInput string,
 	hasAllFields bool,
 ) ([]consts.FieldType, error) {
-	var specifiedColumnsRaw string
+	var selectFieldsRaw string
 	var fields []consts.FieldType
 
 	switch {
 	case fieldInput != "":
-		specifiedColumnsRaw = fieldInput
+		selectFieldsRaw = fieldInput
 	case addFieldInput != "":
-		specifiedColumnsRaw = addFieldInput
+		selectFieldsRaw = addFieldInput
 		fallthrough
 	default:
 		if hasAllFields {
@@ -28,20 +28,17 @@ func parseFields(
 		}
 	}
 
-	if specifiedColumnsRaw != "" {
-		specifiedColumns := strings.Split(
-			strings.ToLower(strings.TrimSpace(specifiedColumnsRaw)),
-			",",
-		)
+	if selectFieldsRaw != "" {
+		cleanSelectFields := strings.ToLower(strings.TrimSpace(selectFieldsRaw))
 
-		for _, column := range specifiedColumns {
-			fieldType, exists := consts.FieldTypeLookup[strings.TrimSpace(column)]
+		for selectField := range strings.SplitSeq(cleanSelectFields, ",") {
+			field, exists := consts.FieldTypeLookup[strings.TrimSpace(selectField)]
 
 			if !exists {
-				return nil, fmt.Errorf("Error: '%s' is not a valid column", column)
+				return nil, fmt.Errorf("Error: '%s' is not a valid field for selection", selectField)
 			}
 
-			fields = append(fields, fieldType)
+			fields = append(fields, field)
 		}
 	}
 

--- a/internal/consts/fields.go
+++ b/internal/consts/fields.go
@@ -21,6 +21,7 @@ const (
 	FieldRequiredBy
 	FieldProvides
 	FieldConflicts
+	FieldReplaces
 )
 
 const (
@@ -40,6 +41,7 @@ const (
 	requiredBy  = "required-by"
 	provides    = "provides"
 	conflicts   = "conflicts"
+	replaces    = "replaces"
 	arch        = "arch"
 	license     = "license"
 	url         = "url"
@@ -73,6 +75,7 @@ var FieldTypeLookup = map[string]FieldType{
 	requiredBy:  FieldRequiredBy,
 	provides:    FieldProvides,
 	conflicts:   FieldConflicts,
+	replaces:    FieldReplaces,
 }
 
 var SubfieldTypeLookup = map[string]SubfieldType{
@@ -91,6 +94,7 @@ var FieldNameLookup = map[FieldType]string{
 	FieldRequiredBy:  requiredBy,
 	FieldProvides:    provides,
 	FieldConflicts:   conflicts,
+	FieldReplaces:    replaces,
 	FieldArch:        arch,
 	FieldLicense:     license,
 	FieldUrl:         url,
@@ -120,6 +124,7 @@ var (
 		FieldRequiredBy,
 		FieldProvides,
 		FieldConflicts,
+		FieldReplaces,
 		FieldArch,
 		FieldLicense,
 		FieldUrl,

--- a/internal/display/render_json.go
+++ b/internal/display/render_json.go
@@ -23,6 +23,7 @@ type PkgInfoJson struct {
 	RequiredBy  []string `json:"requiredBy,omitempty"`
 	Provides    []string `json:"provides,omitempty"`
 	Conflicts   []string `json:"conflicts,omitempty"`
+	Replaces    []string `json:"replaces,omitempty"`
 }
 
 func (o *OutputManager) renderJson(pkgPtrs []*pkgdata.PkgInfo, fields []consts.FieldType) {
@@ -102,6 +103,8 @@ func getJsonValues(pkg *pkgdata.PkgInfo, fields []consts.FieldType) *PkgInfoJson
 			filteredPackage.Provides = flattenRelations(pkg.Provides)
 		case consts.FieldConflicts:
 			filteredPackage.Conflicts = flattenRelations(pkg.Conflicts)
+		case consts.FieldReplaces:
+			filteredPackage.Replaces = flattenRelations(pkg.Replaces)
 		}
 	}
 

--- a/internal/display/render_table.go
+++ b/internal/display/render_table.go
@@ -23,6 +23,7 @@ var columnHeaders = map[consts.FieldType]string{
 	consts.FieldRequiredBy:  "REQUIRED BY",
 	consts.FieldProvides:    "PROVIDES",
 	consts.FieldConflicts:   "CONFLICTS",
+	consts.FieldReplaces:    "REPLACES",
 	consts.FieldArch:        "ARCH",
 	consts.FieldLicense:     "LICENSE",
 	consts.FieldUrl:         "URL",
@@ -104,6 +105,8 @@ func getTableValue(pkg *pkgdata.PkgInfo, field consts.FieldType, ctx tableContex
 		return formatRelations(pkg.Provides)
 	case consts.FieldConflicts:
 		return formatRelations(pkg.Conflicts)
+	case consts.FieldReplaces:
+		return formatRelations(pkg.Replaces)
 	case consts.FieldArch:
 		return pkg.Arch
 	case consts.FieldLicense:

--- a/internal/pkgdata/cache.go
+++ b/internal/pkgdata/cache.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	cacheVersion    = 4 // bump when updating structure of PkgInfo/Relation/pkginfo.proto
+	cacheVersion    = 5 // bump when updating structure of PkgInfo/Relation/pkginfo.proto
 	xdgCacheHomeEnv = "XDG_CACHE_HOME"
 	homeEnv         = "HOME"
 	qpCacheDir      = "query-packages"
@@ -132,6 +132,7 @@ func pkgsToProtos(pkgs []*PkgInfo) []*pb.PkgInfo {
 			RequiredBy:  relationsToProtos(pkg.RequiredBy),
 			Provides:    relationsToProtos(pkg.Provides),
 			Conflicts:   relationsToProtos(pkg.Conflicts),
+			Replaces:    relationsToProtos(pkg.Replaces),
 		}
 	}
 
@@ -170,6 +171,7 @@ func protosToPkgs(pbPkgs []*pb.PkgInfo) []*PkgInfo {
 			RequiredBy:  protosToRelations(pbPkg.RequiredBy),
 			Provides:    protosToRelations(pbPkg.Provides),
 			Conflicts:   protosToRelations(pbPkg.Conflicts),
+			Replaces:    protosToRelations(pbPkg.Replaces),
 		}
 	}
 

--- a/internal/pkgdata/fetch.go
+++ b/internal/pkgdata/fetch.go
@@ -26,6 +26,7 @@ const (
 	fieldUrl         = "%URL%"
 	fieldDescription = "%DESC%"
 	fieldPkgBase     = "%BASE%"
+	fieldReplaces    = "%REPLACES%"
 
 	PacmanDbPath = "/var/lib/pacman/local"
 )
@@ -139,7 +140,7 @@ func parseDescFile(descPath string) (*PkgInfo, error) {
 				fieldArch, fieldLicense, fieldUrl, fieldDescription, fieldPkgBase:
 				currentField = line
 
-			case fieldDepends, fieldProvides, fieldConflicts:
+			case fieldDepends, fieldProvides, fieldConflicts, fieldReplaces:
 				currentField = line
 				block, next := collectBlockBytes(data, end+1)
 
@@ -253,13 +254,17 @@ func applySingleLineField(pkg *PkgInfo, field string, value string) error {
 }
 
 func applyMultiLineField(pkg *PkgInfo, field string, lines []string) {
+	relations := parseRelations(lines)
+
 	switch field {
 	case fieldDepends:
-		pkg.Depends = parseRelations(lines)
+		pkg.Depends = relations
 	case fieldProvides:
-		pkg.Provides = parseRelations(lines)
+		pkg.Provides = relations
 	case fieldConflicts:
-		pkg.Conflicts = parseRelations(lines)
+		pkg.Conflicts = relations
+	case fieldReplaces:
+		pkg.Replaces = relations
 	}
 }
 

--- a/internal/pkgdata/packageinfo.go
+++ b/internal/pkgdata/packageinfo.go
@@ -33,4 +33,5 @@ type PkgInfo struct {
 	RequiredBy  []Relation
 	Provides    []Relation
 	Conflicts   []Relation
+	Replaces    []Relation
 }

--- a/internal/pkgdata/reverse_dependencies.go
+++ b/internal/pkgdata/reverse_dependencies.go
@@ -10,7 +10,7 @@ func CalculateReverseDependencies(
 	_ meta.ProgressReporter, // TODO: Add progress reporting
 ) ([]*PkgInfo, error) {
 	packagePointerMap := make(map[string]*PkgInfo)
-	packageDependencyMap := make(map[string][]Relation)
+	reverseDependencyTree := make(map[string][]Relation)
 	providesMap := make(map[string]string)
 	// key: provided library/package, value: package that provides it (provider)
 
@@ -36,8 +36,8 @@ func CalculateReverseDependencies(
 				continue // skip if a package names itself as a dependency
 			}
 
-			packageDependencyMap[depName] = append(
-				packageDependencyMap[depName],
+			reverseDependencyTree[depName] = append(
+				reverseDependencyTree[depName],
 				Relation{
 					Name:     pkg.Name,
 					Version:  depPackage.Version,
@@ -47,10 +47,10 @@ func CalculateReverseDependencies(
 		}
 	}
 
-	for name := range packageDependencyMap {
+	for name := range reverseDependencyTree {
 		if pkg, exists := packagePointerMap[name]; exists {
 			visited := map[string]int32{name: 0}
-			fullDependencyTree := walkReverseDeps(name, packageDependencyMap, visited)
+			fullDependencyTree := walkReverseDeps(name, reverseDependencyTree, visited)
 			pkg.RequiredBy = dedupToLowestDepth(fullDependencyTree)
 		}
 	}

--- a/internal/protobuf/pkginfo.pb.go
+++ b/internal/protobuf/pkginfo.pb.go
@@ -165,6 +165,7 @@ type PkgInfo struct {
 	RequiredBy    []*Relation            `protobuf:"bytes,10,rep,name=required_by,json=requiredBy,proto3" json:"required_by,omitempty"`
 	Provides      []*Relation            `protobuf:"bytes,11,rep,name=provides,proto3" json:"provides,omitempty"`
 	Conflicts     []*Relation            `protobuf:"bytes,12,rep,name=conflicts,proto3" json:"conflicts,omitempty"`
+	Replaces      []*Relation            `protobuf:"bytes,15,rep,name=replaces,proto3" json:"replaces,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -297,6 +298,13 @@ func (x *PkgInfo) GetConflicts() []*Relation {
 	return nil
 }
 
+func (x *PkgInfo) GetReplaces() []*Relation {
+	if x != nil {
+		return x.Replaces
+	}
+	return nil
+}
+
 type CachedPkgs struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	LastModified  int64                  `protobuf:"varint,1,opt,name=last_modified,json=lastModified,proto3" json:"last_modified,omitempty"`
@@ -366,7 +374,7 @@ const file_protobuf_pkginfo_proto_rawDesc = "" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\tR\aversion\x12/\n" +
 	"\boperator\x18\x03 \x01(\x0e2\x13.pkginfo.RelationOpR\boperator\x12\x14\n" +
-	"\x05depth\x18\x04 \x01(\x05R\x05depth\"\xbf\x03\n" +
+	"\x05depth\x18\x04 \x01(\x05R\x05depth\"\xee\x03\n" +
 	"\aPkgInfo\x12\x1c\n" +
 	"\ttimestamp\x18\x01 \x01(\x03R\ttimestamp\x12\x12\n" +
 	"\x04size\x18\x02 \x01(\x03R\x04size\x12\x12\n" +
@@ -383,7 +391,8 @@ const file_protobuf_pkginfo_proto_rawDesc = "" +
 	" \x03(\v2\x11.pkginfo.RelationR\n" +
 	"requiredBy\x12-\n" +
 	"\bprovides\x18\v \x03(\v2\x11.pkginfo.RelationR\bprovides\x12/\n" +
-	"\tconflicts\x18\f \x03(\v2\x11.pkginfo.RelationR\tconflicts\"q\n" +
+	"\tconflicts\x18\f \x03(\v2\x11.pkginfo.RelationR\tconflicts\x12-\n" +
+	"\breplaces\x18\x0f \x03(\v2\x11.pkginfo.RelationR\breplaces\"q\n" +
 	"\n" +
 	"CachedPkgs\x12#\n" +
 	"\rlast_modified\x18\x01 \x01(\x03R\flastModified\x12$\n" +
@@ -425,12 +434,13 @@ var file_protobuf_pkginfo_proto_depIdxs = []int32{
 	1, // 2: pkginfo.PkgInfo.required_by:type_name -> pkginfo.Relation
 	1, // 3: pkginfo.PkgInfo.provides:type_name -> pkginfo.Relation
 	1, // 4: pkginfo.PkgInfo.conflicts:type_name -> pkginfo.Relation
-	2, // 5: pkginfo.CachedPkgs.pkgs:type_name -> pkginfo.PkgInfo
-	6, // [6:6] is the sub-list for method output_type
-	6, // [6:6] is the sub-list for method input_type
-	6, // [6:6] is the sub-list for extension type_name
-	6, // [6:6] is the sub-list for extension extendee
-	0, // [0:6] is the sub-list for field type_name
+	1, // 5: pkginfo.PkgInfo.replaces:type_name -> pkginfo.Relation
+	2, // 6: pkginfo.CachedPkgs.pkgs:type_name -> pkginfo.PkgInfo
+	7, // [7:7] is the sub-list for method output_type
+	7, // [7:7] is the sub-list for method input_type
+	7, // [7:7] is the sub-list for extension type_name
+	7, // [7:7] is the sub-list for extension extendee
+	0, // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_protobuf_pkginfo_proto_init() }

--- a/protobuf/pkginfo.proto
+++ b/protobuf/pkginfo.proto
@@ -38,6 +38,7 @@ message PkgInfo {
   repeated Relation required_by = 10;
   repeated Relation provides = 11;
   repeated Relation conflicts = 12;
+  repeated Relation replaces = 15;
 }
 
 message CachedPkgs {


### PR DESCRIPTION
Users can now list the base package of meta/split packages with `qp -s replaces` or `qp -S replaces` or `qp -A`.

Addresses #160 