### PR TITLE
Feature: Add pkgbase query

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,20 +225,30 @@ qp -w has:depends             # must have dependencies
 qp -w not:conflicts           # must not conflict with anything
 ```
 
-#### available queries
-| query type  | syntax | description |
-|-------------|--------|-------------|
-| **date** | `date=<value>` | query by installation date. supports exact dates, ranges (`YYYY-MM-DD:YYYY-MM-DD`), and open-ended ranges (`YYYY-MM-DD:` or `:YYYY-MM-DD`) |
-| **size** | `size=<value>` | query by package size on disk. supports exact values (`10MB`), ranges (`10MB:1GB`), and open-ended ranges (`:500KB`, `1GB:`) |
-| **name** | `name=<package>` / <br> `name=<package-1>,<package-2>,<etc>` | query by package name |
-| **installation reason** | `reason=explicit` / `reason=dependencies` | query packages by installation reason: explicitly installed or installed as a dependency |
-| **architecture** | `arch=<architecture>` / <br> `arch=<architecture-1>,<architecture-2>,<etc>` | query by packages that are built for the specified architectures <br> **note**: "any" is a separate architecture category |
-| **license** | `license=<license>` / <br> `license=<license-1>,<license-2>,<etc>` | query by license name (substring match) |
-| **description** | `description=<string>` / <br> `description=<string-1>,<string-2>,<etc>` | query by package description |
-| **conflicts** | `conflicts=<package>` / <br> `conflicts=<package-1,<package-2>,<etc>` | query by packages that conflict with the specified packages |
-| **depends** | `depends=<package>` / <br> `depends=<package-1>,<package-2>,<etc>` | query by packages that have the specified packages as dependencies |
-| **required by** | `required-by=<package>` / <br> `required-by=<package-1>,<package-2>,<etc>` | query by packages that are required by the specified packages |
-| **provides** | `provides=<package>` / <br> `provides=<package-1>,<package-2>,<etc>` | query by package that provide the specified packages/libraries |
+#### query types
+| field type | description|
+|------------|------------|
+|string | matches textual fields. used for fields like name, license, description, etc.|
+|range | matches numerical or time-based fields across a range. supports full ranges (start:end), open-ended ranges (start: / :end), or exact values. used for date and size.|
+|relation | matches fields that contain relationships to other packages (e.g., dependencies, conflicts, provides)|
+
+#### avaialble queries
+| field name | field type |
+|------------|------------|
+| date | range |
+| size | range |
+| name | string |
+| reason | string |
+| arch | string |
+| license | string |
+| pkgbase | string |
+| description | string |
+| url | string |
+| conflicts | relation |
+| replaces | relation |
+| depends | relation |
+| required-by | relation |
+| provides | relation |
 
 ### available fields for selection
 - `date` - installation date of the package

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ this package is compatible with the following distributions:
 | – | name exclusion query | – | streaming pipeline |
 | – | short-args for queries | – | key/value output |
 | – | XML output | – | package description sort |
-| – | package base query | – | required-by sort |
+| ✓ | package base query | – | required-by sort |
 | – | required-by count sort | – | dependency count sort |
 | ✓ | build-date field | - | build-date filter |
 | - | build-date sort | ✓ | pkgtype field |

--- a/internal/config/help.go
+++ b/internal/config/help.go
@@ -34,6 +34,7 @@ func PrintHelp() {
 	fmt.Println("    conflicts=fuse            Query packages that conflict with the specified packages")
 	fmt.Println("    arch=x86_64               Show packages built for the specified architectures. \"any\" is a valid category of architecture.")
 	fmt.Println("    description=x86_64        Query packages by description (substring match)")
+	fmt.Println("    pkgbase                   Query packages by pkgbase")
 
 	fmt.Println("\nSorting Options:")
 	fmt.Println("  -O, --order <type>:<direction> Apply sorting to package output")

--- a/internal/pipeline/filtering/builder.go
+++ b/internal/pipeline/filtering/builder.go
@@ -25,8 +25,8 @@ func QueriesToConditions(queries []config.FieldQuery) ([]*FilterCondition, error
 		case consts.FieldDate, consts.FieldSize:
 			condition, err = parseRangeCondition(query)
 
-		case consts.FieldName, consts.FieldReason,
-			consts.FieldArch, consts.FieldLicense, consts.FieldDescription:
+		case consts.FieldName, consts.FieldReason, consts.FieldArch,
+			consts.FieldLicense, consts.FieldPkgBase, consts.FieldDescription:
 			condition, err = parseStringCondition(query)
 
 		case consts.FieldRequiredBy, consts.FieldDepends,

--- a/qp.1
+++ b/qp.1
@@ -21,7 +21,7 @@ The utility provides powerful querying capabilities, including:
 .br
 - License queries
 .br
-- Reverse dependency queries (requirements)
+- Reverse dependency queries (requirements or required-by)
 .br
 - Conflict queries
 .br
@@ -183,6 +183,9 @@ Filter by architecture.
 .TP
 .B license=<license>
 Filter by license name.
+.TP
+.B pkgbase=<pkgbase>
+Filter by package base.
 .TP
 .B description=<text>
 Filter by package description.


### PR DESCRIPTION
Users can now query by pkgbase with `-w pkgbase=<pkgbase>`

Example:
```bash
> qp -s name,pkgbase -w pkgbase=ttf-nerd-fonts-symbols
NAME                           PKGBASE
ttf-nerd-fonts-symbols-common  ttf-nerd-fonts-symbols
ttf-nerd-fonts-symbols         ttf-nerd-fonts-symbols
```

Closes #206  