### PR TITLE
Feature: Comprehensive forward dependency resolution

### DIFF
--- a/cmd/qp/main.go
+++ b/cmd/qp/main.go
@@ -37,7 +37,7 @@ func mainWithConfig(configProvider config.ConfigProvider) error {
 	pipelinePhases := []phasekit.PipelinePhase{
 		phasekit.New("Loading cache", phasekit.LoadCacheStep, &wg),
 		phasekit.New("Fetching packages", phasekit.FetchStep, &wg),
-		phasekit.New("Calculating reverse dependencies", phasekit.ReverseDepStep, &wg),
+		phasekit.New("Resolving dependency tree", phasekit.ResolveDepTreeStep, &wg),
 		phasekit.New("Saving cache", phasekit.SaveCacheStep, &wg),
 		phasekit.New("Filtering", phasekit.FilterStep, &wg),
 		phasekit.New("Sorting", phasekit.SortStep, &wg),

--- a/internal/display/formatting.go
+++ b/internal/display/formatting.go
@@ -17,15 +17,17 @@ func formatRelations(relations []pkgdata.Relation) string {
 }
 
 func flattenRelations(relations []pkgdata.Relation) []string {
-	relationOutputs := make([]string, 0, len(relations))
+	relationsAtDepth := pkgdata.GetRelationsByDepth(relations, 1)
+	relationOutputs := make([]string, 0, len(relationsAtDepth))
 
-	for _, rel := range relations {
-		if rel.Operator == pkgdata.OpNone {
-			relationOutputs = append(relationOutputs, rel.Name)
-		} else {
-			op := relationOpToString(rel.Operator)
-			relationOutputs = append(relationOutputs, fmt.Sprintf("%s%s%s", rel.Name, op, rel.Version))
+	for _, rel := range relationsAtDepth {
+		var virtualFormat string
+		if rel.ProviderName != "" {
+			virtualFormat = fmt.Sprintf(" (provided by %s)", rel.ProviderName)
 		}
+
+		op := relationOpToString(rel.Operator)
+		relationOutputs = append(relationOutputs, fmt.Sprintf("%s%s%s%s", rel.Name, op, rel.Version, virtualFormat))
 	}
 
 	return relationOutputs

--- a/internal/display/render_json.go
+++ b/internal/display/render_json.go
@@ -36,10 +36,10 @@ func (o *OutputManager) renderJson(pkgPtrs []*pkgdata.PkgInfo, fields []consts.F
 	encoder.SetIndent("", "  ")
 
 	if err := encoder.Encode(filteredPkgPtrs); err != nil {
-		o.writeLine(fmt.Sprintf("Error genereating JSON output: %v", err))
+		o.writeLine(fmt.Sprintf("Error generating JSON output: %v", err))
 	}
 
-	o.writeLine(buffer.String())
+	o.write(buffer.String())
 }
 
 func getUniqueFields(fields []consts.FieldType) []consts.FieldType {
@@ -96,9 +96,7 @@ func getJsonValues(pkg *pkgdata.PkgInfo, fields []consts.FieldType) *PkgInfoJson
 		case consts.FieldDepends:
 			filteredPackage.Depends = flattenRelations(pkg.Depends)
 		case consts.FieldRequiredBy:
-			filteredPackage.RequiredBy = flattenRelations(
-				pkgdata.GetRelationsByDepth(pkg.RequiredBy, 1),
-			)
+			filteredPackage.RequiredBy = flattenRelations(pkg.RequiredBy)
 		case consts.FieldProvides:
 			filteredPackage.Provides = flattenRelations(pkg.Provides)
 		case consts.FieldConflicts:

--- a/internal/pipeline/phase/steps.go
+++ b/internal/pipeline/phase/steps.go
@@ -49,7 +49,7 @@ func FetchStep(
 	return pkgPtrs, nil
 }
 
-func ReverseDepStep(
+func ResolveDepTreeStep(
 	_ config.Config,
 	pkgPtrs []*pkgdata.PkgInfo,
 	reportProgress ProgressReporter,
@@ -59,7 +59,7 @@ func ReverseDepStep(
 		return pkgPtrs, nil
 	}
 
-	return pkgdata.CalculateReverseDependencies(pkgPtrs, reportProgress)
+	return pkgdata.ResolveDependencyTree(pkgPtrs, reportProgress)
 }
 
 // TODO: add progress reporting

--- a/internal/pkgdata/cache.go
+++ b/internal/pkgdata/cache.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	cacheVersion    = 5 // bump when updating structure of PkgInfo/Relation/pkginfo.proto
+	cacheVersion    = 6 // bump when updating structure of PkgInfo/Relation/pkginfo.proto OR when dependency resolution is updated
 	xdgCacheHomeEnv = "XDG_CACHE_HOME"
 	homeEnv         = "HOME"
 	qpCacheDir      = "query-packages"
@@ -104,10 +104,11 @@ func relationsToProtos(rels []Relation) []*pb.Relation {
 	pbRels := make([]*pb.Relation, len(rels))
 	for i, rel := range rels {
 		pbRels[i] = &pb.Relation{
-			Name:     rel.Name,
-			Version:  rel.Version,
-			Operator: pb.RelationOp(rel.Operator),
-			Depth:    rel.Depth,
+			Name:         rel.Name,
+			Version:      rel.Version,
+			Operator:     pb.RelationOp(rel.Operator),
+			Depth:        rel.Depth,
+			ProviderName: rel.ProviderName,
 		}
 	}
 
@@ -143,10 +144,11 @@ func protosToRelations(pbRels []*pb.Relation) []Relation {
 	rels := make([]Relation, len(pbRels))
 	for i, pbRel := range pbRels {
 		rels[i] = Relation{
-			Name:     pbRel.Name,
-			Version:  pbRel.Version,
-			Operator: RelationOp(pbRel.Operator),
-			Depth:    pbRel.Depth,
+			Name:         pbRel.Name,
+			Version:      pbRel.Version,
+			Operator:     RelationOp(pbRel.Operator),
+			Depth:        pbRel.Depth,
+			ProviderName: pbRel.ProviderName,
 		}
 	}
 

--- a/internal/pkgdata/packageinfo.go
+++ b/internal/pkgdata/packageinfo.go
@@ -12,10 +12,11 @@ const (
 )
 
 type Relation struct {
-	Name     string
-	Version  string
-	Operator RelationOp
-	Depth    int32
+	Name         string
+	ProviderName string
+	Version      string
+	Operator     RelationOp
+	Depth        int32
 }
 
 type PkgInfo struct {

--- a/internal/pkgdata/reverse_dependencies.go
+++ b/internal/pkgdata/reverse_dependencies.go
@@ -5,12 +5,13 @@ import (
 )
 
 // TODO: we can do this concurrently. let's get on that.
-func CalculateReverseDependencies(
+func ResolveDependencyTree(
 	pkgPtrs []*PkgInfo,
 	_ meta.ProgressReporter, // TODO: Add progress reporting
 ) ([]*PkgInfo, error) {
 	packagePointerMap := make(map[string]*PkgInfo)
 	reverseDependencyTree := make(map[string][]Relation)
+	forwardDependencyTree := make(map[string][]Relation)
 	providesMap := make(map[string][]string)
 	// key: provided library/package, value: package that provides it (provider)
 
@@ -41,7 +42,18 @@ func CalculateReverseDependencies(
 						Version:  depPackage.Version,
 						Operator: depPackage.Operator,
 						Depth:    1,
-					})
+					},
+				)
+
+				forwardDependencyTree[pkg.Name] = append(
+					forwardDependencyTree[pkg.Name],
+					Relation{
+						Name:     targetName,
+						Version:  depPackage.Version,
+						Operator: depPackage.Operator,
+						Depth:    1,
+					},
+				)
 			}
 		}
 	}

--- a/internal/protobuf/pkginfo.pb.go
+++ b/internal/protobuf/pkginfo.pb.go
@@ -87,6 +87,7 @@ type Relation struct {
 	Version       string                 `protobuf:"bytes,2,opt,name=version,proto3" json:"version,omitempty"`
 	Operator      RelationOp             `protobuf:"varint,3,opt,name=operator,proto3,enum=pkginfo.RelationOp" json:"operator,omitempty"`
 	Depth         int32                  `protobuf:"varint,4,opt,name=depth,proto3" json:"depth,omitempty"`
+	ProviderName  string                 `protobuf:"bytes,5,opt,name=providerName,proto3" json:"providerName,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -147,6 +148,13 @@ func (x *Relation) GetDepth() int32 {
 		return x.Depth
 	}
 	return 0
+}
+
+func (x *Relation) GetProviderName() string {
+	if x != nil {
+		return x.ProviderName
+	}
+	return ""
 }
 
 type PkgInfo struct {
@@ -369,12 +377,13 @@ var File_protobuf_pkginfo_proto protoreflect.FileDescriptor
 
 const file_protobuf_pkginfo_proto_rawDesc = "" +
 	"\n" +
-	"\x16protobuf/pkginfo.proto\x12\apkginfo\"\x7f\n" +
+	"\x16protobuf/pkginfo.proto\x12\apkginfo\"\xa3\x01\n" +
 	"\bRelation\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\tR\aversion\x12/\n" +
 	"\boperator\x18\x03 \x01(\x0e2\x13.pkginfo.RelationOpR\boperator\x12\x14\n" +
-	"\x05depth\x18\x04 \x01(\x05R\x05depth\"\xee\x03\n" +
+	"\x05depth\x18\x04 \x01(\x05R\x05depth\x12\"\n" +
+	"\fproviderName\x18\x05 \x01(\tR\fproviderName\"\xee\x03\n" +
 	"\aPkgInfo\x12\x1c\n" +
 	"\ttimestamp\x18\x01 \x01(\x03R\ttimestamp\x12\x12\n" +
 	"\x04size\x18\x02 \x01(\x03R\x04size\x12\x12\n" +

--- a/protobuf/pkginfo.proto
+++ b/protobuf/pkginfo.proto
@@ -20,6 +20,7 @@ message Relation {
   string version = 2;
   RelationOp operator = 3;
   int32 depth = 4;
+  string providerName = 5;
 }
 
 message PkgInfo {


### PR DESCRIPTION
Now we calculate the full forward dependency graph at every depth as well as informing the user which packages provide a library right in the dependencies.

When a provider is installed for a dependency, the dependency is listed with a (provided by XYZ). 

Example:
```bash
> qp -s name,required-by,depends -w name=nss --json
[
  {
    "name": "nss",
    "depends": [
      "glibc",
      "nspr",
      "p11-kit",
      "sh (provided by bash)",
      "sqlite",
      "zlib"
    ],
    "requiredBy": [
      "poppler"
    ]
  }
]
```

This also lays the groundwork for adding in depth options further on.

Addresses #167 