### PR TITLE
Feature: Add groups field

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ this package is compatible with the following distributions:
 
 ## features
 
-- list installed packages with install date/timestamps, dependencies, provisions, requirements, size on disk, conflicts, replacements, architecture, license, description, build date, package base, package type, and version
+- list installed packages with install date/timestamps, dependencies, provisions, requirements, size on disk, conflicts, replacements, architecture, license, description, build date, package base, package type, groups, and version
 - query by explicitly installed packages
 - query by packages installed as dependencies
 - query by packages required by specified packages
@@ -92,12 +92,12 @@ this package is compatible with the following distributions:
 | ✓ | build-date field | - | build-date filter |
 | - | build-date sort | ✓ | pkgtype field |
 | - | pkgtype filter | - | pkgtype sort |
-| ✓ | architecture query | - | groups field |
+| ✓ | architecture query | ✓ | groups field |
 | ✓	| conflicts query | - | package description sort |
 | ✓	| regenerate cache option | - | groups filter |
 | - | packager field | - | optional dependency field |
 | ✓ | sort by size on disk | - | conflicts sort |
-
+| - | validation field | - | validation sort |
 
 ## installation
 
@@ -211,6 +211,7 @@ short-flag queries and long-flag queries can be combined.
 - `pkgbase` - name of the base package used to group split packages; for non-split packages, it is the same as the package name. 
 - `description` - package description
 - `url` - the URL of the official site of the software being packaged
+- `groups` - package groups or categories (e.g., base, gnome, xfce4)
 - `conflicts` - list of packages that conflict, or cause problems, with the package
 - `replaces` - list of packages that are replaced by the package
 - `depends` - list of dependencies (output can be long)

