### PR TITLE
Feature: Fuzzy/Exact range querying

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ this package is compatible with the following distributions:
 | ✓ | validation field | - | validation sort |
 | ✓ | reverse optional dependencies field (optional for) | - | optdepends installation indicator |
 | - | optional-for query | - | separate field for optdepends reason |
+| ✓ | fuzzy/strict querying | - | exclusion querying |
+| - | existence querying | - | depth querying |
 
 ## installation
 
@@ -184,9 +186,17 @@ all queries that take package/library/program names as arguments can also take a
 
 short-flag queries and long-flag queries can be combined.
 
-you can also query for exact terms in each field by using `==` instead of `=` (excluding time and size fields).
+you can also execute strict queries in each field by using `==` instead of `=`.
 
-`=` will execute a fuzzy, substring match.
+`=` will execute a fuzzy match:
+ - strings and relations -> substring match
+ - dates -> approximating by day
+ - sizes -> approximating with a 0.3% tolerance by total bytes
+
+`==` will execute a strict match:
+ - strings and relations -> exact character-by-character match
+ - dates -> exact timestamp match, to the second
+ - sizes -> exact size on disk match, to the byte
 
 #### available queries
 | query type  | syntax | description |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,13 +21,17 @@ type Config struct {
 	RegenCache        bool
 	SortOption        SortOption
 	Fields            []consts.FieldType
-	FieldQueries      FieldQueries
+	FieldQueries      []FieldQuery
 }
 
