### PR TITLE
Feature: Fuzzy/Exact querying (fuzzy: =, exact: ==)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,27 +184,29 @@ all queries that take package/library/program names as arguments can also take a
 
 short-flag queries and long-flag queries can be combined.
 
+you can also query for exact terms in each field by using `==` instead of `=` (excluding time and size fields).
+
+`=` will execute a fuzzy, substring match.
+
 #### available queries
 | query type  | syntax | description |
 |-------------|--------|-------------|
-| **license** | `license=<license>` / <br> `license=<license-1>,<license-2>,<etc>` | query by license name (substring match) |
 | **date** | `date=<value>` | query by installation date. supports exact dates, ranges (`YYYY-MM-DD:YYYY-MM-DD`), and open-ended ranges (`YYYY-MM-DD:` or `:YYYY-MM-DD`) |
-| **required by** | `required-by=<package>` / <br> `required-by=<package-1>,<package-2>,<etc>` | query by packages that are required by the specified packages |
-| **depends** | `depends=<package>` / <br> `depends=<package-1>,<package-2>,<etc>` | query by packages that have the specified packages as dependencies |
-| **provides** | `provides=<package>` / <br> `provides=<package-1>,<package-2>,<etc>` | query by package that provide the specified packages/libraries |
-| **conflicts** | `conflicts=<package>` / <br> `conflicts=<package-1,<package-2>,<etc>` | query by packages that conflict with the specified packages |
-| **architecture** | `arch=<architecture>` / <br> `arch=<architecture-1>,<architecture-2>,<etc>` | query by packages that are built for the specified architectures <br> **note**: "any" is a separate architecture category |
-| **name** | `name=<package>` / <br> `name=<package-1>,<package-2>,<etc>` | query by package name (substring match) |
-| **installation reason** | `reason=explicit` / `reason=dependencies` | query packages by installation reason: explicitly installed or installed as a dependency |
 | **size** | `size=<value>` | query by package size on disk. supports exact values (`10MB`), ranges (`10MB:1GB`), and open-ended ranges (`:500KB`, `1GB:`) |
-| **description** | `description=<string>` / <br> `description=<string-1>,<string-2>,<etc>` | query by package description (substring match) |
+| **name** | `name=<package>` / <br> `name=<package-1>,<package-2>,<etc>` | query by package name |
+| **installation reason** | `reason=explicit` / `reason=dependencies` | query packages by installation reason: explicitly installed or installed as a dependency |
+| **architecture** | `arch=<architecture>` / <br> `arch=<architecture-1>,<architecture-2>,<etc>` | query by packages that are built for the specified architectures <br> **note**: "any" is a separate architecture category |
+| **license** | `license=<license>` / <br> `license=<license-1>,<license-2>,<etc>` | query by license name (substring match) |
+| **description** | `description=<string>` / <br> `description=<string-1>,<string-2>,<etc>` | query by package description |
+| **conflicts** | `conflicts=<package>` / <br> `conflicts=<package-1,<package-2>,<etc>` | query by packages that conflict with the specified packages |
+| **depends** | `depends=<package>` / <br> `depends=<package-1>,<package-2>,<etc>` | query by packages that have the specified packages as dependencies |
+| **required by** | `required-by=<package>` / <br> `required-by=<package-1>,<package-2>,<etc>` | query by packages that are required by the specified packages |
+| **provides** | `provides=<package>` / <br> `provides=<package-1>,<package-2>,<etc>` | query by package that provide the specified packages/libraries |
 
 ### available fields for selection
 - `date` - installation date of the package
 - `build-date` - date the package was built
 - `size` - package size on disk
-- `pkgtype` - package type (pkg, split, debug, source, unknown*)
-    - ***note**: older packages may show "unknown" pkgtype if built before pacman introduced XDATA
 - `name` - package name
 - `reason` - installation reason (explicit/dependency)
 - `version` - installed package version
@@ -215,6 +217,8 @@ short-flag queries and long-flag queries can be combined.
 - `url` - the URL of the official site of the software being packaged
 - `validation` - package integrity validation method (e.g., sha256", "pgp")
 - `packager` - person/entity who built the package (if available)
+- `pkgtype` - package type (pkg, split, debug, source, unknown*)
+    - ***note**: older packages may show "unknown" pkgtype if built before pacman introduced XDATA
 - `groups` - package groups or categories (e.g., base, gnome, xfce4)
 - `conflicts` - list of packages that conflict, or cause problems, with the package
 - `replaces` - list of packages that are replaced by the package
@@ -505,6 +509,10 @@ are treated as separate parameters.
 36. sort packages by their package base while showing their names and package bases, in reverse alphabetical order:
    ```bash
    qp -O pkgbase:desc -s name,pkgbase
+   ```
+37. show packages that are exactly named "bash":
+   ```bash
+   qp -w name==bash
    ```
 
 ## license

--- a/internal/config/help.go
+++ b/internal/config/help.go
@@ -14,6 +14,7 @@ func PrintHelp() {
 
 	fmt.Println("\nQuerying Options:")
 	fmt.Println("  -w, --where <field>=<value> Apply queries to refine package listings. Can be used multiple times.")
+	fmt.Println("                              Exact queryies use '==' and fuzzy queries use '='.")
 	fmt.Println("                               Example: --where size=100MB:1GB --where name=firefox")
 
 	fmt.Println("\n  Available queries:")

--- a/internal/config/query_parser.go
+++ b/internal/config/query_parser.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"qp/internal/consts"
+	"strconv"
 	"strings"
 )
 
@@ -69,6 +70,28 @@ func addQuery(
 		subfields = make(SubfieldQueries)
 	}
 
+	value = parseMatchSugar(subfield, subfields, value)
+
 	subfields[subfield] = value
 	queries[field] = subfields
+}
+
+func parseMatchSugar(
+	subfield consts.SubfieldType,
+	subfields SubfieldQueries,
+	value string,
+) string {
+	if subfield != consts.SubfieldTarget || value == "" {
+		return value
+	}
+
+	matchType := consts.MatchFuzzy
+
+	if value[0] == '=' {
+		matchType = consts.MatchExact
+		value = value[1:]
+	}
+
+	subfields[consts.SubfieldMatch] = strconv.Itoa(int(matchType))
+	return value
 }

--- a/internal/consts/fields.go
+++ b/internal/consts/fields.go
@@ -3,6 +3,7 @@ package consts
 type (
 	FieldType    int
 	SubfieldType int32
+	MatchType    int32
 )
 
 // ordered by filter efficiency