--- a/internal/config/help.go
+++ b/internal/config/help.go
@@ -68,6 +68,7 @@ func PrintHelp() {
 	fmt.Println("  pkgbase      Name of the base package used to group split packages; for non-split packages, it is the same as the package name.")
 	fmt.Println("  pkgtype      Type of the package (standard, split, debug, source, unknown)")
 	fmt.Println("               Note: Older packages may show \"unknown\" pkgtype if built before pacman introduced XDATA.")
+	fmt.Println("  groups       Package groups or categories (e.g., base, gnome, xfce4)")
 
 	fmt.Println("\nExamples:")
 	fmt.Println("  qp -l 10                      # Show the last 10 installed packages")

--- a/internal/consts/fields.go
+++ b/internal/consts/fields.go
@@ -15,6 +15,7 @@ const (
 	FieldPkgBase
 	FieldDescription
 	FieldUrl
+	FieldGroups
 	FieldSize
 	FieldDate
 	FieldBuildDate
@@ -44,6 +45,7 @@ const (
 	pkgBase     = "pkgbase"
 	description = "description"
 	url         = "url"
+	groups      = "groups"
 	conflicts   = "conflicts"
 	replaces    = "replaces"
 	depends     = "depends"
@@ -80,6 +82,7 @@ var FieldTypeLookup = map[string]FieldType{
 	pkgBase:     FieldPkgBase,
 	description: FieldDescription,
 	url:         FieldUrl,
+	groups:      FieldGroups,
 	conflicts:   FieldConflicts,
 	replaces:    FieldReplaces,
 	depends:     FieldDepends,
@@ -106,6 +109,7 @@ var FieldNameLookup = map[FieldType]string{
 	FieldPkgBase:     pkgBase,
 	FieldDescription: description,
 	FieldUrl:         url,
+	FieldGroups:      groups,
 	FieldConflicts:   conflicts,
 	FieldReplaces:    replaces,
 	FieldDepends:     depends,
@@ -125,6 +129,7 @@ var (
 		FieldReason,
 		FieldSize,
 	}
+	// note: this is also the order the columns will be displayed in table output
 	ValidFields = []FieldType{
 		FieldDate,
 		FieldBuildDate,
@@ -138,6 +143,7 @@ var (
 		FieldPkgBase,
 		FieldDescription,
 		FieldUrl,
+		FieldGroups,
 		FieldConflicts,
 		FieldReplaces,
 		FieldDepends,

--- a/internal/display/render_json.go
+++ b/internal/display/render_json.go
@@ -21,6 +21,7 @@ type PkgInfoJson struct {
 	PkgBase          string   `json:"pkgbase,omitempty"`
 	Description      string   `json:"description,omitempty"`
 	Url              string   `json:"url,omitempty"`
+	Groups           []string `json:"groups,omitempty"`
 	Conflicts        []string `json:"conflicts,omitempty"`
 	Replaces         []string `json:"replaces,omitempty"`
 	Depends          []string `json:"depends,omitempty"`
@@ -99,6 +100,8 @@ func getJsonValues(pkg *pkgdata.PkgInfo, fields []consts.FieldType) *PkgInfoJson
 			filteredPackage.Description = pkg.Description
 		case consts.FieldUrl:
 			filteredPackage.Url = pkg.Url
+		case consts.FieldGroups:
+			filteredPackage.Groups = pkg.Groups
 		case consts.FieldConflicts:
 			filteredPackage.Conflicts = flattenRelations(pkg.Conflicts)
 		case consts.FieldReplaces:

--- a/internal/display/render_table.go
+++ b/internal/display/render_table.go
@@ -26,6 +26,7 @@ var columnHeaders = map[consts.FieldType]string{
 	consts.FieldPkgBase:     "PKGBASE",
 	consts.FieldDescription: "DESCRIPTION",
 	consts.FieldUrl:         "URL",
+	consts.FieldGroups:      "GROUPS",
 	consts.FieldConflicts:   "CONFLICTS",
 	consts.FieldReplaces:    "REPLACES",
 	consts.FieldDepends:     "DEPENDS",
@@ -81,7 +82,12 @@ func renderRows(
 ) {
 	row := make([]string, len(fields))
 	for i, fields := range fields {
-		row[i] = getTableValue(pkg, fields, ctx)
+		value := getTableValue(pkg, fields, ctx)
+		if value == "" {
+			value = "-"
+		}
+
+		row[i] = value
 	}
 
 	fmt.Fprintln(w, strings.Join(row, "\t"))
@@ -117,6 +123,8 @@ func getTableValue(pkg *pkgdata.PkgInfo, field consts.FieldType, ctx tableContex
 		return pkg.License
 	case consts.FieldUrl:
 		return pkg.Url
+	case consts.FieldGroups:
+		return strings.Join(pkg.Groups, ", ")
 	case consts.FieldDescription:
 		return pkg.Description
 	case consts.FieldPkgBase:

--- a/internal/pkgdata/cache.go
+++ b/internal/pkgdata/cache.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	cacheVersion    = 8 // bump when updating structure of PkgInfo/Relation/pkginfo.proto OR when dependency resolution is updated
+	cacheVersion    = 9 // bump when updating structure of PkgInfo/Relation/pkginfo.proto OR when dependency resolution is updated
 	xdgCacheHomeEnv = "XDG_CACHE_HOME"
 	homeEnv         = "HOME"
 	qpCacheDir      = "query-packages"
@@ -131,6 +131,7 @@ func pkgsToProtos(pkgs []*PkgInfo) []*pb.PkgInfo {
 			Url:              pkg.Url,
 			Description:      pkg.Description,
 			PkgBase:          pkg.PkgBase,
+			Groups:           pkg.Groups,
 			Depends:          relationsToProtos(pkg.Depends),
 			RequiredBy:       relationsToProtos(pkg.RequiredBy),
 			Provides:         relationsToProtos(pkg.Provides),
@@ -173,6 +174,7 @@ func protosToPkgs(pbPkgs []*pb.PkgInfo) []*PkgInfo {
 			Url:              pbPkg.Url,
 			Description:      pbPkg.Description,
 			PkgBase:          pbPkg.PkgBase,
+			Groups:           pbPkg.Groups,
 			Depends:          protosToRelations(pbPkg.Depends),
 			RequiredBy:       protosToRelations(pbPkg.RequiredBy),
 			Provides:         protosToRelations(pbPkg.Provides),

--- a/internal/pkgdata/fetch.go
+++ b/internal/pkgdata/fetch.go
@@ -14,21 +14,22 @@ import (
 )
 
 const (
-	fieldName        = "%NAME%"
 	fieldInstallDate = "%INSTALLDATE%"
+	fieldBuildDate   = "%BUILDDATE%"
+	fieldName        = "%NAME%"
 	fieldSize        = "%SIZE%"
 	fieldReason      = "%REASON%"
 	fieldVersion     = "%VERSION%"
+	fieldArch        = "%ARCH%"
+	fieldLicense     = "%LICENSE%"
+	fieldPkgBase     = "%BASE%"
+	fieldDescription = "%DESC%"
+	fieldUrl         = "%URL%"
+	fieldGroups      = "%GROUPS%"
 	fieldDepends     = "%DEPENDS%"
 	fieldProvides    = "%PROVIDES%"
 	fieldConflicts   = "%CONFLICTS%"
-	fieldArch        = "%ARCH%"
-	fieldLicense     = "%LICENSE%"
-	fieldUrl         = "%URL%"
-	fieldDescription = "%DESC%"
-	fieldPkgBase     = "%BASE%"
 	fieldReplaces    = "%REPLACES%"
-	fieldBuildDate   = "%BUILDDATE%"
 	fieldXData       = "%XDATA%"
 
 	subfieldPkgType = "pkgtype"
@@ -145,7 +146,7 @@ func parseDescFile(descPath string) (*PkgInfo, error) {
 				fieldArch, fieldLicense, fieldUrl, fieldDescription, fieldPkgBase, fieldBuildDate:
 				currentField = line
 
-			case fieldDepends, fieldProvides, fieldConflicts, fieldReplaces, fieldXData:
+			case fieldGroups, fieldDepends, fieldProvides, fieldConflicts, fieldReplaces, fieldXData:
 				currentField = line
 				block, next := collectBlockBytes(data, end+1)
 
@@ -268,6 +269,8 @@ func applySingleLineField(pkg *PkgInfo, field string, value string) error {
 
 func applyMultiLineField(pkg *PkgInfo, field string, block []string) {
 	switch field {
+	case fieldGroups:
+		pkg.Groups = block
 	case fieldDepends, fieldProvides, fieldConflicts, fieldReplaces:
 		applyRelations(pkg, field, block)
 	case fieldXData:

--- a/internal/pkgdata/filters.go
+++ b/internal/pkgdata/filters.go
@@ -79,6 +79,16 @@ func FilterBySizeRange(pkg *PkgInfo, startSize int64, endSize int64) bool {
 	return !(roundedSize < roundSizeInBytes(startSize) || roundedSize > roundSizeInBytes(endSize))
 }
 
+func FilterSliceByStrings(pkgStrings []string, targetStrings []string) bool {
+	for _, pkgString := range pkgStrings {
+		if FilterByStrings(pkgString, targetStrings) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func FilterByStrings(pkgString string, targetStrings []string) bool {
 	pkgString = strings.ToLower(pkgString)
 

--- a/internal/pkgdata/packageinfo.go
+++ b/internal/pkgdata/packageinfo.go
@@ -46,6 +46,8 @@ type PkgInfo struct {
 	Description string
 	PkgBase     string
 
+	Groups []string
+
 	Depends    []Relation
 	RequiredBy []Relation
 	Provides   []Relation

--- a/internal/protobuf/pkginfo.pb.go
+++ b/internal/protobuf/pkginfo.pb.go
@@ -226,6 +226,7 @@ type PkgInfo struct {
 	Url              string                 `protobuf:"bytes,8,opt,name=url,proto3" json:"url,omitempty"`
 	Description      string                 `protobuf:"bytes,13,opt,name=description,proto3" json:"description,omitempty"`
 	PkgBase          string                 `protobuf:"bytes,14,opt,name=pkg_base,json=pkgBase,proto3" json:"pkg_base,omitempty"`
+	Groups           []string               `protobuf:"bytes,19,rep,name=groups,proto3" json:"groups,omitempty"`
 	Depends          []*Relation            `protobuf:"bytes,9,rep,name=depends,proto3" json:"depends,omitempty"`
 	RequiredBy       []*Relation            `protobuf:"bytes,10,rep,name=required_by,json=requiredBy,proto3" json:"required_by,omitempty"`
 	Provides         []*Relation            `protobuf:"bytes,11,rep,name=provides,proto3" json:"provides,omitempty"`
@@ -349,6 +350,13 @@ func (x *PkgInfo) GetPkgBase() string {
 	return ""
 }
 
+func (x *PkgInfo) GetGroups() []string {
+	if x != nil {
+		return x.Groups
+	}
+	return nil
+}
+
 func (x *PkgInfo) GetDepends() []*Relation {
 	if x != nil {
 		return x.Depends
@@ -454,7 +462,7 @@ const file_protobuf_pkginfo_proto_rawDesc = "" +
 	"\aversion\x18\x02 \x01(\tR\aversion\x12/\n" +
 	"\boperator\x18\x03 \x01(\x0e2\x13.pkginfo.RelationOpR\boperator\x12\x14\n" +
 	"\x05depth\x18\x04 \x01(\x05R\x05depth\x12\"\n" +
-	"\fproviderName\x18\x05 \x01(\tR\fproviderName\"\xd9\x04\n" +
+	"\fproviderName\x18\x05 \x01(\tR\fproviderName\"\xf1\x04\n" +
 	"\aPkgInfo\x12+\n" +
 	"\x11install_timestamp\x18\x11 \x01(\x03R\x10installTimestamp\x12'\n" +
 	"\x0fbuild_timestamp\x18\x10 \x01(\x03R\x0ebuildTimestamp\x12\x12\n" +
@@ -467,7 +475,8 @@ const file_protobuf_pkginfo_proto_rawDesc = "" +
 	"\alicense\x18\a \x01(\tR\alicense\x12\x10\n" +
 	"\x03url\x18\b \x01(\tR\x03url\x12 \n" +
 	"\vdescription\x18\r \x01(\tR\vdescription\x12\x19\n" +
-	"\bpkg_base\x18\x0e \x01(\tR\apkgBase\x12+\n" +
+	"\bpkg_base\x18\x0e \x01(\tR\apkgBase\x12\x16\n" +
+	"\x06groups\x18\x13 \x03(\tR\x06groups\x12+\n" +
 	"\adepends\x18\t \x03(\v2\x11.pkginfo.RelationR\adepends\x122\n" +
 	"\vrequired_by\x18\n" +
 	" \x03(\v2\x11.pkginfo.RelationR\n" +

--- a/protobuf/pkginfo.proto
+++ b/protobuf/pkginfo.proto
@@ -46,6 +46,8 @@ message PkgInfo {
   string description = 13;
   string pkg_base = 14;
 
+  repeated string groups = 19;
+
   repeated Relation depends = 9;
   repeated Relation required_by = 10;
   repeated Relation provides = 11;


### PR DESCRIPTION
Users can now list the groups of packages with `qp -s groups` or `qp -S groups` or `qp -A`.

Example:
```bash
> qp -s name,groups -w name=vulkan
NAME               GROUPS
vulkan-icd-loader  vulkan-devel
vulkan-broadcom    -
vulkan-headers     vulkan-devel
```

Closes #179 