### PR TITLE
Feature: Add optdepends field

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ you can find installation instructions [here](#installation).
 
 ![GitHub Downloads](https://img.shields.io/github/downloads/Zweih/qp/total?style=for-the-badge&logo=github&label=Downloads%20Since%202%2F4%2F2025&color=1793d1)
 
-![Alt](https://repobeats.axiom.co/api/embed/504d7ad06523d97d04d9fa0c5f694922ec779b96.svg "Repobeats analytics image")
+![Alt](https://repobeats.axiom.co/api/embed/a13406d103a649d70641774ee85e7a9983ccf96b.svg "Repobeats analytics image")
 
 <details open>
 <summary><strong>download and clone statistics</strong></summary>
@@ -37,7 +37,7 @@ this package is compatible with the following distributions:
 
 ## features
 
-- list installed packages with install date/timestamps, dependencies, provisions, reverse dependencies (required by), size on disk, conflicts, replacements, architecture, license, description, build date, package base, package type, validation, packager, groups, and version
+- list installed packages with install date/timestamps, dependencies, provisions, reverse dependencies (required by), size on disk, conflicts, replacements, architecture, license, description, build date, package base, package type, validation, packager, optional dependencies, groups, and version
 - query by explicitly installed packages
 - query by packages installed as dependencies
 - query by packages required by specified packages
@@ -95,7 +95,7 @@ this package is compatible with the following distributions:
 | ✓ | architecture query | ✓ | groups field |
 | ✓	| conflicts query | - | package description sort |
 | ✓	| regenerate cache option | - | groups filter |
-| ✓ | packager field | - | optional dependency field |
+| ✓ | packager field | ✓ | optional dependency field |
 | ✓ | sort by size on disk | - | conflicts sort |
 | ✓ | validation field | - | validation sort |
 
@@ -216,63 +216,77 @@ short-flag queries and long-flag queries can be combined.
 - `groups` - package groups or categories (e.g., base, gnome, xfce4)
 - `conflicts` - list of packages that conflict, or cause problems, with the package
 - `replaces` - list of packages that are replaced by the package
-- `depends` - list of dependencies (output can be long)
-- `required-by` - list of packages required by the package and are dependent (output can be long) 
-- `provides` - list of alternative package names or shared libraries provided by package (output can be long)
+- `depends` - list of dependencies
+- `optdepends` - list of optional dependencies
+- `required-by` - list of packages required by the package and are dependent 
+- `provides` - list of alternative package names or shared libraries provided by package
 
 ### JSON output
 the `--json` flag outputs the package data as structured JSON instead of a table. this can be useful for scripts or automation.
 
 example:
 ```bash
-qp -Aw name=tinysparql --json
+qp -Aw name=util-linux --json
 ```
 
-`tinysparql` is one of the few packages that actually has all the fields populated.
+`util-linux` is one of the few packages that actually has all the fields populated.
 
 output format:
 ```json
 [
   {
-    "installTimestamp": 1743448252,
-    "buildTimestamp": 1742778264,
-    "size": 4446373,
-    "name": "tinysparql",
+    "timestamp": 1741107872,
+    "size": 15514095,
+    "name": "util-linux",
     "reason": "dependency",
-    "version": "3.9.1-1",
-    "pkgtype": "split",
-    "arch": "aarch64",
-    "license": "GPL-2.0-or-later",
-    "pkgbase": "tinysparql",
-    "description": "Low-footprint RDF triple store with SPARQL 1.1 interface",
-    "url": "https://tinysparql.org/",
+    "version": "2.40.4-1",
+    "arch": "x86_64",
+    "license": "LicenseRef-PublicDomain",
+    "pkgbase": "util-linux",
+    "description": "Miscellaneous system utilities for Linux",
+    "url": "https://github.com/util-linux/util-linux",
     "validation": "pgp",
-    "packager": "Fabian Bornschein <fabiscafe@archlinux.org>",
+    "packager": "Christian Hesse <eworm@archlinux.org>",
     "conflicts": [
-      "tracker3<=3.7.3-2"
+      "hardlink",
+      "rfkill"
     ],
     "replaces": [
-      "tracker3<=3.7.3-2"
+      "hardlink",
+      "rfkill"
     ],
     "depends": [
-      "avahi",
-      "gcc-libs",
-      "glib2",
+      "coreutils",
+      "file",
       "glibc",
-      "icu",
-      "json-glib",
-      "libsoup3",
-      "libstemmer",
-      "libxml2",
-      "sqlite"
+      "libcap-ng",
+      "libcrypt.so=2-64 → libxcrypt",
+      "libmagic.so=1-64 → file",
+      "libncursesw.so=6-64 → ncurses",
+      "libsystemd.so=0-64 → systemd-libs",
+      "libudev.so=1-64 → systemd-libs",
+      "libxcrypt",
+      "ncurses",
+      "pam",
+      "readline",
+      "shadow",
+      "systemd-libs",
+      "util-linux-libs=2.41",
+      "zlib"
+    ],
+    "optDepends": [
+      "words (default dictionary for look)"
     ],
     "requiredBy": [
-      "gtk3",
-      "gtk4"
+      "base",
+      "fakeroot",
+      "mkinitcpio",
+      "systemd",
+      "zeromq"
     ],
     "provides": [
-      "libtinysparql-3.0.so=0-64",
-      "tracker3=3.9.1"
+      "hardlink",
+      "rfkill"
     ]
   }
 ]

--- a/README.md
+++ b/README.md
@@ -234,61 +234,77 @@ qp -Aw name=util-linux --json
 output format:
 ```json
 [
-  {
-    "installTimestamp": 1743448252,
-    "buildTimestamp": 1742778264,
-    "size": 15514095,
-    "pkgtype": "split"
-    "name": "util-linux",
+  { 
+    "installTimestamp": 1743448253,
+    "buildTimestamp": 1741400060,
+    "size": 58266727,
+    "pkgtype": "split",
+    "name": "gtk3",
     "reason": "dependency",
-    "version": "2.40.4-1",
-    "arch": "x86_64",
-    "license": "LicenseRef-PublicDomain",
-    "pkgbase": "util-linux",
-    "description": "Miscellaneous system utilities for Linux",
-    "url": "https://github.com/util-linux/util-linux",
+    "version": "1:3.24.49-1",
+    "arch": "aarch64",
+    "license": "LGPL-2.1-or-later",
+    "pkgbase": "gtk3",
+    "description": "GObject-based multi-platform GUI toolkit",
+    "url": "https://www.gtk.org/",
     "validation": "pgp",
-    "packager": "Christian Hesse <eworm@archlinux.org>",
+    "packager": "Jan Alexander Steffens (heftig) <heftig@archlinux.org>",
     "conflicts": [
-      "hardlink",
-      "rfkill"
+      "gtk3-print-backends"
     ],
     "replaces": [
-      "hardlink",
-      "rfkill"
+      "gtk3-print-backends<=3.22.26-1"
     ],
     "depends": [
-      "coreutils",
-      "file",
+      "adwaita-icon-theme",
+      "at-spi2-core",
+      "cairo",
+      "cantarell-fonts",
+      "dconf",
+      "desktop-file-utils",
+      "fontconfig",
+      "fribidi",
+      "gdk-pixbuf2",
+      "glib2",
       "glibc",
-      "libcap-ng",
-      "libcrypt.so=2-64 → libxcrypt",
-      "libmagic.so=1-64 → file",
-      "libncursesw.so=6-64 → ncurses",
-      "libsystemd.so=0-64 → systemd-libs",
-      "libudev.so=1-64 → systemd-libs",
-      "libxcrypt",
-      "ncurses",
-      "pam",
-      "readline",
-      "shadow",
-      "systemd-libs",
-      "util-linux-libs=2.41",
-      "zlib"
+      "gtk-update-icon-cache",
+      "harfbuzz",
+      "iso-codes",
+      "libcloudproviders",
+      "libcolord",
+      "libcups",
+      "libegl → libglvnd",
+      "libepoxy",
+      "libgl → libglvnd",
+      "librsvg",
+      "libx11",
+      "libxcomposite",
+      "libxcursor",
+      "libxdamage",
+      "libxext",
+      "libxfixes",
+      "libxi",
+      "libxinerama",
+      "libxkbcommon",
+      "libxrandr",
+      "libxrender",
+      "pango",
+      "shared-mime-info",
+      "tinysparql",
+      "wayland"
     ],
     "optDepends": [
-      "words (default dictionary for look)"
+      "evince (Default print preview command)"
     ],
     "requiredBy": [
-      "base",
-      "fakeroot",
-      "mkinitcpio",
-      "systemd",
-      "zeromq"
+      "ibus",
+      "libdbusmenu-gtk3"
     ],
     "provides": [
-      "hardlink",
-      "rfkill"
+      "gtk3-print-backends",
+      "libgailutil-3.so=0-64",
+      "libgdk-3.so=0-64",
+      "libgtk-3.so=0-64"
     ]
   }
 ]

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ output format:
   {
     "timestamp": 1741107872,
     "size": 15514095,
+    "pkgtype": "split"
     "name": "util-linux",
     "reason": "dependency",
     "version": "2.40.4-1",

--- a/README.md
+++ b/README.md
@@ -235,7 +235,8 @@ output format:
 ```json
 [
   {
-    "timestamp": 1741107872,
+    "installTimestamp": 1743448252,
+    "buildTimestamp": 1742778264,
     "size": 15514095,
     "pkgtype": "split"
     "name": "util-linux",

--- a/README.md
+++ b/README.md
@@ -226,10 +226,10 @@ the `--json` flag outputs the package data as structured JSON instead of a table
 
 example:
 ```bash
-qp -Aw name=util-linux --json
+qp -Aw name=gtk3 --json
 ```
 
-`util-linux` is one of the few packages that actually has all the fields populated.
+`gtk3` is one of the few packages that actually has all the fields populated.
 
 output format:
 ```json

--- a/internal/config/help.go
+++ b/internal/config/help.go
@@ -71,6 +71,7 @@ func PrintHelp() {
 	fmt.Println("  groups       Package groups or categories (e.g., base, gnome, xfce4)")
 	fmt.Println("  validation   Package integrity validation method (e.g., \"sha256\", \"pgp\")")
 	fmt.Println("  packager     Person/entity who built the package (if available)")
+	fmt.Println("  optdepends   List of optional dependencies")
 
 	fmt.Println("\nExamples:")
 	fmt.Println("  qp -l 10                      # Show the last 10 installed packages")

--- a/internal/consts/fields.go
+++ b/internal/consts/fields.go
@@ -23,6 +23,7 @@ const (
 	FieldBuildDate
 	FieldVersion
 	FieldDepends
+	FieldOptDepends
 	FieldRequiredBy
 	FieldProvides
 	FieldConflicts
@@ -53,6 +54,7 @@ const (
 	conflicts   = "conflicts"
 	replaces    = "replaces"
 	depends     = "depends"
+	optdepends  = "optdepends"
 	requiredBy  = "required-by"
 	provides    = "provides"
 
@@ -92,6 +94,7 @@ var FieldTypeLookup = map[string]FieldType{
 	conflicts:   FieldConflicts,
 	replaces:    FieldReplaces,
 	depends:     FieldDepends,
+	optdepends:  FieldOptDepends,
 	requiredBy:  FieldRequiredBy,
 	provides:    FieldProvides,
 }
@@ -121,6 +124,7 @@ var FieldNameLookup = map[FieldType]string{
 	FieldConflicts:   conflicts,
 	FieldReplaces:    replaces,
 	FieldDepends:     depends,
+	FieldOptDepends:  optdepends,
 	FieldRequiredBy:  requiredBy,
 	FieldProvides:    provides,
 }
@@ -157,6 +161,7 @@ var (
 		FieldConflicts,
 		FieldReplaces,
 		FieldDepends,
+		FieldOptDepends,
 		FieldRequiredBy,
 		FieldProvides,
 	}

--- a/internal/display/formatting.go
+++ b/internal/display/formatting.go
@@ -27,12 +27,19 @@ func flattenRelations(relations []pkgdata.Relation) []string {
 
 	for _, rel := range relationsAtDepth {
 		var virtualFormat string
+		var whyFormat string
+
 		if rel.ProviderName != "" {
-			virtualFormat = fmt.Sprintf(" (provided by %s)", rel.ProviderName)
+			virtualFormat = fmt.Sprintf(" → %s", rel.ProviderName)
+		}
+
+		if rel.Why != "" {
+			whyFormat = fmt.Sprintf(" (%s)", rel.Why)
+			fmt.Println(rel.Why)
 		}
 
 		op := relationOpToString(rel.Operator)
-		relationOutputs = append(relationOutputs, fmt.Sprintf("%s%s%s%s", rel.Name, op, rel.Version, virtualFormat))
+		relationOutputs = append(relationOutputs, fmt.Sprintf("%s%s%s%s%s", rel.Name, op, rel.Version, virtualFormat, whyFormat))
 	}
 
 	return relationOutputs

--- a/internal/display/formatting.go
+++ b/internal/display/formatting.go
@@ -35,7 +35,6 @@ func flattenRelations(relations []pkgdata.Relation) []string {
 
 		if rel.Why != "" {
 			whyFormat = fmt.Sprintf(" (%s)", rel.Why)
-			fmt.Println(rel.Why)
 		}
 
 		op := relationOpToString(rel.Operator)

--- a/internal/display/render_json.go
+++ b/internal/display/render_json.go
@@ -27,6 +27,7 @@ type PkgInfoJson struct {
 	Conflicts        []string `json:"conflicts,omitempty"`
 	Replaces         []string `json:"replaces,omitempty"`
 	Depends          []string `json:"depends,omitempty"`
+	OptDepends       []string `json:"optDepends,omitempty"`
 	RequiredBy       []string `json:"requiredBy,omitempty"`
 	Provides         []string `json:"provides,omitempty"`
 }
@@ -114,6 +115,8 @@ func getJsonValues(pkg *pkgdata.PkgInfo, fields []consts.FieldType) *PkgInfoJson
 			filteredPackage.Replaces = flattenRelations(pkg.Replaces)
 		case consts.FieldDepends:
 			filteredPackage.Depends = flattenRelations(pkg.Depends)
+		case consts.FieldOptDepends:
+			filteredPackage.OptDepends = flattenRelations(pkg.OptDepends)
 		case consts.FieldRequiredBy:
 			filteredPackage.RequiredBy = flattenRelations(pkg.RequiredBy)
 		case consts.FieldProvides:

--- a/internal/display/render_table.go
+++ b/internal/display/render_table.go
@@ -32,6 +32,7 @@ var columnHeaders = map[consts.FieldType]string{
 	consts.FieldConflicts:   "CONFLICTS",
 	consts.FieldReplaces:    "REPLACES",
 	consts.FieldDepends:     "DEPENDS",
+	consts.FieldOptDepends:  "OPT DEPENDS",
 	consts.FieldRequiredBy:  "REQUIRED BY",
 	consts.FieldProvides:    "PROVIDES",
 }
@@ -129,6 +130,9 @@ func getTableValue(pkg *pkgdata.PkgInfo, field consts.FieldType, ctx tableContex
 		return strings.Join(pkg.Groups, ", ")
 	case consts.FieldDepends:
 		return formatRelations(pkg.Depends)
+	case consts.FieldOptDepends:
+		fmt.Println(pkg.OptDepends)
+		return formatRelations(pkg.OptDepends)
 	case consts.FieldRequiredBy:
 		return formatRelations(pkg.RequiredBy)
 	case consts.FieldProvides:

--- a/internal/display/render_table.go
+++ b/internal/display/render_table.go
@@ -131,7 +131,6 @@ func getTableValue(pkg *pkgdata.PkgInfo, field consts.FieldType, ctx tableContex
 	case consts.FieldDepends:
 		return formatRelations(pkg.Depends)
 	case consts.FieldOptDepends:
-		fmt.Println(pkg.OptDepends)
 		return formatRelations(pkg.OptDepends)
 	case consts.FieldRequiredBy:
 		return formatRelations(pkg.RequiredBy)

--- a/internal/pkgdata/cache.go
+++ b/internal/pkgdata/cache.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	cacheVersion    = 11 // bump when updating structure of PkgInfo/Relation/pkginfo.proto OR when dependency resolution is updated
+	cacheVersion    = 12 // bump when updating structure of PkgInfo/Relation/pkginfo.proto OR when dependency resolution is updated
 	xdgCacheHomeEnv = "XDG_CACHE_HOME"
 	homeEnv         = "HOME"
 	qpCacheDir      = "query-packages"
@@ -104,11 +104,12 @@ func relationsToProtos(rels []Relation) []*pb.Relation {
 	pbRels := make([]*pb.Relation, len(rels))
 	for i, rel := range rels {
 		pbRels[i] = &pb.Relation{
-			Name:         rel.Name,
-			Version:      rel.Version,
 			Operator:     pb.RelationOp(rel.Operator),
 			Depth:        rel.Depth,
+			Name:         rel.Name,
+			Version:      rel.Version,
 			ProviderName: rel.ProviderName,
+			Why:          rel.Why,
 		}
 	}
 
@@ -135,6 +136,7 @@ func pkgsToProtos(pkgs []*PkgInfo) []*pb.PkgInfo {
 			Packager:         pkg.Packager,
 			Groups:           pkg.Groups,
 			Depends:          relationsToProtos(pkg.Depends),
+			OptDepends:       relationsToProtos(pkg.OptDepends),
 			RequiredBy:       relationsToProtos(pkg.RequiredBy),
 			Provides:         relationsToProtos(pkg.Provides),
 			Conflicts:        relationsToProtos(pkg.Conflicts),
@@ -149,11 +151,12 @@ func protosToRelations(pbRels []*pb.Relation) []Relation {
 	rels := make([]Relation, len(pbRels))
 	for i, pbRel := range pbRels {
 		rels[i] = Relation{
-			Name:         pbRel.Name,
-			Version:      pbRel.Version,
 			Operator:     RelationOp(pbRel.Operator),
 			Depth:        pbRel.Depth,
+			Name:         pbRel.Name,
+			Version:      pbRel.Version,
 			ProviderName: pbRel.ProviderName,
+			Why:          pbRel.Why,
 		}
 	}
 
@@ -180,6 +183,7 @@ func protosToPkgs(pbPkgs []*pb.PkgInfo) []*PkgInfo {
 			Packager:         pbPkg.Packager,
 			Groups:           pbPkg.Groups,
 			Depends:          protosToRelations(pbPkg.Depends),
+			OptDepends:       protosToRelations(pbPkg.OptDepends),
 			RequiredBy:       protosToRelations(pbPkg.RequiredBy),
 			Provides:         protosToRelations(pbPkg.Provides),
 			Conflicts:        protosToRelations(pbPkg.Conflicts),

--- a/internal/pkgdata/packageinfo.go
+++ b/internal/pkgdata/packageinfo.go
@@ -25,9 +25,10 @@ type Relation struct {
 	Depth    int32
 	Operator RelationOp
 
-	Version      string
 	Name         string
+	Version      string
 	ProviderName string
+	Why          string
 }
 
 type PkgInfo struct {
@@ -51,6 +52,7 @@ type PkgInfo struct {
 	Groups []string
 
 	Depends    []Relation
+	OptDepends []Relation
 	RequiredBy []Relation
 	Provides   []Relation
 	Conflicts  []Relation

--- a/internal/protobuf/pkginfo.pb.go
+++ b/internal/protobuf/pkginfo.pb.go
@@ -143,6 +143,7 @@ type Relation struct {
 	Operator      RelationOp             `protobuf:"varint,3,opt,name=operator,proto3,enum=pkginfo.RelationOp" json:"operator,omitempty"`
 	Depth         int32                  `protobuf:"varint,4,opt,name=depth,proto3" json:"depth,omitempty"`
 	ProviderName  string                 `protobuf:"bytes,5,opt,name=providerName,proto3" json:"providerName,omitempty"`
+	Why           string                 `protobuf:"bytes,6,opt,name=why,proto3" json:"why,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -212,6 +213,13 @@ func (x *Relation) GetProviderName() string {
 	return ""
 }
 
+func (x *Relation) GetWhy() string {
+	if x != nil {
+		return x.Why
+	}
+	return ""
+}
+
 type PkgInfo struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
 	InstallTimestamp int64                  `protobuf:"varint,17,opt,name=install_timestamp,json=installTimestamp,proto3" json:"install_timestamp,omitempty"`
@@ -230,6 +238,7 @@ type PkgInfo struct {
 	Packager         string                 `protobuf:"bytes,21,opt,name=packager,proto3" json:"packager,omitempty"`
 	Groups           []string               `protobuf:"bytes,19,rep,name=groups,proto3" json:"groups,omitempty"`
 	Depends          []*Relation            `protobuf:"bytes,9,rep,name=depends,proto3" json:"depends,omitempty"`
+	OptDepends       []*Relation            `protobuf:"bytes,22,rep,name=opt_depends,json=optDepends,proto3" json:"opt_depends,omitempty"`
 	RequiredBy       []*Relation            `protobuf:"bytes,10,rep,name=required_by,json=requiredBy,proto3" json:"required_by,omitempty"`
 	Provides         []*Relation            `protobuf:"bytes,11,rep,name=provides,proto3" json:"provides,omitempty"`
 	Conflicts        []*Relation            `protobuf:"bytes,12,rep,name=conflicts,proto3" json:"conflicts,omitempty"`
@@ -380,6 +389,13 @@ func (x *PkgInfo) GetDepends() []*Relation {
 	return nil
 }
 
+func (x *PkgInfo) GetOptDepends() []*Relation {
+	if x != nil {
+		return x.OptDepends
+	}
+	return nil
+}
+
 func (x *PkgInfo) GetRequiredBy() []*Relation {
 	if x != nil {
 		return x.RequiredBy
@@ -472,13 +488,14 @@ var File_protobuf_pkginfo_proto protoreflect.FileDescriptor
 
 const file_protobuf_pkginfo_proto_rawDesc = "" +
 	"\n" +
-	"\x16protobuf/pkginfo.proto\x12\apkginfo\"\xa3\x01\n" +
+	"\x16protobuf/pkginfo.proto\x12\apkginfo\"\xb5\x01\n" +
 	"\bRelation\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\tR\aversion\x12/\n" +
 	"\boperator\x18\x03 \x01(\x0e2\x13.pkginfo.RelationOpR\boperator\x12\x14\n" +
 	"\x05depth\x18\x04 \x01(\x05R\x05depth\x12\"\n" +
-	"\fproviderName\x18\x05 \x01(\tR\fproviderName\"\xad\x05\n" +
+	"\fproviderName\x18\x05 \x01(\tR\fproviderName\x12\x10\n" +
+	"\x03why\x18\x06 \x01(\tR\x03why\"\xe1\x05\n" +
 	"\aPkgInfo\x12+\n" +
 	"\x11install_timestamp\x18\x11 \x01(\x03R\x10installTimestamp\x12'\n" +
 	"\x0fbuild_timestamp\x18\x10 \x01(\x03R\x0ebuildTimestamp\x12\x12\n" +
@@ -498,6 +515,8 @@ const file_protobuf_pkginfo_proto_rawDesc = "" +
 	"\bpackager\x18\x15 \x01(\tR\bpackager\x12\x16\n" +
 	"\x06groups\x18\x13 \x03(\tR\x06groups\x12+\n" +
 	"\adepends\x18\t \x03(\v2\x11.pkginfo.RelationR\adepends\x122\n" +
+	"\vopt_depends\x18\x16 \x03(\v2\x11.pkginfo.RelationR\n" +
+	"optDepends\x122\n" +
 	"\vrequired_by\x18\n" +
 	" \x03(\v2\x11.pkginfo.RelationR\n" +
 	"requiredBy\x12-\n" +
@@ -550,16 +569,17 @@ var file_protobuf_pkginfo_proto_depIdxs = []int32{
 	0, // 0: pkginfo.Relation.operator:type_name -> pkginfo.RelationOp
 	1, // 1: pkginfo.PkgInfo.pkg_type:type_name -> pkginfo.PkgType
 	2, // 2: pkginfo.PkgInfo.depends:type_name -> pkginfo.Relation
-	2, // 3: pkginfo.PkgInfo.required_by:type_name -> pkginfo.Relation
-	2, // 4: pkginfo.PkgInfo.provides:type_name -> pkginfo.Relation
-	2, // 5: pkginfo.PkgInfo.conflicts:type_name -> pkginfo.Relation
-	2, // 6: pkginfo.PkgInfo.replaces:type_name -> pkginfo.Relation
-	3, // 7: pkginfo.CachedPkgs.pkgs:type_name -> pkginfo.PkgInfo
-	8, // [8:8] is the sub-list for method output_type
-	8, // [8:8] is the sub-list for method input_type
-	8, // [8:8] is the sub-list for extension type_name
-	8, // [8:8] is the sub-list for extension extendee
-	0, // [0:8] is the sub-list for field type_name
+	2, // 3: pkginfo.PkgInfo.opt_depends:type_name -> pkginfo.Relation
+	2, // 4: pkginfo.PkgInfo.required_by:type_name -> pkginfo.Relation
+	2, // 5: pkginfo.PkgInfo.provides:type_name -> pkginfo.Relation
+	2, // 6: pkginfo.PkgInfo.conflicts:type_name -> pkginfo.Relation
+	2, // 7: pkginfo.PkgInfo.replaces:type_name -> pkginfo.Relation
+	3, // 8: pkginfo.CachedPkgs.pkgs:type_name -> pkginfo.PkgInfo
+	9, // [9:9] is the sub-list for method output_type
+	9, // [9:9] is the sub-list for method input_type
+	9, // [9:9] is the sub-list for extension type_name
+	9, // [9:9] is the sub-list for extension extendee
+	0, // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_protobuf_pkginfo_proto_init() }

--- a/protobuf/pkginfo.proto
+++ b/protobuf/pkginfo.proto
@@ -21,6 +21,7 @@ message Relation {
   RelationOp operator = 3;
   int32 depth = 4;
   string providerName = 5;
+  string why = 6;
 }
 
 enum PkgType {
@@ -51,6 +52,7 @@ message PkgInfo {
   repeated string groups = 19;
 
   repeated Relation depends = 9;
+  repeated Relation opt_depends = 22;
   repeated Relation required_by = 10;
   repeated Relation provides = 11;
   repeated Relation conflicts = 12;


### PR DESCRIPTION
Users can now list the optional dependencies of packages with `qp -s optdepends` or `qp -S optdepends` or `qp -A`.

Example:
```bash
> qp -s name,optdepends
NAME                      OPT DEPENDS                               
libutempter               -
lksctp-tools              -
iperf3                    -
python-lark-parser        python-atomicwrites (for atomic_cache), python-regex (for regex support)
python-fastjsonschema     -
python-poetry-core        -
python-typing_extensions  -
websocat                  -
python-certifi            -
python-jmespath           -
aws-cli                   -
python-docutils           python-myst-parser (to parse input in "Markdown" (CommonMark) format), python-pillow (for some image manipulation operations), python-pygments (for syntax highlighting of code directives and roles)
python-botocore           python-awscrt
python-colorama           -
python-s3transfer         python-awscrt
python-rsa                -
python-pyasn1             -
python-yaml               -
libyaml                   -
qp                        -
```

There will most likely be an option to make the output more terse; not including the dependency reason.

Closes #186 