@@ -34,6 +35,12 @@ const (
 const (
 	SubfieldDepth SubfieldType = iota
 	SubfieldTarget
+	SubfieldMatch
+)
+
+const (
+	MatchFuzzy MatchType = iota
+	MatchExact
 )
 
 const (
@@ -62,6 +69,7 @@ const (
 
 	target = "target"
 	depth  = "depth"
+	match  = "match"
 )
 
 var FieldTypeLookup = map[string]FieldType{
@@ -106,6 +114,7 @@ var SubfieldTypeLookup = map[string]SubfieldType{
 	"":     SubfieldTarget,
 	target: SubfieldTarget,
 	depth:  SubfieldDepth,
+	match:  SubfieldMatch,
 }
 
 var FieldNameLookup = map[FieldType]string{
@@ -136,6 +145,7 @@ var FieldNameLookup = map[FieldType]string{
 var SubfieldNameLookup = map[SubfieldType]string{
 	SubfieldTarget: target,
 	SubfieldDepth:  depth,
+	SubfieldMatch:  match,
 }
 
 var (

--- a/internal/display/formatting.go
+++ b/internal/display/formatting.go
@@ -37,43 +37,11 @@ func flattenRelations(relations []pkgdata.Relation) []string {
 			whyFormat = fmt.Sprintf(" (%s)", rel.Why)
 		}
 
-		op := relationOpToString(rel.Operator)
+		op := pkgdata.OperatorToString(rel.Operator)
 		relationOutputs = append(relationOutputs, fmt.Sprintf("%s%s%s%s%s", rel.Name, op, rel.Version, virtualFormat, whyFormat))
 	}
 
 	return relationOutputs
-}
-
-func relationOpToString(op pkgdata.RelationOp) string {
-	switch op {
-	case pkgdata.OpEqual:
-		return "="
-	case pkgdata.OpLess:
-		return "<"
-	case pkgdata.OpLessEqual:
-		return "<="
-	case pkgdata.OpGreater:
-		return ">"
-	case pkgdata.OpGreaterEqual:
-		return ">="
-	default:
-		return ""
-	}
-}
-
-func pkgTypeToString(pkgType pkgdata.PkgType) string {
-	switch pkgType {
-	case pkgdata.PkgTypePkg:
-		return "pkg"
-	case pkgdata.PkgTypeSplit:
-		return "split"
-	case pkgdata.PkgTypeSrc:
-		return "src"
-	case pkgdata.PkgTypeDebug:
-		return "debug"
-	default:
-		return ""
-	}
 }
 
 func formatDate(timestamp int64, ctx tableContext) string {

--- a/internal/display/render_json.go
+++ b/internal/display/render_json.go
@@ -87,7 +87,7 @@ func getJsonValues(pkg *pkgdata.PkgInfo, fields []consts.FieldType) *PkgInfoJson
 		case consts.FieldSize:
 			filteredPackage.Size = pkg.GetInt(field)
 		case consts.FieldPkgType:
-			filteredPackage.PkgType = pkgTypeToString(pkgdata.PkgType(pkg.GetInt(field)))
+			filteredPackage.PkgType = pkg.GetString(field)
 		case consts.FieldName:
 			filteredPackage.Name = pkg.GetString(field)
 		case consts.FieldReason:

--- a/internal/display/render_json.go
+++ b/internal/display/render_json.go
@@ -81,49 +81,49 @@ func getJsonValues(pkg *pkgdata.PkgInfo, fields []consts.FieldType) *PkgInfoJson
 	for _, field := range fields {
 		switch field {
 		case consts.FieldDate:
-			filteredPackage.InstallTimestamp = pkg.InstallTimestamp
+			filteredPackage.InstallTimestamp = pkg.GetInt(field)
 		case consts.FieldBuildDate:
-			filteredPackage.BuildTimestamp = pkg.BuildTimestamp
-		case consts.FieldPkgType:
-			filteredPackage.PkgType = pkgTypeToString(pkg.PkgType)
-		case consts.FieldName:
-			filteredPackage.Name = pkg.Name
-		case consts.FieldReason:
-			filteredPackage.Reason = pkg.Reason
+			filteredPackage.BuildTimestamp = pkg.GetInt(field)
 		case consts.FieldSize:
-			filteredPackage.Size = pkg.Size // return in bytes for json
+			filteredPackage.Size = pkg.GetInt(field)
+		case consts.FieldPkgType:
+			filteredPackage.PkgType = pkgTypeToString(pkgdata.PkgType(pkg.GetInt(field)))
+		case consts.FieldName:
+			filteredPackage.Name = pkg.GetString(field)
+		case consts.FieldReason:
+			filteredPackage.Reason = pkg.GetString(field)
 		case consts.FieldVersion:
-			filteredPackage.Version = pkg.Version
+			filteredPackage.Version = pkg.GetString(field)
 		case consts.FieldArch:
-			filteredPackage.Arch = pkg.Arch
+			filteredPackage.Arch = pkg.GetString(field)
 		case consts.FieldLicense:
-			filteredPackage.License = pkg.License
+			filteredPackage.License = pkg.GetString(field)
 		case consts.FieldPkgBase:
-			filteredPackage.PkgBase = pkg.PkgBase
+			filteredPackage.PkgBase = pkg.GetString(field)
 		case consts.FieldDescription:
-			filteredPackage.Description = pkg.Description
+			filteredPackage.Description = pkg.GetString(field)
 		case consts.FieldUrl:
-			filteredPackage.Url = pkg.Url
+			filteredPackage.Url = pkg.GetString(field)
 		case consts.FieldGroups:
 			filteredPackage.Groups = pkg.Groups
 		case consts.FieldValidation:
-			filteredPackage.Validation = pkg.Validation
+			filteredPackage.Validation = pkg.GetString(field)
 		case consts.FieldPackager:
-			filteredPackage.Packager = pkg.Packager
+			filteredPackage.Packager = pkg.GetString(field)
 		case consts.FieldConflicts:
-			filteredPackage.Conflicts = flattenRelations(pkg.Conflicts)
+			filteredPackage.Conflicts = flattenRelations(pkg.GetRelations(field))
 		case consts.FieldReplaces:
-			filteredPackage.Replaces = flattenRelations(pkg.Replaces)
+			filteredPackage.Replaces = flattenRelations(pkg.GetRelations(field))
 		case consts.FieldDepends:
-			filteredPackage.Depends = flattenRelations(pkg.Depends)
+			filteredPackage.Depends = flattenRelations(pkg.GetRelations(field))
 		case consts.FieldOptDepends:
-			filteredPackage.OptDepends = flattenRelations(pkg.OptDepends)
+			filteredPackage.OptDepends = flattenRelations(pkg.GetRelations(field))
 		case consts.FieldRequiredBy:
-			filteredPackage.RequiredBy = flattenRelations(pkg.RequiredBy)
+			filteredPackage.RequiredBy = flattenRelations(pkg.GetRelations(field))
 		case consts.FieldOptionalFor:
-			filteredPackage.OptionalFor = flattenRelations(pkg.OptionalFor)
+			filteredPackage.OptionalFor = flattenRelations(pkg.GetRelations(field))
 		case consts.FieldProvides:
-			filteredPackage.Provides = flattenRelations(pkg.Provides)
+			filteredPackage.Provides = flattenRelations(pkg.GetRelations(field))
 		}
 	}
 

--- a/internal/display/render_table.go
+++ b/internal/display/render_table.go
@@ -103,13 +103,11 @@ func getTableValue(pkg *pkgdata.PkgInfo, field consts.FieldType, ctx tableContex
 		return formatDate(pkg.GetInt(field), ctx)
 	case consts.FieldSize:
 		return formatSize(pkg.GetInt(field))
-	case consts.FieldPkgType:
-		return pkgTypeToString(pkgdata.PkgType(pkg.GetInt(field)))
 
-	case consts.FieldName, consts.FieldArch, consts.FieldLicense,
-		consts.FieldDescription, consts.FieldReason, consts.FieldUrl,
-		consts.FieldValidation, consts.FieldPackager, consts.FieldVersion,
-		consts.FieldPkgBase:
+	case consts.FieldName, consts.FieldReason, consts.FieldVersion,
+		consts.FieldArch, consts.FieldLicense, consts.FieldUrl,
+		consts.FieldDescription, consts.FieldPkgBase, consts.FieldValidation,
+		consts.FieldPackager, consts.FieldPkgType:
 		return pkg.GetString(field)
 
 	case consts.FieldGroups:

--- a/internal/display/render_table.go
+++ b/internal/display/render_table.go
@@ -99,51 +99,28 @@ func renderRows(
 
 func getTableValue(pkg *pkgdata.PkgInfo, field consts.FieldType, ctx tableContext) string {
 	switch field {
-	case consts.FieldDate:
-		return formatDate(pkg.InstallTimestamp, ctx)
-	case consts.FieldBuildDate:
-		return formatDate(pkg.BuildTimestamp, ctx)
+	case consts.FieldDate, consts.FieldBuildDate:
+		return formatDate(pkg.GetInt(field), ctx)
 	case consts.FieldSize:
-		return formatSize(pkg.Size)
+		return formatSize(pkg.GetInt(field))
 	case consts.FieldPkgType:
-		return pkgTypeToString(pkg.PkgType)
-	case consts.FieldName:
-		return pkg.Name
-	case consts.FieldReason:
-		return pkg.Reason
-	case consts.FieldVersion:
-		return pkg.Version
-	case consts.FieldArch:
-		return pkg.Arch
-	case consts.FieldLicense:
-		return pkg.License
-	case consts.FieldPkgBase:
-		return pkg.PkgBase
-	case consts.FieldDescription:
-		return pkg.Description
-	case consts.FieldUrl:
-		return pkg.Url
-	case consts.FieldValidation:
-		return pkg.Validation
-	case consts.FieldPackager:
-		return pkg.Packager
+		return pkgTypeToString(pkgdata.PkgType(pkg.GetInt(field)))
+
+	case consts.FieldName, consts.FieldArch, consts.FieldLicense,
+		consts.FieldDescription, consts.FieldReason, consts.FieldUrl,
+		consts.FieldValidation, consts.FieldPackager, consts.FieldVersion,
+		consts.FieldPkgBase:
+		return pkg.GetString(field)
+
 	case consts.FieldGroups:
 		return strings.Join(pkg.Groups, ", ")
-	case consts.FieldConflicts:
-		return formatRelations(pkg.Conflicts)
-	case consts.FieldReplaces:
-		return formatRelations(pkg.Replaces)
-	case consts.FieldDepends:
-		return formatRelations(pkg.Depends)
-	case consts.FieldOptDepends:
-		return formatRelations(pkg.OptDepends)
-	case consts.FieldRequiredBy:
-		return formatRelations(pkg.RequiredBy)
-	case consts.FieldOptionalFor:
-		return formatRelations(pkg.OptionalFor)
-	case consts.FieldProvides:
-		return formatRelations(pkg.Provides)
-	default:
-		return ""
+
+	case consts.FieldConflicts, consts.FieldReplaces, consts.FieldDepends,
+		consts.FieldOptDepends, consts.FieldRequiredBy, consts.FieldOptionalFor,
+		consts.FieldProvides:
+		relations := pkg.GetRelations(field)
+		return formatRelations(relations)
 	}
+
+	return ""
 }

--- a/internal/pipeline/filtering/builder.go
+++ b/internal/pipeline/filtering/builder.go
@@ -82,7 +82,9 @@ func parseRelationCondition(
 		}
 	}
 
-	return newRelationCondition(field, targetNames, int32(depth))
+	match := stringToMatchType(subfields[consts.SubfieldMatch])
+
+	return newRelationCondition(field, targetNames, int32(depth), match)
 }
 
 func parseStringCondition(
@@ -95,7 +97,9 @@ func parseStringCondition(
 	}
 
 	targets := strings.Split(targetString, ",")
-	return newStringCondition(field, targets)
+	match := stringToMatchType(subfields[consts.SubfieldMatch])
+
+	return newStringCondition(field, targets, match)
 }
 
 func parseReasonCondition(subfields config.SubfieldQueries) (*FilterCondition, error) {
@@ -145,4 +149,10 @@ func parseDateCondition(subfields config.SubfieldQueries) (*FilterCondition, err
 	}
 
 	return newDateCondition(dateFilter), nil
+}
+
+func stringToMatchType(input string) consts.MatchType {
+	parsed, _ := strconv.Atoi(input)
+
+	return consts.MatchType(parsed)
 }

--- a/internal/pkgdata/cache.go
+++ b/internal/pkgdata/cache.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	cacheVersion    = 13 // bump when updating structure of PkgInfo/Relation/pkginfo.proto OR when dependency resolution is updated
+	cacheVersion    = 14 // bump when updating structure of PkgInfo/Relation/pkginfo.proto OR when dependency resolution is updated
 	xdgCacheHomeEnv = "XDG_CACHE_HOME"
 	homeEnv         = "HOME"
 	qpCacheDir      = "query-packages"
@@ -126,7 +126,6 @@ func pkgsToProtos(pkgs []*PkgInfo) []*pb.PkgInfo {
 			Name:             pkg.Name,
 			Reason:           pkg.Reason,
 			Version:          pkg.Version,
-			PkgType:          pb.PkgType(pkg.PkgType),
 			Arch:             pkg.Arch,
 			License:          pkg.License,
 			Url:              pkg.Url,
@@ -134,6 +133,7 @@ func pkgsToProtos(pkgs []*PkgInfo) []*pb.PkgInfo {
 			PkgBase:          pkg.PkgBase,
 			Validation:       pkg.Validation,
 			Packager:         pkg.Packager,
+			PkgType:          pkg.PkgType,
 			Groups:           pkg.Groups,
 			Conflicts:        relationsToProtos(pkg.Conflicts),
 			Replaces:         relationsToProtos(pkg.Replaces),
@@ -174,7 +174,6 @@ func protosToPkgs(pbPkgs []*pb.PkgInfo) []*PkgInfo {
 			Name:             pbPkg.Name,
 			Reason:           pbPkg.Reason,
 			Version:          pbPkg.Version,
-			PkgType:          PkgType(pbPkg.PkgType),
 			Arch:             pbPkg.Arch,
 			License:          pbPkg.License,
 			Url:              pbPkg.Url,
@@ -182,6 +181,7 @@ func protosToPkgs(pbPkgs []*pb.PkgInfo) []*PkgInfo {
 			PkgBase:          pbPkg.PkgBase,
 			Validation:       pbPkg.Validation,
 			Packager:         pbPkg.Packager,
+			PkgType:          pbPkg.PkgType,
 			Groups:           pbPkg.Groups,
 			Conflicts:        protosToRelations(pbPkg.Conflicts),
 			Replaces:         protosToRelations(pbPkg.Replaces),

--- a/internal/pkgdata/fetch.go
+++ b/internal/pkgdata/fetch.go
@@ -302,7 +302,7 @@ func applyXData(pkg *PkgInfo, block []string) {
 
 			switch subfield {
 			case subfieldPkgType:
-				pkg.PkgType = stringToPkgType(value)
+				pkg.PkgType = value
 			}
 		}
 	}
@@ -364,7 +364,7 @@ parseVersion:
 		}
 	}
 
-	operator := stringToOperator(input[opStart:opEnd])
+	operator := StringToOperator(input[opStart:opEnd])
 	var version string
 
 	if opEnd < len(input) {
@@ -376,37 +376,5 @@ parseVersion:
 		Operator: operator,
 		Version:  version,
 		Depth:    depth,
-	}
-}
-
-func stringToPkgType(pkgTypeInput string) PkgType {
-	switch pkgTypeInput {
-	case "pkg":
-		return PkgTypePkg
-	case "split":
-		return PkgTypeSplit
-	case "src":
-		return PkgTypeSrc
-	case "debug":
-		return PkgTypeDebug
-	default:
-		return PkgTypeUnknown
-	}
-}
-
-func stringToOperator(operatorInput string) RelationOp {
-	switch operatorInput {
-	case "=":
-		return OpEqual
-	case "<":
-		return OpLess
-	case "<=":
-		return OpLessEqual
-	case ">":
-		return OpGreater
-	case ">=":
-		return OpGreaterEqual
-	default:
-		return OpNone
 	}
 }

--- a/internal/pkgdata/filters.go
+++ b/internal/pkgdata/filters.go
@@ -19,30 +19,6 @@ type FilterCondition struct {
 	FieldType consts.FieldType
 }
 
-func ExactRelations(relations []Relation, targetNames []string) bool {
-	for _, targetName := range targetNames {
-		for _, relation := range relations {
-			if relation.Name == targetName {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
-func FuzzyRelations(relations []Relation, targetNames []string) bool {
-	for _, targetName := range targetNames {
-		for _, relation := range relations {
-			if strings.Contains(relation.Name, targetName) {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
 func FilterByReason(installReason string, targetReason string) bool {
 	return installReason == targetReason
 }

--- a/internal/pkgdata/filters.go
+++ b/internal/pkgdata/filters.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"qp/internal/consts"
 	"qp/internal/pipeline/meta"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -18,10 +19,22 @@ type FilterCondition struct {
 	FieldType consts.FieldType
 }
 
-func FilterByRelation(relations []Relation, targetNames []string) bool {
+func ExactRelations(relations []Relation, targetNames []string) bool {
 	for _, targetName := range targetNames {
 		for _, relation := range relations {
 			if relation.Name == targetName {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func FuzzyRelations(relations []Relation, targetNames []string) bool {
+	for _, targetName := range targetNames {
+		for _, relation := range relations {
+			if strings.Contains(relation.Name, targetName) {
 				return true
 			}
 		}
@@ -81,7 +94,7 @@ func FilterBySizeRange(pkg *PkgInfo, startSize int64, endSize int64) bool {
 
 func FilterSliceByStrings(pkgStrings []string, targetStrings []string) bool {
 	for _, pkgString := range pkgStrings {
-		if FilterByStrings(pkgString, targetStrings) {
+		if FuzzyStrings(pkgString, targetStrings) {
 			return true
 		}
 	}
@@ -89,7 +102,7 @@ func FilterSliceByStrings(pkgStrings []string, targetStrings []string) bool {
 	return false
 }
 
-func FilterByStrings(pkgString string, targetStrings []string) bool {
+func FuzzyStrings(pkgString string, targetStrings []string) bool {
 	pkgString = strings.ToLower(pkgString)
 
 	for _, targetString := range targetStrings {
@@ -99,6 +112,12 @@ func FilterByStrings(pkgString string, targetStrings []string) bool {
 	}
 
 	return false
+}
+
+func ExactStrings(pkgString string, targetStrings []string) bool {
+	pkgString = strings.ToLower(pkgString)
+
+	return slices.Contains(targetStrings, pkgString)
 }
 
 func FilterPackages(

--- a/internal/pkgdata/packageinfo.go
+++ b/internal/pkgdata/packageinfo.go
@@ -15,16 +15,6 @@ const (
 	OpGreaterEqual
 )
 
-type PkgType int32
-
-const (
-	PkgTypeUnknown PkgType = iota
-	PkgTypePkg
-	PkgTypeSplit
-	PkgTypeSrc
-	PkgTypeDebug
-)
-
 type Relation struct {
 	Depth    int32
 	Operator RelationOp
@@ -40,8 +30,6 @@ type PkgInfo struct {
 	BuildTimestamp   int64
 	Size             int64
 
-	PkgType PkgType
-
 	Name        string
 	Reason      string
 	Version     string
@@ -52,6 +40,7 @@ type PkgInfo struct {
 	Url         string
 	Validation  string
 	Packager    string
+	PkgType     string
 
 	Groups []string
 
@@ -62,6 +51,19 @@ type PkgInfo struct {
 	Provides    []Relation
 	Conflicts   []Relation
 	Replaces    []Relation
+}
+
+func (pkg *PkgInfo) GetInt(field consts.FieldType) int64 {
+	switch field {
+	case consts.FieldDate:
+		return pkg.InstallTimestamp
+	case consts.FieldBuildDate:
+		return pkg.BuildTimestamp
+	case consts.FieldSize:
+		return pkg.Size
+	default:
+		panic("invalid field passed to GetInt")
+	}
 }
 
 func (pkg *PkgInfo) GetString(field consts.FieldType) string {
@@ -86,6 +88,8 @@ func (pkg *PkgInfo) GetString(field consts.FieldType) string {
 		return pkg.Validation
 	case consts.FieldPackager:
 		return pkg.Packager
+	case consts.FieldPkgType:
+		return pkg.PkgType
 	default:
 		panic("invalid field passed to GetString: " + consts.FieldNameLookup[field])
 	}
@@ -112,17 +116,44 @@ func (pkg *PkgInfo) GetRelations(field consts.FieldType) []Relation {
 	}
 }
 
-func (pkg *PkgInfo) GetInt(field consts.FieldType) int64 {
-	switch field {
-	case consts.FieldDate:
-		return pkg.InstallTimestamp
-	case consts.FieldBuildDate:
-		return pkg.BuildTimestamp
-	case consts.FieldSize:
-		return pkg.Size
-	case consts.FieldPkgType:
-		return int64(pkg.PkgType)
+const (
+	equal        = "="
+	less         = "<"
+	greater      = ">"
+	lessEqual    = less + equal
+	greaterEqual = greater + equal
+)
+
+func StringToOperator(operatorInput string) RelationOp {
+	switch operatorInput {
+	case equal:
+		return OpEqual
+	case less:
+		return OpLess
+	case greater:
+		return OpGreater
+	case lessEqual:
+		return OpLessEqual
+	case greaterEqual:
+		return OpGreaterEqual
 	default:
-		panic("invalid field passed to GetInt")
+		return OpNone
+	}
+}
+
+func OperatorToString(op RelationOp) string {
+	switch op {
+	case OpEqual:
+		return equal
+	case OpLess:
+		return less
+	case OpGreater:
+		return greater
+	case OpLessEqual:
+		return lessEqual
+	case OpGreaterEqual:
+		return greaterEqual
+	default:
+		return ""
 	}
 }

--- a/internal/pkgdata/packageinfo.go
+++ b/internal/pkgdata/packageinfo.go
@@ -1,5 +1,9 @@
 package pkgdata
 
+import (
+	"qp/internal/consts"
+)
+
 type RelationOp int32
 
 const (
@@ -43,9 +47,9 @@ type PkgInfo struct {
 	Version     string
 	Arch        string
 	License     string
-	Url         string
-	Description string
 	PkgBase     string
+	Description string
+	Url         string
 	Validation  string
 	Packager    string
 
@@ -58,4 +62,67 @@ type PkgInfo struct {
 	Provides    []Relation
 	Conflicts   []Relation
 	Replaces    []Relation
+}
+
+func (pkg *PkgInfo) GetString(field consts.FieldType) string {
+	switch field {
+	case consts.FieldName:
+		return pkg.Name
+	case consts.FieldReason:
+		return pkg.Reason
+	case consts.FieldVersion:
+		return pkg.Version
+	case consts.FieldArch:
+		return pkg.Arch
+	case consts.FieldLicense:
+		return pkg.License
+	case consts.FieldPkgBase:
+		return pkg.PkgBase
+	case consts.FieldDescription:
+		return pkg.Description
+	case consts.FieldUrl:
+		return pkg.Url
+	case consts.FieldValidation:
+		return pkg.Validation
+	case consts.FieldPackager:
+		return pkg.Packager
+	default:
+		panic("invalid field passed to GetString: " + consts.FieldNameLookup[field])
+	}
+}
+
+func (pkg *PkgInfo) GetRelations(field consts.FieldType) []Relation {
+	switch field {
+	case consts.FieldConflicts:
+		return pkg.Conflicts
+	case consts.FieldReplaces:
+		return pkg.Replaces
+	case consts.FieldDepends:
+		return pkg.Depends
+	case consts.FieldOptDepends:
+		return pkg.OptDepends
+	case consts.FieldRequiredBy:
+		return pkg.RequiredBy
+	case consts.FieldOptionalFor:
+		return pkg.OptionalFor
+	case consts.FieldProvides:
+		return pkg.Provides
+	default:
+		panic("invalid field passed to GetRelations")
+	}
+}
+
+func (pkg *PkgInfo) GetInt(field consts.FieldType) int64 {
+	switch field {
+	case consts.FieldDate:
+		return pkg.InstallTimestamp
+	case consts.FieldBuildDate:
+		return pkg.BuildTimestamp
+	case consts.FieldSize:
+		return pkg.Size
+	case consts.FieldPkgType:
+		return int64(pkg.PkgType)
+	default:
+		panic("invalid field passed to GetInt")
+	}
 }

--- a/internal/protobuf/pkginfo.pb.go
+++ b/internal/protobuf/pkginfo.pb.go
@@ -81,61 +81,6 @@ func (RelationOp) EnumDescriptor() ([]byte, []int) {
 	return file_protobuf_pkginfo_proto_rawDescGZIP(), []int{0}
 }
 
-type PkgType int32
-
-const (
-	PkgType_UNKNOWN PkgType = 0
-	PkgType_PKG     PkgType = 1
-	PkgType_SPLIT   PkgType = 2
-	PkgType_SRC     PkgType = 3
-	PkgType_DEBUG   PkgType = 4
-)
-
-// Enum value maps for PkgType.
-var (
-	PkgType_name = map[int32]string{
-		0: "UNKNOWN",
-		1: "PKG",
-		2: "SPLIT",
-		3: "SRC",
-		4: "DEBUG",
-	}
-	PkgType_value = map[string]int32{
-		"UNKNOWN": 0,
-		"PKG":     1,
-		"SPLIT":   2,
-		"SRC":     3,
-		"DEBUG":   4,
-	}
-)
-
-func (x PkgType) Enum() *PkgType {
-	p := new(PkgType)
-	*p = x
-	return p
-}
-
-func (x PkgType) String() string {
-	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
-}
-
-func (PkgType) Descriptor() protoreflect.EnumDescriptor {
-	return file_protobuf_pkginfo_proto_enumTypes[1].Descriptor()
-}
-
-func (PkgType) Type() protoreflect.EnumType {
-	return &file_protobuf_pkginfo_proto_enumTypes[1]
-}
-
-func (x PkgType) Number() protoreflect.EnumNumber {
-	return protoreflect.EnumNumber(x)
-}
-
-// Deprecated: Use PkgType.Descriptor instead.
-func (PkgType) EnumDescriptor() ([]byte, []int) {
-	return file_protobuf_pkginfo_proto_rawDescGZIP(), []int{1}
-}
-
 type Relation struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -225,7 +170,6 @@ type PkgInfo struct {
 	InstallTimestamp int64                  `protobuf:"varint,17,opt,name=install_timestamp,json=installTimestamp,proto3" json:"install_timestamp,omitempty"`
 	BuildTimestamp   int64                  `protobuf:"varint,16,opt,name=build_timestamp,json=buildTimestamp,proto3" json:"build_timestamp,omitempty"`
 	Size             int64                  `protobuf:"varint,2,opt,name=size,proto3" json:"size,omitempty"`
-	PkgType          PkgType                `protobuf:"varint,18,opt,name=pkg_type,json=pkgType,proto3,enum=pkginfo.PkgType" json:"pkg_type,omitempty"`
 	Name             string                 `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
 	Reason           string                 `protobuf:"bytes,4,opt,name=reason,proto3" json:"reason,omitempty"`
 	Version          string                 `protobuf:"bytes,5,opt,name=version,proto3" json:"version,omitempty"`
@@ -236,6 +180,7 @@ type PkgInfo struct {
 	PkgBase          string                 `protobuf:"bytes,14,opt,name=pkg_base,json=pkgBase,proto3" json:"pkg_base,omitempty"`
 	Validation       string                 `protobuf:"bytes,20,opt,name=validation,proto3" json:"validation,omitempty"`
 	Packager         string                 `protobuf:"bytes,21,opt,name=packager,proto3" json:"packager,omitempty"`
+	PkgType          string                 `protobuf:"bytes,24,opt,name=pkg_type,json=pkgType,proto3" json:"pkg_type,omitempty"`
 	Groups           []string               `protobuf:"bytes,19,rep,name=groups,proto3" json:"groups,omitempty"`
 	Conflicts        []*Relation            `protobuf:"bytes,12,rep,name=conflicts,proto3" json:"conflicts,omitempty"`
 	Replaces         []*Relation            `protobuf:"bytes,15,rep,name=replaces,proto3" json:"replaces,omitempty"`
@@ -297,13 +242,6 @@ func (x *PkgInfo) GetSize() int64 {
 		return x.Size
 	}
 	return 0
-}
-
-func (x *PkgInfo) GetPkgType() PkgType {
-	if x != nil {
-		return x.PkgType
-	}
-	return PkgType_UNKNOWN
 }
 
 func (x *PkgInfo) GetName() string {
@@ -372,6 +310,13 @@ func (x *PkgInfo) GetValidation() string {
 func (x *PkgInfo) GetPackager() string {
 	if x != nil {
 		return x.Packager
+	}
+	return ""
+}
+
+func (x *PkgInfo) GetPkgType() string {
+	if x != nil {
+		return x.PkgType
 	}
 	return ""
 }
@@ -503,12 +448,11 @@ const file_protobuf_pkginfo_proto_rawDesc = "" +
 	"\boperator\x18\x03 \x01(\x0e2\x13.pkginfo.RelationOpR\boperator\x12\x14\n" +
 	"\x05depth\x18\x04 \x01(\x05R\x05depth\x12\"\n" +
 	"\fproviderName\x18\x05 \x01(\tR\fproviderName\x12\x10\n" +
-	"\x03why\x18\x06 \x01(\tR\x03why\"\x97\x06\n" +
+	"\x03why\x18\x06 \x01(\tR\x03why\"\x8b\x06\n" +
 	"\aPkgInfo\x12+\n" +
 	"\x11install_timestamp\x18\x11 \x01(\x03R\x10installTimestamp\x12'\n" +
 	"\x0fbuild_timestamp\x18\x10 \x01(\x03R\x0ebuildTimestamp\x12\x12\n" +
-	"\x04size\x18\x02 \x01(\x03R\x04size\x12+\n" +
-	"\bpkg_type\x18\x12 \x01(\x0e2\x10.pkginfo.PkgTypeR\apkgType\x12\x12\n" +
+	"\x04size\x18\x02 \x01(\x03R\x04size\x12\x12\n" +
 	"\x04name\x18\x03 \x01(\tR\x04name\x12\x16\n" +
 	"\x06reason\x18\x04 \x01(\tR\x06reason\x12\x18\n" +
 	"\aversion\x18\x05 \x01(\tR\aversion\x12\x12\n" +
@@ -520,7 +464,8 @@ const file_protobuf_pkginfo_proto_rawDesc = "" +
 	"\n" +
 	"validation\x18\x14 \x01(\tR\n" +
 	"validation\x12\x1a\n" +
-	"\bpackager\x18\x15 \x01(\tR\bpackager\x12\x16\n" +
+	"\bpackager\x18\x15 \x01(\tR\bpackager\x12\x19\n" +
+	"\bpkg_type\x18\x18 \x01(\tR\apkgType\x12\x16\n" +
 	"\x06groups\x18\x13 \x03(\tR\x06groups\x12/\n" +
 	"\tconflicts\x18\f \x03(\v2\x11.pkginfo.RelationR\tconflicts\x12-\n" +
 	"\breplaces\x18\x0f \x03(\v2\x11.pkginfo.RelationR\breplaces\x12+\n" +
@@ -531,7 +476,7 @@ const file_protobuf_pkginfo_proto_rawDesc = "" +
 	" \x03(\v2\x11.pkginfo.RelationR\n" +
 	"requiredBy\x124\n" +
 	"\foptional_for\x18\x17 \x03(\v2\x11.pkginfo.RelationR\voptionalFor\x12-\n" +
-	"\bprovides\x18\v \x03(\v2\x11.pkginfo.RelationR\bprovidesJ\x04\b\x01\x10\x02\"q\n" +
+	"\bprovides\x18\v \x03(\v2\x11.pkginfo.RelationR\bprovidesJ\x04\b\x01\x10\x02J\x04\b\x12\x10\x13\"q\n" +
 	"\n" +
 	"CachedPkgs\x12#\n" +
 	"\rlast_modified\x18\x01 \x01(\x03R\flastModified\x12$\n" +
@@ -545,13 +490,7 @@ const file_protobuf_pkginfo_proto_rawDesc = "" +
 	"\n" +
 	"LESS_EQUAL\x10\x03\x12\v\n" +
 	"\aGREATER\x10\x04\x12\x11\n" +
-	"\rGREATER_EQUAL\x10\x05*>\n" +
-	"\aPkgType\x12\v\n" +
-	"\aUNKNOWN\x10\x00\x12\a\n" +
-	"\x03PKG\x10\x01\x12\t\n" +
-	"\x05SPLIT\x10\x02\x12\a\n" +
-	"\x03SRC\x10\x03\x12\t\n" +
-	"\x05DEBUG\x10\x04B\x1cZ\x1ainternal/protobuf;protobufb\x06proto3"
+	"\rGREATER_EQUAL\x10\x05B\x1cZ\x1ainternal/protobuf;protobufb\x06proto3"
 
 var (
 	file_protobuf_pkginfo_proto_rawDescOnce sync.Once
@@ -565,31 +504,29 @@ func file_protobuf_pkginfo_proto_rawDescGZIP() []byte {
 	return file_protobuf_pkginfo_proto_rawDescData
 }
 
-var file_protobuf_pkginfo_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_protobuf_pkginfo_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_protobuf_pkginfo_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
 var file_protobuf_pkginfo_proto_goTypes = []any{
 	(RelationOp)(0),    // 0: pkginfo.RelationOp
-	(PkgType)(0),       // 1: pkginfo.PkgType
-	(*Relation)(nil),   // 2: pkginfo.Relation
-	(*PkgInfo)(nil),    // 3: pkginfo.PkgInfo
-	(*CachedPkgs)(nil), // 4: pkginfo.CachedPkgs
+	(*Relation)(nil),   // 1: pkginfo.Relation
+	(*PkgInfo)(nil),    // 2: pkginfo.PkgInfo
+	(*CachedPkgs)(nil), // 3: pkginfo.CachedPkgs
 }
 var file_protobuf_pkginfo_proto_depIdxs = []int32{
-	0,  // 0: pkginfo.Relation.operator:type_name -> pkginfo.RelationOp
-	1,  // 1: pkginfo.PkgInfo.pkg_type:type_name -> pkginfo.PkgType
-	2,  // 2: pkginfo.PkgInfo.conflicts:type_name -> pkginfo.Relation
-	2,  // 3: pkginfo.PkgInfo.replaces:type_name -> pkginfo.Relation
-	2,  // 4: pkginfo.PkgInfo.depends:type_name -> pkginfo.Relation
-	2,  // 5: pkginfo.PkgInfo.opt_depends:type_name -> pkginfo.Relation
-	2,  // 6: pkginfo.PkgInfo.required_by:type_name -> pkginfo.Relation
-	2,  // 7: pkginfo.PkgInfo.optional_for:type_name -> pkginfo.Relation
-	2,  // 8: pkginfo.PkgInfo.provides:type_name -> pkginfo.Relation
-	3,  // 9: pkginfo.CachedPkgs.pkgs:type_name -> pkginfo.PkgInfo
-	10, // [10:10] is the sub-list for method output_type
-	10, // [10:10] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	0, // 0: pkginfo.Relation.operator:type_name -> pkginfo.RelationOp
+	1, // 1: pkginfo.PkgInfo.conflicts:type_name -> pkginfo.Relation
+	1, // 2: pkginfo.PkgInfo.replaces:type_name -> pkginfo.Relation
+	1, // 3: pkginfo.PkgInfo.depends:type_name -> pkginfo.Relation
+	1, // 4: pkginfo.PkgInfo.opt_depends:type_name -> pkginfo.Relation
+	1, // 5: pkginfo.PkgInfo.required_by:type_name -> pkginfo.Relation
+	1, // 6: pkginfo.PkgInfo.optional_for:type_name -> pkginfo.Relation
+	1, // 7: pkginfo.PkgInfo.provides:type_name -> pkginfo.Relation
+	2, // 8: pkginfo.CachedPkgs.pkgs:type_name -> pkginfo.PkgInfo
+	9, // [9:9] is the sub-list for method output_type
+	9, // [9:9] is the sub-list for method input_type
+	9, // [9:9] is the sub-list for extension type_name
+	9, // [9:9] is the sub-list for extension extendee
+	0, // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_protobuf_pkginfo_proto_init() }
@@ -602,7 +539,7 @@ func file_protobuf_pkginfo_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_protobuf_pkginfo_proto_rawDesc), len(file_protobuf_pkginfo_proto_rawDesc)),
-			NumEnums:      2,
+			NumEnums:      1,
 			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/protobuf/pkginfo.proto
+++ b/protobuf/pkginfo.proto
@@ -24,20 +24,11 @@ message Relation {
   string why = 6;
 }
 
-enum PkgType {
-  UNKNOWN = 0;
-  PKG = 1;
-  SPLIT = 2;
-  SRC = 3;
-  DEBUG = 4;
-}
-
 message PkgInfo {
-  reserved 1;
+  reserved 1, 18;
   int64 install_timestamp = 17;
   int64 build_timestamp = 16;
   int64 size = 2;
-  PkgType pkg_type = 18;
   string name = 3;
   string reason = 4;
   string version = 5;
@@ -48,6 +39,7 @@ message PkgInfo {
   string pkg_base = 14;
   string validation = 20;
   string packager = 21;
+  string pkg_type = 24;
 
   repeated string groups = 19;
 

--- a/qp.1
+++ b/qp.1
@@ -1,10 +1,9 @@
 .\" Man page for qp
-.TH qp 1 "April 2025" "qp 4.2.0" "User Commands"
+.TH qp 1 "April 2025" "qp 4.20.0" "User Commands"
 .SH NAME
-qp \- List and query installed packages on Arch-based systems.
+qp \- Query Packages. A CLI utility for querying installed packages.
 .SH SYNOPSIS
-.B qp
-.RI [ \-l | \-\-limit <number> ] [ \-a | \-\-all ] [ \-w <field>=<value> ] [ \-s | \-\-select <list> ] [ \-S | \-\-select-add <list> ] [ \-A | \-\-select-all ] [ \-O | \-\-order <field>:<direction> ] [ \-\-json ] [ \-\-no-headers ] [ \-\-full-timestamp ] [ \-\-no-progress ] [ \-\-no-cache ] [ \-h | \-\-help ]
+.B qp [options]
 
 .SH DESCRIPTION
 .B qp
@@ -27,189 +26,154 @@ The utility provides powerful querying capabilities, including:
 
 .SH OPTIONS
 .TP
-.B \-l, \-\-limit <number>
-Display the specified number of recent packages (default: 20). Ignored if
-.B \-a
-or
-.B \-\-all
-is used.
+.BR \-l " " \fInumber\fR ", " \-\-limit=\fInumber\fR
+Limit the number of recent packages displayed (default: 20).
 .TP
-.B \-a, \-\-all
-Show all installed packages, ignoring
-.B \-l
-/
-.B \-\-limit
+.BR \-a ", " \-\-all
+Show all installed packages, ignoring \-l/--limit.
 .TP
-.B \-w, \-\-where <field>=<value>
-Apply package queries. This option can be used multiple times. Exact query with `==`, substring query with `=`.
-
-.PP
-Supported queries:
-.IP
-.B license=<license-name>
-: Packages that contain the specified license. Supports comma-separated list.
-.IP
-.B date=<YYYY-MM-DD>
-: Packages installed on the specified date.
-.IP
-.B date=YYYY-MM-DD:
-: Packages installed on or after the date.
-.IP
-.B date=:YYYY-MM-DD
-: Packages installed up to the specified date.
-.IP
-.B date=YYYY-MM-DD:YYYY-MM-DD
-: Packages installed within a date range.
-.IP
-.B size=10MB:
-: Packages larger than 10MB.
-.IP
-.B size=:500KB
-: Packages up to 500KB.
-.IP
-.B size=1GB:5GB
-: Packages between 1GB and 5GB.
-.IP
-.B reason=explicit
-: Explicitly installed packages.
-.IP
-.B reason=dependencies
-: Packages installed as dependencies.
-.IP
-.B name=firefox
-: Match package names. Supports comma-separated list.
-.IP
-.B required-by=vlc
-: Packages required by "vlc".
-.IP
-.B depends=glibc
-: Packages that depend on "glibc".
-.IP
-.B provides=awk
-: Packages that provide "awk".
-.IP
-.B conflicts=linuxqq
-: Packages that conflict with "linuxqq".
-.IP
-.B arch=x86_64
-: Packages built for specified architectures. "any" is also valid.
-.IP
-.B description="linux kernel"
-: Packages that contain "linux kernel" in their description.
-
-.PP
-Example:
-.EX
-qp -w reason=explicit -w size=100MB:
-.EE
-
+.BR \-w " " \fIfield=value\fR ", " \-\-where=\fIfield=value\fR
+Apply multiple flexible queries. Can be used multiple times.
+Examples:
+.br
+\fB--where size=10MB:1GB\fR
+.br
+\fB--where date=2024-01-01:\fR
+.br
+\fB--where reason=explicit\fR
+.br
+\fB--where name=firefox\fR
+.br
+\fB--where required-by=vlc\fR
+.br
+\fB--where depends=glibc\fR
+.br
+\fB--where conflicts=sdl2\fR
+.br
+\fB--where arch=x86_64\fR
+.br
+\fB--where license=GPL\fR
+.br
+\fB--where description="linux kernel"\fR
 .TP
-.B \-O, \-\-order <field>:<direction>
-Sort results by the specified field, ascending or descending directions (asc/desc).
-Available fields for sorting.
-.IP
-.B date
-(default): Sort by installation date.
-.IP
-.B name
-: Sort alphabetically by package name.
-.IP
-.B size
-: Sort by size on disk
-.IP
-.B license
-: Sort alphabetically by package license.
-
+.BR \-O " " \fIfield:direction\fR ", " \-\-order=\fIfield:direction\fR
+Sort results. Default is \fBdate:asc\fR.
+Fields: \fIdate\fR, \fIname\fR, \fIsize\fR, \fIlicense\fR, \fIpkgbase\fR.
 .TP
 .B \-\-no-headers
-Omit headers in table output. Useful for scripting.
-
+Omit column headers in output (useful for scripting).
 .TP
-.B \-s, \-\-select <list>
-Specify a comma-separated list of fields to display. Overrides default fields.
-
+.BR \-s " " \fIlist\fR ", " \-\-select=\fIlist\fR
+Comma-separated list of fields to display.
+Cannot be used with \fB--select-all\fR or \fB--select-add\fR.
 .TP
-.B \-S, \-\-select-add <list>
-Add fields to default output or to
-.B \-\-select-all
-
+.BR \-S " " \fIlist\fR ", " \-\-select-add=\fIlist\fR
+Add comma-separated fields to the default selection.
 .TP
-.B \-A, \-\-select-all
+.BR \-A ", " \-\-select-all
 Display all available fields.
-
+.TP
+.B \-\-full-timestamp
+Show full install and build timestamps.
 .TP
 .B \-\-json
-Output results in JSON format. Overrides
-.B \-\-full-timestamp
-
-.PP
-Example:
-.EX
-qp -w name=sqlite --json -s name,version,size
-.EE
-
-.TP
-.B \-\-full-timestamp
-Show full date + time instead of just the date.
-
+Output results in JSON format.
 .TP
 .B \-\-no-progress
-Suppress progress output, even in interactive mode.
-
+Disable the progress bar in non-interactive environments.
 .TP
 .B \-\-no-cache
-Disable cache loading/saving and force fresh package data loading
-
+Disable cache loading/saving and force fresh package data loading.
 .TP
-.B \-h, \-\-help
-Show help information.
+.B \-\-regen-cache
+Force fresh data loading and update the cache.
+.TP
+.BR \-h ", " \-\-help
+Display help information.
+
+.SH QUERYING WITH --where
+The \fB--where\fR or \fB-w\fR option allows complex queries using multiple filters.
+Multiple \fB-w\fR flags can be combined.
+Queries support both substring (\fB=\fR) and exact (\fB==\fR) matches.
+
+Supported query types:
+.TP
+.B date=<value>
+Installation date (exact, range, or open-ended).
+.TP
+.B size=<value>
+Package size (exact, range, or open-ended).
+.TP
+.B name=<package>
+Filter by package name.
+.TP
+.B reason=explicit|dependencies
+Filter by installation reason.
+.TP
+.B arch=<arch>
+Filter by architecture.
+.TP
+.B license=<license>
+Filter by license name.
+.TP
+.B description=<text>
+Filter by package description.
+.TP
+.B conflicts=<package>
+Filter by conflicting packages.
+.TP
+.B depends=<package>
+Filter by dependencies.
+.TP
+.B required-by=<package>
+Filter by dependent packages.
+.TP
+.B provides=<package>
+Filter by provided libraries/packages.
+
+.SH AVAILABLE FIELDS
+Available fields for \fB--select\fR, \fB--select-add\fR, or \fB--select-all\fR:
+.IP
+date, build-date, size, name, reason, version, arch, license, pkgbase,
+description, url, validation, packager, pkgtype, groups, conflicts,
+replaces, depends, optdepends, required-by, optional-for, provides.
+
+.SH JSON OUTPUT
+Use \fB--json\fR to output query results in structured JSON format for scripts.
 
 .SH EXAMPLES
+Display all packages:
+.br
+\fBqp --all\fR
+.PP
+Query packages by size and output JSON:
+.br
+\fBqp -Aw size=10MB:100MB --json\fR
+.PP
+Select specific fields:
+.br
+\fBqp -s name,version,size\fR
+.PP
+Order packages by name:
+.br
+\fBqp --order=name\fR
+.PP
+Complex query:
+.br
+\fBqp -Aw arch=x86_64 depends=glibc --order=size:desc --select name,size\fR
+
+.SH TIPS
 .TP
-Last 10 installed packages:
-.EX
-qp -l 10
-.EE
+Group short flags:
+\fBqp -aw name=yay\fR
 .TP
-All explicitly installed packages:
-.EX
-qp -w reason=explicit
-.EE
+Pipe output for long lists:
+\fBqp -s name,depends | less\fR
 .TP
-Between 100MB–1GB, installed before June 30, 2024:
-.EX
-qp -w size=100MB:1GB -w date=:2024-06-30
-.EE
+Use --flag=value for clarity:
+\fBqp --select=name,size --limit=50\fR
 .TP
-Packages required by "firefox":
-.EX
-qp -w required-by=firefox
-.EE
-.TP
-JSON output:
-.EX
-qp --json
-.EE
-.TP
-Save explicit packages to JSON file:
-.EX
-qp -w reason=explicit --json > explicit-packages.json
-.EE
-.TP
-Show names and sizes without headers:
-.EX
-qp --no-headers -s name,size
-.EE
-.TP
-Packages that depend on "glibc" and are required by "ffmpeg":
-.EX
-qp -w depends=glibc -w required-by=ffmpeg
-.EE
-.TP
-Packages built for "any" architecture:
-.EX
-qp -w arch=any
-.EE
+Use --no-headers in scripts for clean output.
 
 .SH AUTHOR
 Written by Fernando Nunez <me@fernandonunez.io>.

--- a/qp.1
+++ b/qp.1
@@ -41,7 +41,7 @@ Show all installed packages, ignoring
 .B \-\-limit
 .TP
 .B \-w, \-\-where <field>=<value>
-Apply package queries. This option can be used multiple times.
+Apply package queries. This option can be used multiple times. Exact query with `==`, substring query with `=`.
 
 .PP
 Supported queries:


### PR DESCRIPTION
Users can now choose between querying exactly or fuzzily for string and relation fields. 

Fuzzy is the default `=`:
```bash
qp -s name -w name=pacman
NAME
pacman-mirrorlist
pacman-contrib
pacman
```

Exact querying is done with `==`:
```bash
> qp -s name -w name==pacman
NAME
pacman
```

Closes #194 