### PR TITLE
Feature: Add packager query

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ this package is compatible with the following distributions:
   - package size or size range
   - package names
   - package description
+  - package packager
 - sort by: 
   - installation date
   - package name
@@ -112,7 +113,7 @@ this package is compatible with the following distributions:
 | ✓ | fuzzy/strict querying | - | exclusion querying |
 | ✓ | existence querying | - | depth querying |
 | ✓ | pkgtype query | - | optdepends query |
-| - | packager query | - | origin field |
+| ✓ | packager query | - | origin field |
 | - | origin sort | - | origin query |
 
 ## installation
@@ -258,6 +259,7 @@ qp -w no:conflicts           # must not conflict with anything
 | description | string |
 | url | string |
 | pkgtype | string |
+| packager | string |
 | conflicts | relation |
 | replaces | relation |
 | depends | relation |

--- a/internal/config/help.go
+++ b/internal/config/help.go
@@ -36,6 +36,7 @@ func PrintHelp() {
 	fmt.Println("    description=x86_64        Query packages by description")
 	fmt.Println("    pkgbase=pacman            Query packages by pkgbase")
 	fmt.Println("    pkgtype=split             Query packages by package type")
+	fmt.Println("    packager=archlinux.org    Query packages by packager")
 
 	fmt.Println("\nSorting Options:")
 	fmt.Println("  -O, --order <type>:<direction> Apply sorting to package output")

--- a/internal/config/query_parser.go
+++ b/internal/config/query_parser.go
@@ -29,6 +29,7 @@ func parseQueryInput(input string) (
 	opEnd := -1
 	match := consts.MatchFuzzy
 	negation := false
+	var depth int32 = 1
 
 	for i := range input {
 		if input[i] == ':' {
@@ -64,8 +65,11 @@ func parseQueryInput(input string) (
 		return FieldQuery{}, err
 	}
 
-	rawTarget := strings.TrimSpace(input[opEnd:])
-	target, depth := extractDepth(rawTarget)
+	target := strings.TrimSpace(input[opEnd:])
+
+	if _, exists := consts.RelationFields[field]; exists {
+		target, depth = extractDepth(target)
+	}
 
 	return FieldQuery{
 		Negate: negation,

--- a/internal/consts/fields.go
+++ b/internal/consts/fields.go
@@ -149,3 +149,33 @@ var (
 		FieldProvides,
 	}
 )
+
+var StringFields = map[FieldType]struct{}{
+	FieldPkgType:     {},
+	FieldName:        {},
+	FieldReason:      {},
+	FieldVersion:     {},
+	FieldArch:        {},
+	FieldLicense:     {},
+	FieldPkgBase:     {},
+	FieldDescription: {},
+	FieldUrl:         {},
+	FieldValidation:  {},
+	FieldPackager:    {},
+}
+
+var RelationFields = map[FieldType]struct{}{
+	FieldDepends:     {},
+	FieldOptDepends:  {},
+	FieldRequiredBy:  {},
+	FieldOptionalFor: {},
+	FieldProvides:    {},
+	FieldConflicts:   {},
+	FieldReplaces:    {},
+}
+
+var RangeFields = map[FieldType]struct{}{
+	FieldDate:      {},
+	FieldBuildDate: {},
+	FieldSize:      {},
+}

--- a/internal/pipeline/filtering/builder.go
+++ b/internal/pipeline/filtering/builder.go
@@ -27,7 +27,7 @@ func QueriesToConditions(queries []config.FieldQuery) ([]*FilterCondition, error
 
 		case consts.FieldName, consts.FieldReason, consts.FieldArch,
 			consts.FieldLicense, consts.FieldPkgBase, consts.FieldDescription,
-			consts.FieldPkgType:
+			consts.FieldPkgType, consts.FieldPackager:
 			condition, err = parseStringCondition(query)
 
 		case consts.FieldRequiredBy, consts.FieldDepends,

--- a/qp.1
+++ b/qp.1
@@ -39,6 +39,8 @@ The utility provides powerful querying capabilities, including:
 .br
 - Package type queries
 .br
+- Package packager queries
+.br
 - Sorting and JSON output
 
 .SH OPTIONS
@@ -191,8 +193,12 @@ Filter by package base.
 .TP
 .B description=<text>
 Filter by package description.
-.TP pkgtype=<pkgtype>
+.TP 
+.B pkgtype=<pkgtype>
 Filter by package type.
+.TP
+.B packager=<packager>
+Filter by package packager
 .TP
 .B conflicts=<package>
 Filter by conflicting packages.


### PR DESCRIPTION
Users can now query by packager with `-w packager=<packager>`

Example:
```bash
> qp -w packager=@archlinuxarm.org -s name
NAME                      PACKAGER
libutempter               Arch Linux ARM Build System <builder+seatt
iperf3                    Arch Linux ARM Build System <builder+n1@ar
lksctp-tools              Arch Linux ARM Build System <builder+seatt
python-fastjsonschema     Arch Linux ARM Build System <builder+seattle@archlinuxarm.org>
python-typing_extensions  Arch Linux ARM Build System <builder+seattle@archlinuxarm.org>
python-poetry-core        Arch Linux ARM Build System <builder+seattle@archlinuxarm.org>
python-lark-parser        Arch Linux ARM Build System <builder+seattle@archlinuxarm.org>
websocat                  Arch Linux ARM Build System <builder+n1@archlinuxarm.org>
python-certifi            Arch Linux ARM Build System <builder+seattle@archlinuxarm.org>
python-jmespath           Arch Linux ARM Build System <builder+seattle@archlinuxarm.org>
aws-cli                   Arch Linux ARM Build System <builder+n1@archlinuxarm.org>
python-s3transfer         Arch Linux ARM Build System <builder+n1@archlinuxarm.org>
python-docutils           Arch Linux ARM Build System <builder+seattle@archlinuxarm.org>
python-pyasn1             Arch Linux ARM Build System <builder+seattle@archlinuxarm.org>
python-yaml               Arch Linux ARM Build System <builder+seattle@archlinuxarm.org>
python-colorama           Arch Linux ARM Build System <builder+seattle@archlinuxarm.org>
python-rsa                Arch Linux ARM Build System <builder+seattle@archlinuxarm.org>
python-botocore           Arch Linux ARM Build System <builder+seattle@archlinuxarm.org>
libyaml                   Arch Linux ARM Build System <builder+seattle@archlinuxarm.org>
python-awscrt             Arch Linux ARM Build System <builder+n1@archlinuxarm.org>
```

Closes #215 