-type (
-	FieldQueries    map[consts.FieldType]SubfieldQueries
-	SubfieldQueries map[consts.SubfieldType]string
-)
+type FieldQuery struct {
+	IsExistence bool
+	Negate      bool
+	Field       consts.FieldType
+	Match       consts.MatchType
+	Depth       int32
+	Target      string
+}
 
 type SortOption struct {
 	Field consts.FieldType

--- a/internal/config/help.go
+++ b/internal/config/help.go
@@ -14,7 +14,7 @@ func PrintHelp() {
 
 	fmt.Println("\nQuerying Options:")
 	fmt.Println("  -w, --where <field>=<value> Apply queries to refine package listings. Can be used multiple times.")
-	fmt.Println("                              Exact queryies use '==' and fuzzy queries use '='.")
+	fmt.Println("                              Strict queryies use '==' and fuzzy queries use '='.")
 	fmt.Println("                               Example: --where size=100MB:1GB --where name=firefox")
 
 	fmt.Println("\n  Available queries:")

--- a/internal/config/legacy_parser.go
+++ b/internal/config/legacy_parser.go
@@ -1,46 +1,65 @@
 package config
 
-import "qp/internal/consts"
-
-func addLegacyQuery(
-	queries FieldQueries,
-	field consts.FieldType,
-	subfield consts.SubfieldType,
-	value string,
-) {
-	if value == "" {
-		return
-	}
-
-	subfields := queries[field]
-	if subfields == nil {
-		subfields = make(SubfieldQueries)
-	}
-
-	subfields[subfield] = value
-	queries[field] = subfields
-}
+import (
+	"qp/internal/consts"
+)
 
 func convertLegacyQueries(
-	queries FieldQueries,
+	queries []FieldQuery,
 	dateFilter string,
 	nameFilter string,
 	sizeFilter string,
 	requiredByFilter string,
 	explicitOnly bool,
 	dependenciesOnly bool,
-) FieldQueries {
-	addLegacyQuery(queries, consts.FieldDate, consts.SubfieldTarget, dateFilter)
-	addLegacyQuery(queries, consts.FieldName, consts.SubfieldTarget, nameFilter)
-	addLegacyQuery(queries, consts.FieldSize, consts.SubfieldTarget, sizeFilter)
-	addLegacyQuery(queries, consts.FieldRequiredBy, consts.SubfieldTarget, requiredByFilter)
+) []FieldQuery {
+	if dateFilter != "" {
+		queries = append(queries, FieldQuery{
+			Field:  consts.FieldDate,
+			Target: dateFilter,
+			Match:  consts.MatchFuzzy,
+		})
+	}
+
+	if nameFilter != "" {
+		queries = append(queries, FieldQuery{
+			Field:  consts.FieldName,
+			Target: nameFilter,
+			Match:  consts.MatchFuzzy,
+		})
+	}
+
+	if sizeFilter != "" {
+		queries = append(queries, FieldQuery{
+			Field:  consts.FieldSize,
+			Target: sizeFilter,
+			Match:  consts.MatchFuzzy,
+		})
+	}
+
+	if requiredByFilter != "" {
+		queries = append(queries, FieldQuery{
+			Field:  consts.FieldRequiredBy,
+			Target: requiredByFilter,
+			Match:  consts.MatchFuzzy,
+			Depth:  1,
+		})
+	}
 
 	if explicitOnly {
-		addLegacyQuery(queries, consts.FieldReason, consts.SubfieldTarget, ReasonExplicit)
+		queries = append(queries, FieldQuery{
+			Field:  consts.FieldReason,
+			Target: ReasonExplicit,
+			Match:  consts.MatchFuzzy,
+		})
 	}
 
 	if dependenciesOnly {
-		addLegacyQuery(queries, consts.FieldReason, consts.SubfieldTarget, ReasonDependency)
+		queries = append(queries, FieldQuery{
+			Field:  consts.FieldReason,
+			Target: ReasonDependency,
+			Match:  consts.MatchFuzzy,
+		})
 	}
 
 	return queries

--- a/internal/consts/fields.go
+++ b/internal/consts/fields.go
@@ -1,10 +1,6 @@
 package consts
 
-type (
-	FieldType    int
-	SubfieldType int32
-	MatchType    int32
-)
+type FieldType int
 
 // ordered by filter efficiency
 const (
@@ -33,17 +29,6 @@ const (
 )
 
 const (
-	SubfieldDepth SubfieldType = iota
-	SubfieldTarget
-	SubfieldMatch
-)
-
-const (
-	MatchFuzzy MatchType = iota
-	MatchExact
-)
-
-const (
 	date        = "date"
 	buildDate   = "build-date"
 	name        = "name"
@@ -66,10 +51,6 @@ const (
 	requiredBy  = "required-by"
 	optionalFor = "optional-for"
 	provides    = "provides"
-
-	target = "target"
-	depth  = "depth"
-	match  = "match"
 )
 
 var FieldTypeLookup = map[string]FieldType{
@@ -110,13 +91,6 @@ var FieldTypeLookup = map[string]FieldType{
 	provides:    FieldProvides,
 }
 
-var SubfieldTypeLookup = map[string]SubfieldType{
-	"":     SubfieldTarget,
-	target: SubfieldTarget,
-	depth:  SubfieldDepth,
-	match:  SubfieldMatch,
-}
-
 var FieldNameLookup = map[FieldType]string{
 	FieldDate:        date,
 	FieldBuildDate:   buildDate,
@@ -140,12 +114,6 @@ var FieldNameLookup = map[FieldType]string{
 	FieldRequiredBy:  requiredBy,
 	FieldOptionalFor: optionalFor,
 	FieldProvides:    provides,
-}
-
-var SubfieldNameLookup = map[SubfieldType]string{
-	SubfieldTarget: target,
-	SubfieldDepth:  depth,
-	SubfieldMatch:  match,
 }
 
 var (

--- a/internal/consts/matches.go
+++ b/internal/consts/matches.go
@@ -1,0 +1,10 @@
+package consts
+
+type (
+	MatchType int32
+)
+
+const (
+	MatchFuzzy MatchType = iota
+	MatchStrict
+)

--- a/internal/pipeline/filtering/builder.go
+++ b/internal/pipeline/filtering/builder.go
@@ -78,6 +78,10 @@ func parseStringCondition(query config.FieldQuery) (*FilterCondition, error) {
 }
 
 func parseRangeCondition(query config.FieldQuery) (*FilterCondition, error) {
+	if query.IsExistence {
+		return nil, nil
+	}
+
 	var parser func(string) (RangeSelector, error)
 
 	switch query.Field {

--- a/qp.1
+++ b/qp.1
@@ -94,7 +94,7 @@ Display help information.
 .SH QUERYING WITH --where
 The \fB--where\fR or \fB-w\fR option allows complex queries using multiple filters.
 Multiple \fB-w\fR flags can be combined.
-Queries support both substring (\fB=\fR) and exact (\fB==\fR) matches.
+Queries support both substring (\fB=\fR) and strict (\fB==\fR) matches.
 
 Supported query types:
 .TP


### PR DESCRIPTION
Users can now use fuzzy/strict (`=/==`) syntax for range queries. 

Example:
```bash
> qp -w size=4.43MB
DATE        NAME  REASON    SIZE
2025-04-14  qp    explicit  4.43 MB

> qp -w size==4.43MB
DATE        NAME  REASON    SIZE
2025-04-14  qp    explicit  4.43 MB

> qp -w size=4.41MB:4.45MB
DATE        NAME                   REASON      SIZE
2025-03-01  python-prompt_toolkit  dependency  4.40 MB
2025-04-14  qp                     explicit    4.43 MB

> qp -w size==4.41MB:4.45MB
DATE        NAME  REASON    SIZE
2025-04-14  qp    explicit  4.43 MB
```

For sizes: `==` is exact down to the byte, where `=` has a tolerance of 0.4% of the total bytes.

For dates: `==` is exact down to the second, where `=` rounds to the nearest day.

Closes #196 