### PR TITLE
Feature: Add pkgtype field

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ this package is compatible with the following distributions:
 | ✓	| conflicts query | - | package description sort |
 | - | regen-cache option | - | groups filter |
 | - | packager field | - | optional dependency field |
-| ✓ | query by size on disk | - | conflicts sort |
+| ✓ | sort by size on disk | - | conflicts sort |
 
 
 ## installation

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 you can find installation instructions [here](#installation).
 
-`qp` supports querying/sorting for install date, package name, install reason (explicit/dependency), size on disk, reverse dependencies, dependency requirements, description, replacements, conflicts, provision, and more. check [usage](#usage) for all available options.
+`qp` supports querying/sorting for install date, package name, install reason (explicit/dependency), size on disk, reverse dependencies, dependency requirements, description, replacements, conflicts, provisions, build date, package type and more. check [usage](#usage) for all available options.
 
 ![qp logo | query packages logo](https://gistcdn.githack.com/Zweih/9009d5c74eab8a5515a8a64a0495df32/raw/ef8a8ac3655fd3dee24494a3403867919d806b63/qp-logo_clean.svg)
 
@@ -37,7 +37,7 @@ this package is compatible with the following distributions:
 
 ## features
 
-- list installed packages with date/timestamps, dependencies, provisions, requirements, size on disk, conflicts, replacements, architecture, license, description, build date, package base, and version
+- list installed packages with install date/timestamps, dependencies, provisions, requirements, size on disk, conflicts, replacements, architecture, license, description, build date, package base, package type, and version
 - query by explicitly installed packages
 - query by packages installed as dependencies
 - query by packages required by specified packages
@@ -96,8 +96,10 @@ this package is compatible with the following distributions:
 | ✓ | license query | – | optional dependency field |
 | ✓ | improve sorting efficiency (8% speed boost) | ✓ | package description query |
 | ✓ | dependency depth resolution | ✓ | no-cache option |
-| ✓ | build-date field | - | rebuild-cache option |
-
+| ✓ | build-date field | - | regen-cache option |
+| ✓ | pkgtype field | - | build-date filter |
+| - | build-date sort | - | pkgtype sort |
+| - | pkgtype filter | - | groups field |
 
 ## installation
 
@@ -167,7 +169,7 @@ qp [options]
 - `--no-headers`: omit column headers in table output (useful for scripting)
 - `-s <list>` | `--select <list>`: comma-separated list of fields to display (cannot use with `--select-all` or `--select-add`)
 - `-S <list>` | `--select-add <list>`: comma-separated list of fields to add to defaults or `--select-all`
-- `-A` | `--select-all`: output all available fields (overrides defaults)
+- `-A` | `--select-all`: output all available fields (overrides defaults) 
 - `--full-timestamp`: display the full timestamp (date and time) of package install/build instead of just the date
 - `--json`: output results in JSON format (overrides table output and `--full-timestamp`)
 - `--no-progress`: force no progress bar outside of non-interactive environments
@@ -203,16 +205,18 @@ short-flag queries and long-flag queries can be combined.
 - `reason` - installation reason (explicit/dependency)
 - `size` - package size on disk
 - `version` - installed package version
+- `pkgtype` - package type (standard, split, debug, source, unknown*)
+         ***note**: older packages may show "unknown" pkgtype if built before pacman introduced XDATA
+- `arch` - architecture the package was built for (e.g., x86_64, aarch64, any)
+- `license` - package software license
+- `pkgbase` - name of the base package used to group split packages; for non-split packages, it is the same as the package name. 
+- `description` - package description
+- `url` - the URL of the official site of the software being packaged
+- `conflicts` - list of packages that conflict, or cause problems, with the package
+- `replaces` - list of packages that are replaced by the package
 - `depends` - list of dependencies (output can be long)
 - `required-by` - list of packages required by the package and are dependent (output can be long) 
 - `provides` - list of alternative package names or shared libraries provided by package (output can be long)
-- `conflicts` - list of packages that conflict, or cause problems, with the package
-- `replaces` - list of packages that are replaced by the package
-- `arch` - architecture the package was built for (e.g., x86_64, aarch64, any)
-- `license` - package software license
-- `url` - the URL of the official site of the software being packaged
-- `description` - package description
-- `pkgbase` - name of the base package used to group split packages; for non-split packages, it is the same as the package name. 
 
 ### JSON output
 the `--json` flag outputs the package data as structured JSON instead of a table. this can be useful for scripts or automation.
@@ -228,16 +232,24 @@ output format:
 ```json
 [
   {
-    "timestamp": 1743448252,
+    "installTimestamp": 1743448252,
+    "buildTimestamp": 1742778264,
     "size": 4446373,
     "name": "tinysparql",
     "reason": "dependency",
     "version": "3.9.1-1",
+    "pkgtype": "split",
     "arch": "aarch64",
     "license": "GPL-2.0-or-later",
-    "url": "https://tinysparql.org/",
-    "description": "Low-footprint RDF triple store with SPARQL 1.1 interface",
     "pkgbase": "tinysparql",
+    "description": "Low-footprint RDF triple store with SPARQL 1.1 interface",
+    "url": "https://tinysparql.org/",
+    "conflicts": [
+      "tracker3<=3.7.3-2"
+    ],
+    "replaces": [
+      "tracker3<=3.7.3-2"
+    ],
     "depends": [
       "avahi",
       "gcc-libs",
@@ -255,14 +267,8 @@ output format:
       "gtk4"
     ],
     "provides": [
-      "tracker3=3.9.1",
-      "libtinysparql-3.0.so=0-64"
-    ],
-    "conflicts": [
-      "tracker3<=3.7.3-2"
-    ],
-    "replaces": [
-      "tracker3<=3.7.3-2"
+      "libtinysparql-3.0.so=0-64",
+      "tracker3=3.9.1"
     ]
   }
 ]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 you can find installation instructions [here](#installation).
 
-`qp` supports querying/sorting for install date, package name, install reason (explicit/dependency), size on disk, reverse dependencies, dependency requirements, description, replacements, conflicts, provision, and more. check [usage](#usage) for all available options.
+`qp` supports querying/sorting for install date, package name, install reason (explicit/dependency), size on disk, reverse dependencies, dependency requirements, description, replacements, conflicts, provisions, build date, package type and more. check [usage](#usage) for all available options.
 
 ![qp logo | query packages logo](https://gistcdn.githack.com/Zweih/9009d5c74eab8a5515a8a64a0495df32/raw/ef8a8ac3655fd3dee24494a3403867919d806b63/qp-logo_clean.svg)
 
@@ -37,7 +37,7 @@ this package is compatible with the following distributions:
 
 ## features
 
-- list installed packages with date/timestamps, dependencies, provisions, requirements, size on disk, conflicts, replacements, architecture, license, description, build date, package base, and version
+- list installed packages with install date/timestamps, dependencies, provisions, requirements, size on disk, conflicts, replacements, architecture, license, description, build date, package base, package type, and version
 - query by explicitly installed packages
 - query by packages installed as dependencies
 - query by packages required by specified packages
@@ -203,16 +203,18 @@ short-flag queries and long-flag queries can be combined.
 - `reason` - installation reason (explicit/dependency)
 - `size` - package size on disk
 - `version` - installed package version
+- `pkgtype` - package type (standard, split, debug, source, unknown*)
+    - ***note**: older packages may show "unknown" pkgtype if built before pacman introduced XDATA
+- `arch` - architecture the package was built for (e.g., x86_64, aarch64, any)
+- `license` - package software license
+- `pkgbase` - name of the base package used to group split packages; for non-split packages, it is the same as the package name. 
+- `description` - package description
+- `url` - the URL of the official site of the software being packaged
+- `conflicts` - list of packages that conflict, or cause problems, with the package
+- `replaces` - list of packages that are replaced by the package
 - `depends` - list of dependencies (output can be long)
 - `required-by` - list of packages required by the package and are dependent (output can be long) 
 - `provides` - list of alternative package names or shared libraries provided by package (output can be long)
-- `conflicts` - list of packages that conflict, or cause problems, with the package
-- `replaces` - list of packages that are replaced by the package
-- `arch` - architecture the package was built for (e.g., x86_64, aarch64, any)
-- `license` - package software license
-- `url` - the URL of the official site of the software being packaged
-- `description` - package description
-- `pkgbase` - name of the base package used to group split packages; for non-split packages, it is the same as the package name. 
 
 ### JSON output
 the `--json` flag outputs the package data as structured JSON instead of a table. this can be useful for scripts or automation.
@@ -228,16 +230,24 @@ output format:
 ```json
 [
   {
-    "timestamp": 1743448252,
+    "installTimestamp": 1743448252,
+    "buildTimestamp": 1742778264,
     "size": 4446373,
     "name": "tinysparql",
     "reason": "dependency",
     "version": "3.9.1-1",
+    "pkgtype": "split",
     "arch": "aarch64",
     "license": "GPL-2.0-or-later",
-    "url": "https://tinysparql.org/",
-    "description": "Low-footprint RDF triple store with SPARQL 1.1 interface",
     "pkgbase": "tinysparql",
+    "description": "Low-footprint RDF triple store with SPARQL 1.1 interface",
+    "url": "https://tinysparql.org/",
+    "conflicts": [
+      "tracker3<=3.7.3-2"
+    ],
+    "replaces": [
+      "tracker3<=3.7.3-2"
+    ],
     "depends": [
       "avahi",
       "gcc-libs",
@@ -255,14 +265,8 @@ output format:
       "gtk4"
     ],
     "provides": [
-      "tracker3=3.9.1",
-      "libtinysparql-3.0.so=0-64"
-    ],
-    "conflicts": [
-      "tracker3<=3.7.3-2"
-    ],
-    "replaces": [
-      "tracker3<=3.7.3-2"
+      "libtinysparql-3.0.so=0-64",
+      "tracker3=3.9.1"
     ]
   }
 ]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 you can find installation instructions [here](#installation).
 
-`qp` supports querying/sorting for install date, package name, install reason (explicit/dependency), size on disk, reverse dependencies, dependency requirements, description, replacements, conflicts, provisions, build date, package type and more. check [usage](#usage) for all available options.
+`qp` supports querying/sorting for install date, package name, install reason (explicit/dependency), size on disk, reverse dependencies, dependency requirements, description, replacements, conflicts, provision, and more. check [usage](#usage) for all available options.
 
 ![qp logo | query packages logo](https://gistcdn.githack.com/Zweih/9009d5c74eab8a5515a8a64a0495df32/raw/ef8a8ac3655fd3dee24494a3403867919d806b63/qp-logo_clean.svg)
 
@@ -37,7 +37,7 @@ this package is compatible with the following distributions:
 
 ## features
 
-- list installed packages with install date/timestamps, dependencies, provisions, requirements, size on disk, conflicts, replacements, architecture, license, description, build date, package base, package type, and version
+- list installed packages with date/timestamps, dependencies, provisions, requirements, size on disk, conflicts, replacements, architecture, license, description, build date, package base, and version
 - query by explicitly installed packages
 - query by packages installed as dependencies
 - query by packages required by specified packages
@@ -60,46 +60,44 @@ this package is compatible with the following distributions:
 
 | Status | Feature | Status | Feature |
 |--------|---------|--------|---------|
-| ✓ | rewrite in golang | ✓ | remove expac as a dependency (300% speed boost) |
-| ✓ | additional queries | ✓ | package provisions |
-| – | list possibly or confirmed stale/abandoned packages | ✓ | optional full timestamp |
-| ✓ | sort by size on disk | ✓ | add CI to release binaries |
-| ✓ | protobuf caching (127% speed boost) | ✓ | remove Go as a dependency |
-| – | dependency graph | ✓ | query by range of size on disk |
-| ✓ | concurrent querying | ✓ | user defined field selection |
-| ✓ | query by size on disk | ✓ | dependencies of each package (dependency field) |
-| ✓ | asynchronous progress bar | ✓ | reverse-dependencies of each package (required-by field) |
-| ✓ | channel-based aggregation | ✓ | package description field |
-| ✓ | concurrent sorting | ✓ | package URL field |
-| ✓ | query by package name | ✓ | package architecture field |
-| ✓ | package version field | ✓ | package conflicts field |
-| ✓ | query by date range | ✓ | conflicts query |
-| ✓ | concurrent file reading (200% speed boost) | – | name exclusion query |
-| ✓ | remove expac as a dependency | – | self-referencing field |
-| ✓ | package provisions | ✓ | JSON output |
-| ✓ | optional full timestamp | ✓ | no-headers option |
-| ✓ | add CI to release binaries | ✓ | provides query |
-| ✓ | remove Go as a dependency | ✓ | depends query |
-| ✓ | query by range of size on disk | ✓ | all-fields option |
-| ✓ | user defined field selection | ✓ | required-by query |
-| – | key/value output | ✓ | list of packages for package queries |
-| ✓ | config dependency injection for testing | – | required-by count sort |
-| ✓ | optimize file reading (28% speed boost) | ✓ | metaflag for all queries |
-| ✓ | package license field | – | XML output |
-| – | package base query | – | package description sort |
-| – | required-by sort | ✓ | package base field |
-| ✓ | package base sort | ✓ | use chunked channel-based concurrent querying (12% speed boost) |
-| – | short-args for queries | ✓ | license sort |
-| – | packager field | – | streaming pipeline |
-| ✓ | architecture query | ✓ | optimize query order (4% speed boost) |
-| – | dependency count sort | ✓ | replaces field |
-| ✓ | license query | – | optional dependency field |
-| ✓ | improve sorting efficiency (8% speed boost) | ✓ | package description query |
-| ✓ | dependency depth resolution | ✓ | no-cache option |
-| ✓ | build-date field | - | regen-cache option |
-| ✓ | pkgtype field | - | build-date filter |
-| - | build-date sort | - | pkgtype sort |
-| - | pkgtype filter | - | groups field |
+| ✓ | remove expac as a dependency (300% speed boost) | ✓ | concurrent file reading (200% speed boost) |
+| ✓ | protobuf caching (127% speed boost) | ✓ | use chunked channel-based concurrent querying (12% speed boost) |
+| ✓ | optimize file reading (28% speed boost) | ✓ | improve sorting efficiency (8% speed boost) |
+| ✓ | optimize query order (4% speed boost) | ✓ | concurrent querying |
+| ✓ | concurrent sorting | ✓ | asynchronous progress bar |
+| ✓ | channel-based aggregation | ✓ | rewrite in golang |
+| ✓ | automate binaries packaging | ✓ | add CI to release binaries |
+| ✓ | dependency depth resolution | ✓ | config dependency injection for testing |
+| ✓ | query by package name | ✓ | query by size on disk |
+| ✓ | query by range of size on disk | ✓ | query by date range |
+| ✓ | user defined field selection | ✓ | dependencies of each package (dependency field) |
+| ✓ | reverse-dependencies of each package (required-by field) | ✓ | list of packages for package queries |
+| ✓ | package provisions | ✓ | package description query |
+| ✓ | package conflicts field | ✓ | package architecture field |
+| ✓ | package URL field | ✓ | package version field |
+| ✓ | package license field | ✓ | package base field |
+| ✓ | package base sort | ✓ | license query |
+| ✓ | license sort | ✓ | dependency graph |
+| ✓ | metaflag for all queries | ✓ | JSON output |
+| ✓ | no-headers option | ✓ | provides query |
+| ✓ | depends query | ✓ | all-fields option |
+| ✓ | required-by query | ✓ | no-cache option |
+| ✓ | optional full timestamp | ✓ | package description field |
+| – | list possibly or confirmed stale/abandoned packages | – | self-referencing field |
+| – | name exclusion query | – | streaming pipeline |
+| – | short-args for queries | – | key/value output |
+| – | XML output | – | package description sort |
+| – | package base query | – | required-by sort |
+| – | required-by count sort | – | dependency count sort |
+| ✓ | build-date field | - | build-date filter |
+| - | build-date sort | ✓ | pkgtype field |
+| - | pkgtype filter | - | pkgtype sort |
+| ✓ | architecture query | - | groups field |
+| ✓	| conflicts query | - | package description sort |
+| - | regen-cache option | - | groups filter |
+| - | packager field | - | optional dependency field |
+| ✓ | query by size on disk | - | conflicts sort |
+
 
 ## installation
 
@@ -169,7 +167,7 @@ qp [options]
 - `--no-headers`: omit column headers in table output (useful for scripting)
 - `-s <list>` | `--select <list>`: comma-separated list of fields to display (cannot use with `--select-all` or `--select-add`)
 - `-S <list>` | `--select-add <list>`: comma-separated list of fields to add to defaults or `--select-all`
-- `-A` | `--select-all`: output all available fields (overrides defaults) 
+- `-A` | `--select-all`: output all available fields (overrides defaults)
 - `--full-timestamp`: display the full timestamp (date and time) of package install/build instead of just the date
 - `--json`: output results in JSON format (overrides table output and `--full-timestamp`)
 - `--no-progress`: force no progress bar outside of non-interactive environments
@@ -205,18 +203,16 @@ short-flag queries and long-flag queries can be combined.
 - `reason` - installation reason (explicit/dependency)
 - `size` - package size on disk
 - `version` - installed package version
-- `pkgtype` - package type (standard, split, debug, source, unknown*)
-         ***note**: older packages may show "unknown" pkgtype if built before pacman introduced XDATA
-- `arch` - architecture the package was built for (e.g., x86_64, aarch64, any)
-- `license` - package software license
-- `pkgbase` - name of the base package used to group split packages; for non-split packages, it is the same as the package name. 
-- `description` - package description
-- `url` - the URL of the official site of the software being packaged
-- `conflicts` - list of packages that conflict, or cause problems, with the package
-- `replaces` - list of packages that are replaced by the package
 - `depends` - list of dependencies (output can be long)
 - `required-by` - list of packages required by the package and are dependent (output can be long) 
 - `provides` - list of alternative package names or shared libraries provided by package (output can be long)
+- `conflicts` - list of packages that conflict, or cause problems, with the package
+- `replaces` - list of packages that are replaced by the package
+- `arch` - architecture the package was built for (e.g., x86_64, aarch64, any)
+- `license` - package software license
+- `url` - the URL of the official site of the software being packaged
+- `description` - package description
+- `pkgbase` - name of the base package used to group split packages; for non-split packages, it is the same as the package name. 
 
 ### JSON output
 the `--json` flag outputs the package data as structured JSON instead of a table. this can be useful for scripts or automation.
@@ -232,24 +228,16 @@ output format:
 ```json
 [
   {
-    "installTimestamp": 1743448252,
-    "buildTimestamp": 1742778264,
+    "timestamp": 1743448252,
     "size": 4446373,
     "name": "tinysparql",
     "reason": "dependency",
     "version": "3.9.1-1",
-    "pkgtype": "split",
     "arch": "aarch64",
     "license": "GPL-2.0-or-later",
-    "pkgbase": "tinysparql",
-    "description": "Low-footprint RDF triple store with SPARQL 1.1 interface",
     "url": "https://tinysparql.org/",
-    "conflicts": [
-      "tracker3<=3.7.3-2"
-    ],
-    "replaces": [
-      "tracker3<=3.7.3-2"
-    ],
+    "description": "Low-footprint RDF triple store with SPARQL 1.1 interface",
+    "pkgbase": "tinysparql",
     "depends": [
       "avahi",
       "gcc-libs",
@@ -267,8 +255,14 @@ output format:
       "gtk4"
     ],
     "provides": [
-      "libtinysparql-3.0.so=0-64",
-      "tracker3=3.9.1"
+      "tracker3=3.9.1",
+      "libtinysparql-3.0.so=0-64"
+    ],
+    "conflicts": [
+      "tracker3<=3.7.3-2"
+    ],
+    "replaces": [
+      "tracker3<=3.7.3-2"
     ]
   }
 ]

--- a/internal/config/help.go
+++ b/internal/config/help.go
@@ -66,6 +66,8 @@ func PrintHelp() {
 	fmt.Println("  url          URL of the official site of the software being packaged")
 	fmt.Println("  description  Package description")
 	fmt.Println("  pkgbase      Name of the base package used to group split packages; for non-split packages, it is the same as the package name.")
+	fmt.Println("  pkgtype      Type of the package (standard, split, debug, source, unknown)")
+	fmt.Println("               Note: Older packages may show \"unknown\" pkgtype if built before pacman introduced XDATA.")
 
 	fmt.Println("\nExamples:")
 	fmt.Println("  qp -l 10                      # Show the last 10 installed packages")

--- a/internal/consts/fields.go
+++ b/internal/consts/fields.go
@@ -8,6 +8,7 @@ type (
 // ordered by filter efficiency
 const (
 	FieldReason FieldType = iota
+	FieldPkgType
 	FieldArch
 	FieldLicense
 	FieldName
@@ -37,30 +38,33 @@ const (
 	reason      = "reason"
 	size        = "size"
 	version     = "version"
-	description = "description"
+	pkgType     = "pkgtype"
+	arch        = "arch"
+	license     = "license"
 	pkgBase     = "pkgbase"
+	description = "description"
+	url         = "url"
+	conflicts   = "conflicts"
+	replaces    = "replaces"
 	depends     = "depends"
 	requiredBy  = "required-by"
 	provides    = "provides"
-	conflicts   = "conflicts"
-	replaces    = "replaces"
-	arch        = "arch"
-	license     = "license"
-	url         = "url"
-	target      = "target"
-	depth       = "depth"
+
+	target = "target"
+	depth  = "depth"
 )
 
 var FieldTypeLookup = map[string]FieldType{
-	"d":  FieldDate,
-	"n":  FieldName,
-	"r":  FieldReason,
-	"s":  FieldSize,
-	"v":  FieldVersion,
-	"D":  FieldDepends,
-	"R":  FieldRequiredBy,
-	"p":  FieldProvides,
-	"bd": FieldBuildDate,
+	"d":    FieldDate,
+	"n":    FieldName,
+	"r":    FieldReason,
+	"s":    FieldSize,
+	"v":    FieldVersion,
+	"D":    FieldDepends,
+	"R":    FieldRequiredBy,
+	"p":    FieldProvides,
+	"bd":   FieldBuildDate,
+	"type": FieldPkgType,
 
 	"alphabetical": FieldName, // legacy flag, to be deprecated
 
@@ -68,18 +72,19 @@ var FieldTypeLookup = map[string]FieldType{
 	buildDate:   FieldBuildDate,
 	name:        FieldName,
 	reason:      FieldReason,
-	arch:        FieldArch,
-	license:     FieldLicense,
-	url:         FieldUrl,
-	description: FieldDescription,
-	pkgBase:     FieldPkgBase,
 	size:        FieldSize,
 	version:     FieldVersion,
+	pkgType:     FieldPkgType,
+	arch:        FieldArch,
+	license:     FieldLicense,
+	pkgBase:     FieldPkgBase,
+	description: FieldDescription,
+	url:         FieldUrl,
+	conflicts:   FieldConflicts,
+	replaces:    FieldReplaces,
 	depends:     FieldDepends,
 	requiredBy:  FieldRequiredBy,
 	provides:    FieldProvides,
-	conflicts:   FieldConflicts,
-	replaces:    FieldReplaces,
 }
 
 var SubfieldTypeLookup = map[string]SubfieldType{
@@ -95,16 +100,17 @@ var FieldNameLookup = map[FieldType]string{
 	FieldSize:        size,
 	FieldReason:      reason,
 	FieldVersion:     version,
+	FieldPkgType:     pkgType,
+	FieldArch:        arch,
+	FieldLicense:     license,
+	FieldPkgBase:     pkgBase,
+	FieldDescription: description,
+	FieldUrl:         url,
+	FieldConflicts:   conflicts,
+	FieldReplaces:    replaces,
 	FieldDepends:     depends,
 	FieldRequiredBy:  requiredBy,
 	FieldProvides:    provides,
-	FieldConflicts:   conflicts,
-	FieldReplaces:    replaces,
-	FieldArch:        arch,
-	FieldLicense:     license,
-	FieldUrl:         url,
-	FieldDescription: description,
-	FieldPkgBase:     pkgBase,
 }
 
 var SubfieldNameLookup = map[SubfieldType]string{
@@ -126,9 +132,10 @@ var (
 		FieldReason,
 		FieldSize,
 		FieldVersion,
-		FieldPkgBase,
+		FieldPkgType,
 		FieldArch,
 		FieldLicense,
+		FieldPkgBase,
 		FieldDescription,
 		FieldUrl,
 		FieldConflicts,

--- a/internal/display/formatting.go
+++ b/internal/display/formatting.go
@@ -55,6 +55,21 @@ func relationOpToString(op pkgdata.RelationOp) string {
 	}
 }
 
+func pkgTypeToString(pkgType pkgdata.PkgType) string {
+	switch pkgType {
+	case pkgdata.PkgTypePkg:
+		return "pkg"
+	case pkgdata.PkgTypeSplit:
+		return "split"
+	case pkgdata.PkgTypeSrc:
+		return "src"
+	case pkgdata.PkgTypeDebug:
+		return "debug"
+	default:
+		return "unknown"
+	}
+}
+
 func formatDate(timestamp int64, ctx tableContext) string {
 	unixTimestamp := time.Unix(timestamp, 0)
 	return unixTimestamp.Format(ctx.DateFormat)

--- a/internal/display/render_json.go
+++ b/internal/display/render_json.go
@@ -15,16 +15,17 @@ type PkgInfoJson struct {
 	Name             string   `json:"name,omitempty"`
 	Reason           string   `json:"reason,omitempty"`
 	Version          string   `json:"version,omitempty"`
+	PkgType          string   `json:"pkgtype,omitempty"`
 	Arch             string   `json:"arch,omitempty"`
 	License          string   `json:"license,omitempty"`
-	Url              string   `json:"url,omitempty"`
-	Description      string   `json:"description,omitempty"`
 	PkgBase          string   `json:"pkgbase,omitempty"`
+	Description      string   `json:"description,omitempty"`
+	Url              string   `json:"url,omitempty"`
+	Conflicts        []string `json:"conflicts,omitempty"`
+	Replaces         []string `json:"replaces,omitempty"`
 	Depends          []string `json:"depends,omitempty"`
 	RequiredBy       []string `json:"requiredBy,omitempty"`
 	Provides         []string `json:"provides,omitempty"`
-	Conflicts        []string `json:"conflicts,omitempty"`
-	Replaces         []string `json:"replaces,omitempty"`
 }
 
 func (o *OutputManager) renderJson(pkgPtrs []*pkgdata.PkgInfo, fields []consts.FieldType) {
@@ -86,26 +87,28 @@ func getJsonValues(pkg *pkgdata.PkgInfo, fields []consts.FieldType) *PkgInfoJson
 			filteredPackage.Size = pkg.Size // return in bytes for json
 		case consts.FieldVersion:
 			filteredPackage.Version = pkg.Version
+		case consts.FieldPkgType:
+			filteredPackage.PkgType = pkgTypeToString(pkg.PkgType)
 		case consts.FieldArch:
 			filteredPackage.Arch = pkg.Arch
 		case consts.FieldLicense:
 			filteredPackage.License = pkg.License
-		case consts.FieldUrl:
-			filteredPackage.Url = pkg.Url
-		case consts.FieldDescription:
-			filteredPackage.Description = pkg.Description
 		case consts.FieldPkgBase:
 			filteredPackage.PkgBase = pkg.PkgBase
+		case consts.FieldDescription:
+			filteredPackage.Description = pkg.Description
+		case consts.FieldUrl:
+			filteredPackage.Url = pkg.Url
+		case consts.FieldConflicts:
+			filteredPackage.Conflicts = flattenRelations(pkg.Conflicts)
+		case consts.FieldReplaces:
+			filteredPackage.Replaces = flattenRelations(pkg.Replaces)
 		case consts.FieldDepends:
 			filteredPackage.Depends = flattenRelations(pkg.Depends)
 		case consts.FieldRequiredBy:
 			filteredPackage.RequiredBy = flattenRelations(pkg.RequiredBy)
 		case consts.FieldProvides:
 			filteredPackage.Provides = flattenRelations(pkg.Provides)
-		case consts.FieldConflicts:
-			filteredPackage.Conflicts = flattenRelations(pkg.Conflicts)
-		case consts.FieldReplaces:
-			filteredPackage.Replaces = flattenRelations(pkg.Replaces)
 		}
 	}
 

--- a/internal/display/render_table.go
+++ b/internal/display/render_table.go
@@ -20,16 +20,17 @@ var columnHeaders = map[consts.FieldType]string{
 	consts.FieldReason:      "REASON",
 	consts.FieldSize:        "SIZE",
 	consts.FieldVersion:     "VERSION",
+	consts.FieldPkgType:     "PKGTYPE",
+	consts.FieldArch:        "ARCH",
+	consts.FieldLicense:     "LICENSE",
+	consts.FieldPkgBase:     "PKGBASE",
+	consts.FieldDescription: "DESCRIPTION",
+	consts.FieldUrl:         "URL",
+	consts.FieldConflicts:   "CONFLICTS",
+	consts.FieldReplaces:    "REPLACES",
 	consts.FieldDepends:     "DEPENDS",
 	consts.FieldRequiredBy:  "REQUIRED BY",
 	consts.FieldProvides:    "PROVIDES",
-	consts.FieldConflicts:   "CONFLICTS",
-	consts.FieldReplaces:    "REPLACES",
-	consts.FieldArch:        "ARCH",
-	consts.FieldLicense:     "LICENSE",
-	consts.FieldUrl:         "URL",
-	consts.FieldDescription: "DESCRIPTION",
-	consts.FieldPkgBase:     "PKGBASE",
 }
 
 // displays data in tab format
@@ -120,6 +121,8 @@ func getTableValue(pkg *pkgdata.PkgInfo, field consts.FieldType, ctx tableContex
 		return pkg.Description
 	case consts.FieldPkgBase:
 		return pkg.PkgBase
+	case consts.FieldPkgType:
+		return pkgTypeToString(pkg.PkgType)
 	default:
 		return ""
 	}

--- a/internal/pkgdata/cache.go
+++ b/internal/pkgdata/cache.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	cacheVersion    = 7 // bump when updating structure of PkgInfo/Relation/pkginfo.proto OR when dependency resolution is updated
+	cacheVersion    = 8 // bump when updating structure of PkgInfo/Relation/pkginfo.proto OR when dependency resolution is updated
 	xdgCacheHomeEnv = "XDG_CACHE_HOME"
 	homeEnv         = "HOME"
 	qpCacheDir      = "query-packages"
@@ -125,6 +125,7 @@ func pkgsToProtos(pkgs []*PkgInfo) []*pb.PkgInfo {
 			Name:             pkg.Name,
 			Reason:           pkg.Reason,
 			Version:          pkg.Version,
+			PkgType:          pb.PkgType(pkg.PkgType),
 			Arch:             pkg.Arch,
 			License:          pkg.License,
 			Url:              pkg.Url,
@@ -166,6 +167,7 @@ func protosToPkgs(pbPkgs []*pb.PkgInfo) []*PkgInfo {
 			Name:             pbPkg.Name,
 			Reason:           pbPkg.Reason,
 			Version:          pbPkg.Version,
+			PkgType:          PkgType(pbPkg.PkgType),
 			Arch:             pbPkg.Arch,
 			License:          pbPkg.License,
 			Url:              pbPkg.Url,

--- a/internal/pkgdata/packageinfo.go
+++ b/internal/pkgdata/packageinfo.go
@@ -1,6 +1,6 @@
 package pkgdata
 
-type RelationOp int
+type RelationOp int32
 
 const (
 	OpNone RelationOp = iota
@@ -11,29 +11,44 @@ const (
 	OpGreaterEqual
 )
 
+type PkgType int32
+
+const (
+	PkgTypeUnknown PkgType = iota
+	PkgTypePkg
+	PkgTypeSplit
+	PkgTypeSrc
+	PkgTypeDebug
+)
+
 type Relation struct {
+	Depth    int32
+	Operator RelationOp
+
+	Version      string
 	Name         string
 	ProviderName string
-	Version      string
-	Operator     RelationOp
-	Depth        int32
 }
 
 type PkgInfo struct {
 	InstallTimestamp int64
 	BuildTimestamp   int64
 	Size             int64
-	Name             string
-	Reason           string
-	Version          string
-	Arch             string
-	License          string
-	Url              string
-	Description      string
-	PkgBase          string
-	Depends          []Relation
-	RequiredBy       []Relation
-	Provides         []Relation
-	Conflicts        []Relation
-	Replaces         []Relation
+
+	PkgType PkgType
+
+	Name        string
+	Reason      string
+	Version     string
+	Arch        string
+	License     string
+	Url         string
+	Description string
+	PkgBase     string
+
+	Depends    []Relation
+	RequiredBy []Relation
+	Provides   []Relation
+	Conflicts  []Relation
+	Replaces   []Relation
 }

--- a/internal/protobuf/pkginfo.pb.go
+++ b/internal/protobuf/pkginfo.pb.go
@@ -9,12 +9,11 @@
 package protobuf
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -80,6 +79,61 @@ func (x RelationOp) Number() protoreflect.EnumNumber {
 // Deprecated: Use RelationOp.Descriptor instead.
 func (RelationOp) EnumDescriptor() ([]byte, []int) {
 	return file_protobuf_pkginfo_proto_rawDescGZIP(), []int{0}
+}
+
+type PkgType int32
+
+const (
+	PkgType_UNKNOWN PkgType = 0
+	PkgType_PKG     PkgType = 1
+	PkgType_SPLIT   PkgType = 2
+	PkgType_SRC     PkgType = 3
+	PkgType_DEBUG   PkgType = 4
+)
+
+// Enum value maps for PkgType.
+var (
+	PkgType_name = map[int32]string{
+		0: "UNKNOWN",
+		1: "PKG",
+		2: "SPLIT",
+		3: "SRC",
+		4: "DEBUG",
+	}
+	PkgType_value = map[string]int32{
+		"UNKNOWN": 0,
+		"PKG":     1,
+		"SPLIT":   2,
+		"SRC":     3,
+		"DEBUG":   4,
+	}
+)
+
+func (x PkgType) Enum() *PkgType {
+	p := new(PkgType)
+	*p = x
+	return p
+}
+
+func (x PkgType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (PkgType) Descriptor() protoreflect.EnumDescriptor {
+	return file_protobuf_pkginfo_proto_enumTypes[1].Descriptor()
+}
+
+func (PkgType) Type() protoreflect.EnumType {
+	return &file_protobuf_pkginfo_proto_enumTypes[1]
+}
+
+func (x PkgType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use PkgType.Descriptor instead.
+func (PkgType) EnumDescriptor() ([]byte, []int) {
+	return file_protobuf_pkginfo_proto_rawDescGZIP(), []int{1}
 }
 
 type Relation struct {
@@ -163,6 +217,7 @@ type PkgInfo struct {
 	InstallTimestamp int64                  `protobuf:"varint,17,opt,name=install_timestamp,json=installTimestamp,proto3" json:"install_timestamp,omitempty"`
 	BuildTimestamp   int64                  `protobuf:"varint,16,opt,name=build_timestamp,json=buildTimestamp,proto3" json:"build_timestamp,omitempty"`
 	Size             int64                  `protobuf:"varint,2,opt,name=size,proto3" json:"size,omitempty"`
+	PkgType          PkgType                `protobuf:"varint,18,opt,name=pkg_type,json=pkgType,proto3,enum=pkginfo.PkgType" json:"pkg_type,omitempty"`
 	Name             string                 `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
 	Reason           string                 `protobuf:"bytes,4,opt,name=reason,proto3" json:"reason,omitempty"`
 	Version          string                 `protobuf:"bytes,5,opt,name=version,proto3" json:"version,omitempty"`
@@ -229,6 +284,13 @@ func (x *PkgInfo) GetSize() int64 {
 		return x.Size
 	}
 	return 0
+}
+
+func (x *PkgInfo) GetPkgType() PkgType {
+	if x != nil {
+		return x.PkgType
+	}
+	return PkgType_UNKNOWN
 }
 
 func (x *PkgInfo) GetName() string {
@@ -392,11 +454,12 @@ const file_protobuf_pkginfo_proto_rawDesc = "" +
 	"\aversion\x18\x02 \x01(\tR\aversion\x12/\n" +
 	"\boperator\x18\x03 \x01(\x0e2\x13.pkginfo.RelationOpR\boperator\x12\x14\n" +
 	"\x05depth\x18\x04 \x01(\x05R\x05depth\x12\"\n" +
-	"\fproviderName\x18\x05 \x01(\tR\fproviderName\"\xac\x04\n" +
+	"\fproviderName\x18\x05 \x01(\tR\fproviderName\"\xd9\x04\n" +
 	"\aPkgInfo\x12+\n" +
 	"\x11install_timestamp\x18\x11 \x01(\x03R\x10installTimestamp\x12'\n" +
 	"\x0fbuild_timestamp\x18\x10 \x01(\x03R\x0ebuildTimestamp\x12\x12\n" +
-	"\x04size\x18\x02 \x01(\x03R\x04size\x12\x12\n" +
+	"\x04size\x18\x02 \x01(\x03R\x04size\x12+\n" +
+	"\bpkg_type\x18\x12 \x01(\x0e2\x10.pkginfo.PkgTypeR\apkgType\x12\x12\n" +
 	"\x04name\x18\x03 \x01(\tR\x04name\x12\x16\n" +
 	"\x06reason\x18\x04 \x01(\tR\x06reason\x12\x18\n" +
 	"\aversion\x18\x05 \x01(\tR\aversion\x12\x12\n" +
@@ -425,7 +488,13 @@ const file_protobuf_pkginfo_proto_rawDesc = "" +
 	"\n" +
 	"LESS_EQUAL\x10\x03\x12\v\n" +
 	"\aGREATER\x10\x04\x12\x11\n" +
-	"\rGREATER_EQUAL\x10\x05B\x1cZ\x1ainternal/protobuf;protobufb\x06proto3"
+	"\rGREATER_EQUAL\x10\x05*>\n" +
+	"\aPkgType\x12\v\n" +
+	"\aUNKNOWN\x10\x00\x12\a\n" +
+	"\x03PKG\x10\x01\x12\t\n" +
+	"\x05SPLIT\x10\x02\x12\a\n" +
+	"\x03SRC\x10\x03\x12\t\n" +
+	"\x05DEBUG\x10\x04B\x1cZ\x1ainternal/protobuf;protobufb\x06proto3"
 
 var (
 	file_protobuf_pkginfo_proto_rawDescOnce sync.Once
@@ -439,29 +508,29 @@ func file_protobuf_pkginfo_proto_rawDescGZIP() []byte {
 	return file_protobuf_pkginfo_proto_rawDescData
 }
 
-var (
-	file_protobuf_pkginfo_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_protobuf_pkginfo_proto_msgTypes  = make([]protoimpl.MessageInfo, 3)
-	file_protobuf_pkginfo_proto_goTypes   = []any{
-		(RelationOp)(0),    // 0: pkginfo.RelationOp
-		(*Relation)(nil),   // 1: pkginfo.Relation
-		(*PkgInfo)(nil),    // 2: pkginfo.PkgInfo
-		(*CachedPkgs)(nil), // 3: pkginfo.CachedPkgs
-	}
-)
+var file_protobuf_pkginfo_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_protobuf_pkginfo_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_protobuf_pkginfo_proto_goTypes = []any{
+	(RelationOp)(0),    // 0: pkginfo.RelationOp
+	(PkgType)(0),       // 1: pkginfo.PkgType
+	(*Relation)(nil),   // 2: pkginfo.Relation
+	(*PkgInfo)(nil),    // 3: pkginfo.PkgInfo
+	(*CachedPkgs)(nil), // 4: pkginfo.CachedPkgs
+}
 var file_protobuf_pkginfo_proto_depIdxs = []int32{
 	0, // 0: pkginfo.Relation.operator:type_name -> pkginfo.RelationOp
-	1, // 1: pkginfo.PkgInfo.depends:type_name -> pkginfo.Relation
-	1, // 2: pkginfo.PkgInfo.required_by:type_name -> pkginfo.Relation
-	1, // 3: pkginfo.PkgInfo.provides:type_name -> pkginfo.Relation
-	1, // 4: pkginfo.PkgInfo.conflicts:type_name -> pkginfo.Relation
-	1, // 5: pkginfo.PkgInfo.replaces:type_name -> pkginfo.Relation
-	2, // 6: pkginfo.CachedPkgs.pkgs:type_name -> pkginfo.PkgInfo
-	7, // [7:7] is the sub-list for method output_type
-	7, // [7:7] is the sub-list for method input_type
-	7, // [7:7] is the sub-list for extension type_name
-	7, // [7:7] is the sub-list for extension extendee
-	0, // [0:7] is the sub-list for field type_name
+	1, // 1: pkginfo.PkgInfo.pkg_type:type_name -> pkginfo.PkgType
+	2, // 2: pkginfo.PkgInfo.depends:type_name -> pkginfo.Relation
+	2, // 3: pkginfo.PkgInfo.required_by:type_name -> pkginfo.Relation
+	2, // 4: pkginfo.PkgInfo.provides:type_name -> pkginfo.Relation
+	2, // 5: pkginfo.PkgInfo.conflicts:type_name -> pkginfo.Relation
+	2, // 6: pkginfo.PkgInfo.replaces:type_name -> pkginfo.Relation
+	3, // 7: pkginfo.CachedPkgs.pkgs:type_name -> pkginfo.PkgInfo
+	8, // [8:8] is the sub-list for method output_type
+	8, // [8:8] is the sub-list for method input_type
+	8, // [8:8] is the sub-list for extension type_name
+	8, // [8:8] is the sub-list for extension extendee
+	0, // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_protobuf_pkginfo_proto_init() }
@@ -474,7 +543,7 @@ func file_protobuf_pkginfo_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_protobuf_pkginfo_proto_rawDesc), len(file_protobuf_pkginfo_proto_rawDesc)),
-			NumEnums:      1,
+			NumEnums:      2,
 			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/protobuf/pkginfo.proto
+++ b/protobuf/pkginfo.proto
@@ -23,11 +23,20 @@ message Relation {
   string providerName = 5;
 }
 
+enum PkgType {
+  UNKNOWN = 0;
+  PKG = 1;
+  SPLIT = 2;
+  SRC = 3;
+  DEBUG = 4;
+}
+
 message PkgInfo {
   reserved 1;
   int64 install_timestamp = 17;
   int64 build_timestamp = 16;
   int64 size = 2;
+  PkgType pkg_type = 18;
   string name = 3;
   string reason = 4;
   string version = 5;


### PR DESCRIPTION
Users can now list the pkgdata of packages with `qp -s pkgdata` or `qp -S pkgdata` or `qp -A`.

Example:
```bash
> qp  -s name,pkgtype
NAME                      PKGTYPE
mosh                      pkg
lksctp-tools              pkg
iperf3                    pkg
python-lark-parser        pkg
python-poetry-core        pkg
python-typing_extensions  pkg
python-fastjsonschema     pkg
websocat                  pkg
python-jmespath           pkg
python-certifi            pkg
python-s3transfer         pkg
python-rsa                pkg
python-docutils           pkg
python-colorama           pkg
python-botocore           pkg
python-pyasn1             pkg
python-yaml               pkg
libyaml                   pkg
aws-cli                   pkg
qp                        pkg
```

Addresses #175 