### PR TITLE
Documentation: Inject version/date into man page

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,10 +137,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      - name: Inject version and date into man page
+        run: |
+          VERSION="${TAG_NAME#v}"
+          DATE=$(date -u +'%B %Y')
+          sed -e "s/@VERSION@/${VERSION}/g" -e "s/@DATE@/$DATE/g" qp.1 > ./release/qp.1
+
       - name: Package binaries with manpage and NEWS
         run: |
-          cp qp.1 ./release/
-
           for binary in ./release/qp-*; do
             arch=$(basename "$binary" | cut -d'-' -f2)
           
@@ -152,6 +156,7 @@ jobs:
           mkdir -p ./release/temp-qp/qp-${{ env.TAG_NAME }}
           git archive --format=tar HEAD | tar -x -C ./release/temp-qp/qp-${{ env.TAG_NAME }}
           cp ./release/NEWS ./release/temp-qp/qp-${{ env.TAG_NAME }}/
+          cp ./release/qp.1 ./release/temp-qp/qp-${{ env.TAG_NAME }}/qp.1
 
           tar -czf ./release/qp-${{ env.TAG_NAME }}.tar.gz -C ./release/temp-qp qp-${{ env.TAG_NAME }}
 

--- a/qp.1
+++ b/qp.1
@@ -1,5 +1,5 @@
 .\" Man page for qp
-.TH qp 1 "April 2025" "qp 4.22.0" "User Commands"
+.TH qp 1 "@DATE@" "qp @VERSION@" "User Commands"
 .SH NAME
 qp \- Query Packages. A CLI utility for querying installed packages.
 .SH SYNOPSIS


### PR DESCRIPTION
Now we won't have to manually update the manual with version and date info.