### PR TITLE
Feature: Cache regeneration with `--regen-cache`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ this package is compatible with the following distributions:
 | ✓ | metaflag for all queries | ✓ | JSON output |
 | ✓ | no-headers option | ✓ | provides query |
 | ✓ | depends query | ✓ | all-fields option |
-| ✓ | required-by query | ✓ | no-cache option |
+| ✓ | required-by query | ✓ | no cache option |
 | ✓ | optional full timestamp | ✓ | package description field |
 | – | list possibly or confirmed stale/abandoned packages | – | self-referencing field |
 | – | name exclusion query | – | streaming pipeline |
@@ -94,7 +94,7 @@ this package is compatible with the following distributions:
 | - | pkgtype filter | - | pkgtype sort |
 | ✓ | architecture query | - | groups field |
 | ✓	| conflicts query | - | package description sort |
-| - | regen-cache option | - | groups filter |
+| ✓	| regenerate cache option | - | groups filter |
 | - | packager field | - | optional dependency field |
 | ✓ | sort by size on disk | - | conflicts sort |
 
@@ -118,7 +118,7 @@ for the latest (unstable) version from git w/ the AUR, use `qp-git`*.
 the cache is located under `/query-packages` at `$HOME/.cache/` or wherever you have `$XDG_HOME_CACHE` set to.
 
 ### building from source + manual installation
-**note**: this package is specific to arch-based linux distributions
+**note**: this packages is specific to arch-based linux distributions
 
 1. clone the repo:
    ```bash
@@ -172,10 +172,11 @@ qp [options]
 - `--json`: output results in JSON format (overrides table output and `--full-timestamp`)
 - `--no-progress`: force no progress bar outside of non-interactive environments
 - `--no-cache`: disable cache loading/saving and force fresh package data loading
+- `--regen-cache`: disable cache loading, force fresh package data loading, and save fresh cache
 - `-h` | `--help`: print help info
 
 ### querying with `--where`
-the `--where` (short-flag: `-w`) flag allows for powerful querying of installed packages. queries can be combined by using multiple query flags. 
+the `--where` (short-flag: `-w`) flag allows for powerful querying of installed packages. queries can be combined by using multiple `--where/-w` flags.
 
 all queries that take package/library/program names as arguments can also take a comma-separated list. this applies to the queries `name`, `depends`, and `required-by`. 
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	ShowFullTimestamp bool
 	DisableProgress   bool
 	NoCache           bool
+	RegenCache        bool
 	SortOption        SortOption
 	Fields            []consts.FieldType
 	FieldQueries      FieldQueries

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -16,6 +16,7 @@ func ParseFlags(args []string) (Config, error) {
 	var showFullTimestamp bool
 	var disableProgress bool
 	var noCache bool
+	var regenCache bool
 
 	var filterInputs []string
 	var sortInput string
@@ -46,6 +47,7 @@ func ParseFlags(args []string) (Config, error) {
 	pflag.BoolVar(&outputJson, "json", false, "Output results in JSON format")
 	pflag.BoolVar(&disableProgress, "no-progress", false, "Force suppress progress output")
 	pflag.BoolVar(&noCache, "no-cache", false, "Disable cache loading/saving and force fresh package data loading")
+	pflag.BoolVar(&regenCache, "regen-cache", false, "Disable cache loading, force fresh package data loading, and save fresh cache")
 
 	pflag.BoolVarP(&showHelp, "help", "h", false, "Display help")
 
@@ -110,6 +112,7 @@ func ParseFlags(args []string) (Config, error) {
 		HasNoHeaders:      hasNoHeaders,
 		ShowFullTimestamp: showFullTimestamp,
 		NoCache:           noCache,
+		RegenCache:        regenCache,
 		DisableProgress:   disableProgress,
 		SortOption:        sortOption,
 		Fields:            fieldsParsed,

--- a/internal/pipeline/phase/steps.go
+++ b/internal/pipeline/phase/steps.go
@@ -15,7 +15,7 @@ func LoadCacheStep(
 	_ ProgressReporter,
 	pipelineCtx *meta.PipelineContext,
 ) ([]*PkgInfo, error) {
-	if cfg.NoCache {
+	if cfg.NoCache || cfg.RegenCache {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Users can now regenerate the cache with `--regen-cache`. This skips loading the cache, loads fresh data, and saves the freshly built cache.