### PR TITLE
Feature: Existence querying with has:field and not:field

### DIFF
--- a/internal/config/help.go
+++ b/internal/config/help.go
@@ -14,8 +14,8 @@ func PrintHelp() {
 
 	fmt.Println("\nQuerying Options:")
 	fmt.Println("  -w, --where <field>=<value> Apply queries to refine package listings. Can be used multiple times.")
-	fmt.Println("                              Strict queryies use '==' and fuzzy queries use '='.")
-	fmt.Println("                               Example: --where size=100MB:1GB --where name=firefox")
+	fmt.Println("                              Fuzzy queries use '=' and strict queries use '=='.")
+	fmt.Println("                              Existence queries are also available for all fields and is used with 'has:<field>' and 'not:field'")
 
 	fmt.Println("\n  Available queries:")
 	fmt.Println("    date=<YYYY-MM-DD>               Query packages installed on a specific date")
@@ -78,6 +78,7 @@ func PrintHelp() {
 	fmt.Println("  qp --json                     # Output package data in JSON format")
 	fmt.Println("  qp -w name=sqlite --json      # Output details for SQLite in JSON")
 	fmt.Println("  qp --no-headers -s name,size  # Show package names and sizes without headers")
+	fmt.Println("  qp -a -w not:depends          # Show all packages with no dependencies")
 
 	fmt.Println("\nFor more details, see the manpage: man qp")
 	fmt.Println("Or check the README on the GitHub repo.")

--- a/internal/pipeline/filtering/builder.go
+++ b/internal/pipeline/filtering/builder.go
@@ -25,7 +25,8 @@ func QueriesToConditions(queries []config.FieldQuery) ([]*FilterCondition, error
 		case consts.FieldDate, consts.FieldSize:
 			condition, err = parseRangeCondition(query)
 
-		case consts.FieldName, consts.FieldArch, consts.FieldLicense, consts.FieldReason:
+		case consts.FieldName, consts.FieldReason,
+			consts.FieldArch, consts.FieldLicense, consts.FieldDescription:
 			condition, err = parseStringCondition(query)
 
 		case consts.FieldRequiredBy, consts.FieldDepends,

--- a/internal/pipeline/filtering/builder.go
+++ b/internal/pipeline/filtering/builder.go
@@ -53,7 +53,7 @@ func QueriesToConditions(queries []config.FieldQuery) ([]*FilterCondition, error
 
 func parseRelationCondition(query config.FieldQuery) (*FilterCondition, error) {
 	if query.IsExistence {
-		return nil, nil
+		return newRelationExistsCondition(query.Field, query.Depth, query.Negate)
 	}
 
 	if query.Target == "" {
@@ -66,7 +66,7 @@ func parseRelationCondition(query config.FieldQuery) (*FilterCondition, error) {
 
 func parseStringCondition(query config.FieldQuery) (*FilterCondition, error) {
 	if query.IsExistence {
-		return nil, nil
+		return newStringExistsCondition(query.Field, query.Negate)
 	}
 
 	if query.Target == "" {

--- a/internal/pipeline/filtering/conditions.go
+++ b/internal/pipeline/filtering/conditions.go
@@ -108,6 +108,15 @@ func newStringCondition(
 	return &condition, nil
 }
 
+func newStringExistsCondition(field consts.FieldType, mask bool) (*FilterCondition, error) {
+	condition := newCondition(field)
+	condition.Filter = func(pkg *pkgdata.PkgInfo) bool {
+		return pkgdata.StringExists(pkg.GetString(field)) != mask
+	}
+
+	return &condition, nil
+}
+
 func newRelationCondition(
 	field consts.FieldType,
 	targets []string,
@@ -131,6 +140,21 @@ func newRelationCondition(
 		}
 
 		return mask
+	}
+
+	return &condition, nil
+}
+
+func newRelationExistsCondition(
+	field consts.FieldType,
+	depth int32,
+	mask bool,
+) (*FilterCondition, error) {
+	condition := newCondition(field)
+
+	condition.Filter = func(pkg *pkgdata.PkgInfo) bool {
+		relationsAtDepth := pkgdata.GetRelationsByDepth(pkg.GetRelations(field), depth)
+		return pkgdata.RelationExists(relationsAtDepth) != mask
 	}
 
 	return &condition, nil

--- a/internal/pkgdata/filters.go
+++ b/internal/pkgdata/filters.go
@@ -112,6 +112,14 @@ func StrictStrings(pkgString string, targetStrings []string) bool {
 	return slices.Contains(targetStrings, pkgString)
 }
 
+func RelationExists(relations []Relation) bool {
+	return len(relations) > 0
+}
+
+func StringExists(pkgString string) bool {
+	return pkgString != ""
+}
+
 func FilterPackages(
 	pkgPtrs []*PkgInfo,
 	filterConditions []*FilterCondition,

--- a/qp.1
+++ b/qp.1
@@ -1,5 +1,5 @@
 .\" Man page for qp
-.TH qp 1 "April 2025" "qp 4.20.0" "User Commands"
+.TH qp 1 "April 2025" "qp 4.22.0" "User Commands"
 .SH NAME
 qp \- Query Packages. A CLI utility for querying installed packages.
 .SH SYNOPSIS
@@ -10,18 +10,31 @@ qp \- Query Packages. A CLI utility for querying installed packages.
 is a standalone CLI utility for Arch and Arch-based Linux distributions to list and query installed packages. It works with any package manager that uses ALPM, like pacman and others.
 
 The utility provides powerful querying capabilities, including:
+.BR
 - Installation date queries
+.BR
 - Package size queries
+.BR
 - Install reason queries
+.BR
 - License queries
+.BR
 - Reverse dependency queries (requirements)
+.BR
 - Conflict queries
+.BR
 - Dependency queries
+.BR
 - Provision queries
+.BR
 - Package name queries
+.BR
 - Architecture queries
+.BR
 - Description queries
+.BR
 - Package base queries
+.BR
 - Sorting and JSON output
 
 .SH OPTIONS
@@ -94,7 +107,10 @@ Display help information.
 .SH QUERYING WITH --where
 The \fB--where\fR or \fB-w\fR option allows complex queries using multiple filters.
 Multiple \fB-w\fR flags can be combined.
-Queries support both substring (\fB=\fR) and strict (\fB==\fR) matches.
+.BR
+Queries support both fuzzy (\fB=\fR) and strict (\fB==\fR) matches.
+.BR
+Ranges are queried with \fIfield=value\fR, \fIfield=start-value:\fR, \fIfield=:end-value\fR, or \fIfield=start-value:end-value\fR
 
 Supported query types:
 .TP

--- a/qp.1
+++ b/qp.1
@@ -10,31 +10,33 @@ qp \- Query Packages. A CLI utility for querying installed packages.
 is a standalone CLI utility for Arch and Arch-based Linux distributions to list and query installed packages. It works with any package manager that uses ALPM, like pacman and others.
 
 The utility provides powerful querying capabilities, including:
-.BR
+.br
+- Existence queries
+.br
 - Installation date queries
-.BR
+.br
 - Package size queries
-.BR
+.br
 - Install reason queries
-.BR
+.br
 - License queries
-.BR
+.br
 - Reverse dependency queries (requirements)
-.BR
+.br
 - Conflict queries
-.BR
+.br
 - Dependency queries
-.BR
+.br
 - Provision queries
-.BR
+.br
 - Package name queries
-.BR
+.br
 - Architecture queries
-.BR
+.br
 - Description queries
-.BR
+.br
 - Package base queries
-.BR
+.br
 - Sorting and JSON output
 
 .SH OPTIONS
@@ -45,29 +47,37 @@ Limit the number of recent packages displayed (default: 20).
 .BR \-a ", " \-\-all
 Show all installed packages, ignoring \-l/--limit.
 .TP
-.BR \-w " " \fIfield=value\fR ", " \-\-where=\fIfield=value\fR
-Apply multiple flexible queries. Can be used multiple times.
-Examples:
+.BR \-w " " \fIquery\fR ", " \-\-where=\fIquery\fR
+Apply one or more filters to refine package results.
+
+Supported query types:
+.RS
+.TP
+.B string match
+\fIfield=value\fR -> fuzzy match
 .br
-\fB--where size=10MB:1GB\fR
+\fIfield==value\fR -> strict match
+
+.TP
+.B range match
+\fIfield=start:end\fR -> fuzzy match
 .br
-\fB--where date=2024-01-01:\fR
+\fIfield==start:end\fR -> strict match
 .br
-\fB--where reason=explicit\fR
+Supports full ranges (\fBstart:end\fR), open-ended ranges (\fBstart:\fR or \fB:end\fR), and exact values.
 .br
-\fB--where name=firefox\fR
+Only supported for \fBdate\fR and \fBsize\fR.
+
+.TP
+.B existence check
+\fBhas:field\fR -> field must exist or be non-empty
 .br
-\fB--where required-by=vlc\fR
-.br
-\fB--where depends=glibc\fR
-.br
-\fB--where conflicts=sdl2\fR
-.br
-\fB--where arch=x86_64\fR
-.br
-\fB--where license=GPL\fR
-.br
-\fB--where description="linux kernel"\fR
+\fBnot:field\fR -> field must be missing or empty
+.RE
+
+This flag can be used multiple times and mixed freely.
+
+See below for a list of all available query fields.
 .TP
 .BR \-O " " \fIfield:direction\fR ", " \-\-order=\fIfield:direction\fR
 Sort results. Default is \fBdate:asc\fR.
@@ -105,12 +115,54 @@ Force fresh data loading and update the cache.
 Display help information.
 
 .SH QUERYING WITH --where
-The \fB--where\fR or \fB-w\fR option allows complex queries using multiple filters.
-Multiple \fB-w\fR flags can be combined.
-.BR
-Queries support both fuzzy (\fB=\fR) and strict (\fB==\fR) matches.
-.BR
-Ranges are queried with \fIfield=value\fR, \fIfield=start-value:\fR, \fIfield=:end-value\fR, or \fIfield=start-value:end-value\fR
+The \fB--where\fR or \fB-w\fR option allows complex filtering by package metadata.
+
+You can provide multiple \fB-w\fR flags to combine different filters. Each query must follow one of the supported types:
+
+.TP
+.B string match
+\fIfield=value\fR -> fuzzy match
+.br
+\fIfield==value\fR -> strict match
+.br
+Applies to string fields like \fBname\fR, \fBlicense\fR, \fBdescription\fR, etc.
+
+.TP
+.B range match
+\fIfield=start:end\fR -> fuzzy match
+.br
+\fIfield==start:end\fR -> strict match
+.br
+Supported for fields like \fBdate\fR and \fBsize\fR.
+.br
+Ranges can be:
+.br
+- Full range: \fBstart:end\fR
+.br
+- Open-ended: \fBstart:\fR or \fB:end\fR
+.br
+- Exact: \fBvalue\fR
+
+.TP
+.B existence check
+\fBhas:field\fR -> filter for fields that exist or are non-empty
+
+.PP
+Multiple comma-separated values can be supplied for any query (e.g., \fBname=vim,nano\fR).
+
+.PP
+.B Match Behavior by Field Type:
+
+.TS
+box, tab(:);
+cb cb cb
+l l l.
+Field Type: Fuzzy Match: Strict Match
+_
+Strings & Relations: substring (case-insensitive): exact match (case-insensitive)
+Dates: matches by day (ignores time): exact timestamp (to the second)
+Size: ±0.3% byte tolerance (approximate): exact byte size
+.TE
 
 Supported query types:
 .TP


### PR DESCRIPTION
Users can now query the existence of a field with `has:field` and `not:field`

- `has:field` — field must exist or be non-empty
- `not:field` — field must be missing or empty

Closes #200 