### PR TITLE
Refactor: Use pointer for config

### DIFF
--- a/cmd/qp/main.go
+++ b/cmd/qp/main.go
@@ -74,7 +74,7 @@ func setupCache(pipelineCtx *meta.PipelineContext) {
 
 func trimPackagesLen(
 	pkgPtrs []*pkgdata.PkgInfo,
-	cfg config.Config,
+	cfg *config.Config,
 ) []*pkgdata.PkgInfo {
 	if cfg.Count > 0 && !cfg.AllPackages && len(pkgPtrs) > cfg.Count {
 		cutoffIdx := len(pkgPtrs) - cfg.Count
@@ -84,11 +84,15 @@ func trimPackagesLen(
 	return pkgPtrs
 }
 
-func renderOutput(pkgs []*pkgdata.PkgInfo, cfg config.Config) {
+func renderOutput(pkgs []*pkgdata.PkgInfo, cfg *config.Config) {
 	if cfg.OutputJson {
 		out.RenderJson(pkgs, cfg.Fields)
 		return
 	}
 
 	out.RenderTable(pkgs, cfg.Fields, cfg.ShowFullTimestamp, cfg.HasNoHeaders)
+}
+
+func isInteractive(disableProgress bool) bool {
+	return term.IsTerminal(int(os.Stdout.Fd())) && !disableProgress
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,7 +34,7 @@ type SortOption struct {
 }
 
 type ConfigProvider interface {
-	GetConfig() (Config, error)
+	GetConfig() (*Config, error)
 }
 
 type CliConfigProvider struct{}

--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -4,10 +4,10 @@ import (
 	"os"
 )
 
-func (c *CliConfigProvider) GetConfig() (Config, error) {
+func (c *CliConfigProvider) GetConfig() (*Config, error) {
 	cfg, err := ParseFlags(os.Args[1:])
 	if err != nil {
-		return Config{}, err
+		return &Config{}, err
 	}
 
 	if cfg.ShowHelp {
@@ -15,5 +15,5 @@ func (c *CliConfigProvider) GetConfig() (Config, error) {
 		os.Exit(0)
 	}
 
-	return cfg, nil
+	return &cfg, nil
 }

--- a/internal/pipeline/phase/phase.go
+++ b/internal/pipeline/phase/phase.go
@@ -16,7 +16,7 @@ type (
 )
 
 type Step func(
-	cfg config.Config,
+	cfg *config.Config,
 	packages []*PkgInfo,
 	progressReporter meta.ProgressReporter,
 	pipelineCtx *meta.PipelineContext,
@@ -37,7 +37,7 @@ func New(name string, step Step, wg *sync.WaitGroup) PipelinePhase {
 }
 
 func (phase PipelinePhase) Run(
-	cfg config.Config,
+	cfg *config.Config,
 	packages []*PkgInfo,
 	pipelineCtx *meta.PipelineContext,
 ) ([]*PkgInfo, error) {

--- a/internal/pipeline/phase/steps.go
+++ b/internal/pipeline/phase/steps.go
@@ -10,7 +10,7 @@ import (
 )
 
 func LoadCacheStep(
-	cfg config.Config,
+	cfg *config.Config,
 	_ []*PkgInfo,
 	_ ProgressReporter,
 	pipelineCtx *meta.PipelineContext,
@@ -30,7 +30,7 @@ func LoadCacheStep(
 
 // TODO: add progress reporting
 func FetchStep(
-	_ config.Config,
+	_ *config.Config,
 	pkgPtrs []*PkgInfo,
 	_ ProgressReporter,
 	pipelineCtx *meta.PipelineContext,
@@ -50,7 +50,7 @@ func FetchStep(
 }
 
 func ResolveDepTreeStep(
-	_ config.Config,
+	_ *config.Config,
 	pkgPtrs []*pkgdata.PkgInfo,
 	reportProgress ProgressReporter,
 	pipelineCtx *meta.PipelineContext,
@@ -64,7 +64,7 @@ func ResolveDepTreeStep(
 
 // TODO: add progress reporting
 func SaveCacheStep(
-	cfg config.Config,
+	cfg *config.Config,
 	pkgPtrs []*PkgInfo,
 	_ ProgressReporter,
 	pipelineCtx *meta.PipelineContext,
@@ -81,7 +81,7 @@ func SaveCacheStep(
 }
 
 func FilterStep(
-	cfg config.Config,
+	cfg *config.Config,
 	pkgPtrs []*PkgInfo,
 	reportProgress ProgressReporter,
 	_ *meta.PipelineContext,
@@ -99,7 +99,7 @@ func FilterStep(
 }
 
 func SortStep(
-	cfg config.Config,
+	cfg *config.Config,
 	pkgPtrs []*PkgInfo,
 	reportProgress ProgressReporter,
 	_ *meta.PipelineContext,


### PR DESCRIPTION
The config gets passed along the pipeline but is never directly mutated.