### PR TITLE
Feature: Add validation field

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 you can find installation instructions [here](#installation).
 
-`qp` supports querying/sorting for install date, package name, install reason (explicit/dependency), size on disk, reverse dependencies, dependency requirements, description, replacements, conflicts, provisions, build date, package type and more. check [usage](#usage) for all available options.
+`qp` supports querying and sorting for install date, package name, install reason (explicit/dependency), size on disk, reverse dependencies (required by), dependencies, validation, description, replacements, conflicts, provisions, build date, package type and more. check [usage](#usage) for all available options.
 
 ![qp logo | query packages logo](https://gistcdn.githack.com/Zweih/9009d5c74eab8a5515a8a64a0495df32/raw/ef8a8ac3655fd3dee24494a3403867919d806b63/qp-logo_clean.svg)
 
@@ -37,7 +37,7 @@ this package is compatible with the following distributions:
 
 ## features
 
-- list installed packages with install date/timestamps, dependencies, provisions, requirements, size on disk, conflicts, replacements, architecture, license, description, build date, package base, package type, groups, and version
+- list installed packages with install date/timestamps, dependencies, provisions, reverse dependencies (required by), size on disk, conflicts, replacements, architecture, license, description, build date, package base, package type, validation, groups, and version
 - query by explicitly installed packages
 - query by packages installed as dependencies
 - query by packages required by specified packages
@@ -97,7 +97,7 @@ this package is compatible with the following distributions:
 | ✓	| regenerate cache option | - | groups filter |
 | - | packager field | - | optional dependency field |
 | ✓ | sort by size on disk | - | conflicts sort |
-| - | validation field | - | validation sort |
+| ✓ | validation field | - | validation sort |
 
 ## installation
 
@@ -211,6 +211,7 @@ short-flag queries and long-flag queries can be combined.
 - `pkgbase` - name of the base package used to group split packages; for non-split packages, it is the same as the package name. 
 - `description` - package description
 - `url` - the URL of the official site of the software being packaged
+- `validation` - package integrity validation method (e.g., sha256", "pgp")
 - `groups` - package groups or categories (e.g., base, gnome, xfce4)
 - `conflicts` - list of packages that conflict, or cause problems, with the package
 - `replaces` - list of packages that are replaced by the package
@@ -244,6 +245,7 @@ output format:
     "pkgbase": "tinysparql",
     "description": "Low-footprint RDF triple store with SPARQL 1.1 interface",
     "url": "https://tinysparql.org/",
+    "validation": "pgp",
     "conflicts": [
       "tracker3<=3.7.3-2"
     ],

--- a/internal/config/help.go
+++ b/internal/config/help.go
@@ -69,6 +69,7 @@ func PrintHelp() {
 	fmt.Println("  pkgtype      Type of the package (standard, split, debug, source, unknown)")
 	fmt.Println("               Note: Older packages may show \"unknown\" pkgtype if built before pacman introduced XDATA.")
 	fmt.Println("  groups       Package groups or categories (e.g., base, gnome, xfce4)")
+	fmt.Println("  validation   Package integrity validation method (e.g., \"sha256\", \"pgp\")")
 
 	fmt.Println("\nExamples:")
 	fmt.Println("  qp -l 10                      # Show the last 10 installed packages")

--- a/internal/consts/fields.go
+++ b/internal/consts/fields.go
@@ -13,6 +13,7 @@ const (
 	FieldLicense
 	FieldName
 	FieldPkgBase
+	FieldValidation
 	FieldDescription
 	FieldUrl
 	FieldGroups
@@ -45,6 +46,7 @@ const (
 	pkgBase     = "pkgbase"
 	description = "description"
 	url         = "url"
+	validation  = "validation"
 	groups      = "groups"
 	conflicts   = "conflicts"
 	replaces    = "replaces"
@@ -82,6 +84,7 @@ var FieldTypeLookup = map[string]FieldType{
 	pkgBase:     FieldPkgBase,
 	description: FieldDescription,
 	url:         FieldUrl,
+	validation:  FieldValidation,
 	groups:      FieldGroups,
 	conflicts:   FieldConflicts,
 	replaces:    FieldReplaces,
@@ -109,6 +112,7 @@ var FieldNameLookup = map[FieldType]string{
 	FieldPkgBase:     pkgBase,
 	FieldDescription: description,
 	FieldUrl:         url,
+	FieldValidation:  validation,
 	FieldGroups:      groups,
 	FieldConflicts:   conflicts,
 	FieldReplaces:    replaces,
@@ -143,6 +147,7 @@ var (
 		FieldPkgBase,
 		FieldDescription,
 		FieldUrl,
+		FieldValidation,
 		FieldGroups,
 		FieldConflicts,
 		FieldReplaces,

--- a/internal/display/render_json.go
+++ b/internal/display/render_json.go
@@ -21,6 +21,7 @@ type PkgInfoJson struct {
 	PkgBase          string   `json:"pkgbase,omitempty"`
 	Description      string   `json:"description,omitempty"`
 	Url              string   `json:"url,omitempty"`
+	Validation       string   `json:"validation,omitempty"`
 	Groups           []string `json:"groups,omitempty"`
 	Conflicts        []string `json:"conflicts,omitempty"`
 	Replaces         []string `json:"replaces,omitempty"`
@@ -102,6 +103,8 @@ func getJsonValues(pkg *pkgdata.PkgInfo, fields []consts.FieldType) *PkgInfoJson
 			filteredPackage.Url = pkg.Url
 		case consts.FieldGroups:
 			filteredPackage.Groups = pkg.Groups
+		case consts.FieldValidation:
+			filteredPackage.Validation = pkg.Validation
 		case consts.FieldConflicts:
 			filteredPackage.Conflicts = flattenRelations(pkg.Conflicts)
 		case consts.FieldReplaces:

--- a/internal/display/render_table.go
+++ b/internal/display/render_table.go
@@ -26,6 +26,7 @@ var columnHeaders = map[consts.FieldType]string{
 	consts.FieldPkgBase:     "PKGBASE",
 	consts.FieldDescription: "DESCRIPTION",
 	consts.FieldUrl:         "URL",
+	consts.FieldValidation:  "VALIDATION",
 	consts.FieldGroups:      "GROUPS",
 	consts.FieldConflicts:   "CONFLICTS",
 	consts.FieldReplaces:    "REPLACES",
@@ -123,6 +124,8 @@ func getTableValue(pkg *pkgdata.PkgInfo, field consts.FieldType, ctx tableContex
 		return pkg.License
 	case consts.FieldUrl:
 		return pkg.Url
+	case consts.FieldValidation:
+		return pkg.Validation
 	case consts.FieldGroups:
 		return strings.Join(pkg.Groups, ", ")
 	case consts.FieldDescription:

--- a/internal/pkgdata/cache.go
+++ b/internal/pkgdata/cache.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	cacheVersion    = 9 // bump when updating structure of PkgInfo/Relation/pkginfo.proto OR when dependency resolution is updated
+	cacheVersion    = 10 // bump when updating structure of PkgInfo/Relation/pkginfo.proto OR when dependency resolution is updated
 	xdgCacheHomeEnv = "XDG_CACHE_HOME"
 	homeEnv         = "HOME"
 	qpCacheDir      = "query-packages"
@@ -131,6 +131,7 @@ func pkgsToProtos(pkgs []*PkgInfo) []*pb.PkgInfo {
 			Url:              pkg.Url,
 			Description:      pkg.Description,
 			PkgBase:          pkg.PkgBase,
+			Validation:       pkg.Validation,
 			Groups:           pkg.Groups,
 			Depends:          relationsToProtos(pkg.Depends),
 			RequiredBy:       relationsToProtos(pkg.RequiredBy),
@@ -174,6 +175,7 @@ func protosToPkgs(pbPkgs []*pb.PkgInfo) []*PkgInfo {
 			Url:              pbPkg.Url,
 			Description:      pbPkg.Description,
 			PkgBase:          pbPkg.PkgBase,
+			Validation:       pbPkg.Validation,
 			Groups:           pbPkg.Groups,
 			Depends:          protosToRelations(pbPkg.Depends),
 			RequiredBy:       protosToRelations(pbPkg.RequiredBy),

--- a/internal/pkgdata/fetch.go
+++ b/internal/pkgdata/fetch.go
@@ -25,6 +25,7 @@ const (
 	fieldPkgBase     = "%BASE%"
 	fieldDescription = "%DESC%"
 	fieldUrl         = "%URL%"
+	fieldValidation  = "%VALIDATION%"
 	fieldGroups      = "%GROUPS%"
 	fieldDepends     = "%DEPENDS%"
 	fieldProvides    = "%PROVIDES%"
@@ -142,11 +143,14 @@ func parseDescFile(descPath string) (*PkgInfo, error) {
 			line := string(bytes.TrimSpace(data[start:end]))
 
 			switch line {
-			case fieldName, fieldInstallDate, fieldSize, fieldReason, fieldVersion,
-				fieldArch, fieldLicense, fieldUrl, fieldDescription, fieldPkgBase, fieldBuildDate:
+			case fieldName, fieldInstallDate, fieldSize,
+				fieldReason, fieldVersion, fieldArch,
+				fieldLicense, fieldUrl, fieldDescription,
+				fieldValidation, fieldPkgBase, fieldBuildDate:
 				currentField = line
 
-			case fieldGroups, fieldDepends, fieldProvides, fieldConflicts, fieldReplaces, fieldXData:
+			case fieldGroups, fieldDepends, fieldProvides,
+				fieldConflicts, fieldReplaces, fieldXData:
 				currentField = line
 				block, next := collectBlockBytes(data, end+1)
 
@@ -253,6 +257,9 @@ func applySingleLineField(pkg *PkgInfo, field string, value string) error {
 
 	case fieldUrl:
 		pkg.Url = value
+
+	case fieldValidation:
+		pkg.Validation = value
 
 	case fieldDescription:
 		pkg.Description = value

--- a/internal/pkgdata/packageinfo.go
+++ b/internal/pkgdata/packageinfo.go
@@ -45,6 +45,7 @@ type PkgInfo struct {
 	Url         string
 	Description string
 	PkgBase     string
+	Validation  string
 
 	Groups []string
 

--- a/internal/protobuf/pkginfo.pb.go
+++ b/internal/protobuf/pkginfo.pb.go
@@ -226,6 +226,7 @@ type PkgInfo struct {
 	Url              string                 `protobuf:"bytes,8,opt,name=url,proto3" json:"url,omitempty"`
 	Description      string                 `protobuf:"bytes,13,opt,name=description,proto3" json:"description,omitempty"`
 	PkgBase          string                 `protobuf:"bytes,14,opt,name=pkg_base,json=pkgBase,proto3" json:"pkg_base,omitempty"`
+	Validation       string                 `protobuf:"bytes,20,opt,name=validation,proto3" json:"validation,omitempty"`
 	Groups           []string               `protobuf:"bytes,19,rep,name=groups,proto3" json:"groups,omitempty"`
 	Depends          []*Relation            `protobuf:"bytes,9,rep,name=depends,proto3" json:"depends,omitempty"`
 	RequiredBy       []*Relation            `protobuf:"bytes,10,rep,name=required_by,json=requiredBy,proto3" json:"required_by,omitempty"`
@@ -350,6 +351,13 @@ func (x *PkgInfo) GetPkgBase() string {
 	return ""
 }
 
+func (x *PkgInfo) GetValidation() string {
+	if x != nil {
+		return x.Validation
+	}
+	return ""
+}
+
 func (x *PkgInfo) GetGroups() []string {
 	if x != nil {
 		return x.Groups
@@ -462,7 +470,7 @@ const file_protobuf_pkginfo_proto_rawDesc = "" +
 	"\aversion\x18\x02 \x01(\tR\aversion\x12/\n" +
 	"\boperator\x18\x03 \x01(\x0e2\x13.pkginfo.RelationOpR\boperator\x12\x14\n" +
 	"\x05depth\x18\x04 \x01(\x05R\x05depth\x12\"\n" +
-	"\fproviderName\x18\x05 \x01(\tR\fproviderName\"\xf1\x04\n" +
+	"\fproviderName\x18\x05 \x01(\tR\fproviderName\"\x91\x05\n" +
 	"\aPkgInfo\x12+\n" +
 	"\x11install_timestamp\x18\x11 \x01(\x03R\x10installTimestamp\x12'\n" +
 	"\x0fbuild_timestamp\x18\x10 \x01(\x03R\x0ebuildTimestamp\x12\x12\n" +
@@ -475,7 +483,10 @@ const file_protobuf_pkginfo_proto_rawDesc = "" +
 	"\alicense\x18\a \x01(\tR\alicense\x12\x10\n" +
 	"\x03url\x18\b \x01(\tR\x03url\x12 \n" +
 	"\vdescription\x18\r \x01(\tR\vdescription\x12\x19\n" +
-	"\bpkg_base\x18\x0e \x01(\tR\apkgBase\x12\x16\n" +
+	"\bpkg_base\x18\x0e \x01(\tR\apkgBase\x12\x1e\n" +
+	"\n" +
+	"validation\x18\x14 \x01(\tR\n" +
+	"validation\x12\x16\n" +
 	"\x06groups\x18\x13 \x03(\tR\x06groups\x12+\n" +
 	"\adepends\x18\t \x03(\v2\x11.pkginfo.RelationR\adepends\x122\n" +
 	"\vrequired_by\x18\n" +

--- a/protobuf/pkginfo.proto
+++ b/protobuf/pkginfo.proto
@@ -45,6 +45,7 @@ message PkgInfo {
   string url = 8;
   string description = 13;
   string pkg_base = 14;
+  string validation = 20;
 
   repeated string groups = 19;
 


### PR DESCRIPTION
Users can now list the validation of packages with `qp -s validation` or `qp -S validation` or `qp -A`.

Example:
```bash
> qp-s name,validation
NAME                      VALIDATION
mosh                      pgp
iperf3                    pgp
lksctp-tools              pgp
python-fastjsonschema     pgp
python-lark-parser        pgp
python-poetry-core        pgp
python-typing_extensions  pgp
websocat                  pgp
python-certifi            pgp
python-jmespath           pgp
aws-cli                   pgp
python-pyasn1             pgp
python-colorama           pgp
python-s3transfer         pgp
python-rsa                pgp
python-botocore           pgp
python-docutils           pgp
python-yaml               pgp
libyaml                   pgp
qp                        none
```

This brought to my attention that `qp` does not have pgp validation. That has been addressed in #183.

This closes #182 