### PR TITLE
Fix: No package to display in non-interactive mode

### DIFF
--- a/cmd/qp/main.go
+++ b/cmd/qp/main.go
@@ -51,7 +51,10 @@ func mainWithConfig(configProvider config.ConfigProvider) error {
 		}
 
 		if i > 0 && len(pkgPtrs) == 0 { // only start checking once loading/fetching has completed
-			out.WriteLine("No packages to display.")
+			if isInteractive {
+				out.WriteLine("No packages to display.")
+			}
+
 			return nil
 		}
 	}

--- a/internal/pipeline/filtering/builder.go
+++ b/internal/pipeline/filtering/builder.go
@@ -40,6 +40,10 @@ func QueriesToConditions(queries []config.FieldQuery) ([]*FilterCondition, error
 			return []*FilterCondition{}, err
 		}
 
+		if condition == nil {
+			continue
+		}
+
 		conditions = append(conditions, condition)
 	}
 


### PR DESCRIPTION
Issue #197:
> "No packages to display" is nice for user feedback, but in non-interactive modes it can break scripting or make scripting misbehave.
> 
> For example, a user could run `qp -s depends!=python | wc -l` to get the total count of packages packages dependent on a package with "python".
> 
> If there are zero packages that meet that criteria, "No packages to display." will print out. The issue is in that case `wc -l` will return `1` since that output counts a line when it should return `0`.

Now the output only shows in interactive modes.

Closes #197 