### PR TITLE
Feature: Sort relations output alphabetically by default

### DIFF
--- a/internal/display/formatting.go
+++ b/internal/display/formatting.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"qp/internal/consts"
 	"qp/internal/pkgdata"
+	"sort"
 	"strings"
 	"time"
 )
@@ -19,6 +20,10 @@ func formatRelations(relations []pkgdata.Relation) string {
 func flattenRelations(relations []pkgdata.Relation) []string {
 	relationsAtDepth := pkgdata.GetRelationsByDepth(relations, 1)
 	relationOutputs := make([]string, 0, len(relationsAtDepth))
+
+	sort.Slice(relationsAtDepth, func(a int, b int) bool {
+		return relationsAtDepth[a].Name < relationsAtDepth[b].Name
+	})
 
 	for _, rel := range relationsAtDepth {
 		var virtualFormat string


### PR DESCRIPTION
Relations (depends, conflicts, provides, required-by) output is now sorted alphabetically by default.