### PR TITLE
Feature: Add build date sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ this package is compatible with the following distributions:
 | ✓ | package base query | – | required-by sort |
 | – | required-by count sort | – | dependency count sort |
 | ✓ | build-date field | ✓ | build-date query |
-| - | build-date sort | ✓ | pkgtype field |
+| ✓ | build-date sort | ✓ | pkgtype field |
 | - | url query | - | pkgtype sort |
 | ✓ | architecture query | ✓ | groups field |
 | ✓	| conflicts query | - | package description sort |
@@ -175,6 +175,7 @@ qp [options]
   - [see all available query fields below](#available-queries)
 - `-O <field>:<direction>` | `--order <field>:<direction>`: sort results ascending or descending (default sort is `date:asc`):
   - `date`    -> sort by installation date
+  - `build-date` -> sort by installation date
   - `name`    -> sort alphabetically by package name
   - `size`    -> sort by package size on disk
   - `license` -> sort alphabetically by package license
@@ -182,7 +183,7 @@ qp [options]
 - `--no-headers`: omit column headers in table output (useful for scripting)
 - `-s <list>` | `--select <list>`: comma-separated list of fields to display 
    - cannot use with `--select-all` or `--select-add`
-   - [see fields available for selection](#fields-available-for-selection)
+   - [see fields available for selection](#available-fields-for-selection)
 - `-S <list>` | `--select-add <list>`: comma-separated list of fields to add to defaults or `--select-all`
 - `-A` | `--select-all`: output all available fields (overrides defaults)
 - `--full-timestamp`: display the full timestamp (date and time) of package install/build instead of just the date

--- a/internal/config/help.go
+++ b/internal/config/help.go
@@ -43,6 +43,7 @@ func PrintHelp() {
 	fmt.Println("  -O, --order <type>:<direction> Apply sorting to package output")
 	fmt.Println("                                 Default sort is date:asc")
 	fmt.Println("  --order date                   Sort packages by installation date")
+	fmt.Println("  --order build-date             Sort packages by build date")
 	fmt.Println("  --order name                   Sort packages alphabetically by package name")
 	fmt.Println("  --order size                   Sort packages by size in descending order")
 	fmt.Println("  --order license                Sort packages alphabetically by package license")

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -32,20 +32,13 @@ func makeComparator[T ordered](
 
 func GetComparator(field consts.FieldType, asc bool) (PkgComparator, error) {
 	switch field {
-	case consts.FieldDate:
-		return makeComparator(func(p *PkgInfo) int64 { return p.InstallTimestamp }, asc), nil
+	case consts.FieldDate, consts.FieldBuildDate, consts.FieldSize:
+		return makeComparator(func(p *PkgInfo) int64 { return p.GetInt(field) }, asc), nil
 
-	case consts.FieldSize:
-		return makeComparator(func(p *PkgInfo) int64 { return p.Size }, asc), nil
-
-	case consts.FieldName:
-		return makeComparator(func(p *PkgInfo) string { return strings.ToLower(p.Name) }, asc), nil
-
-	case consts.FieldLicense:
-		return makeComparator(func(p *PkgInfo) string { return strings.ToLower(p.License) }, asc), nil
-
-	case consts.FieldPkgBase:
-		return makeComparator(func(p *PkgInfo) string { return strings.ToLower(p.PkgBase) }, asc), nil
+	case consts.FieldName, consts.FieldLicense, consts.FieldPkgBase:
+		return makeComparator(func(p *PkgInfo) string {
+			return strings.ToLower(p.GetString(field))
+		}, asc), nil
 
 	default:
 		return nil, errors.New("invalid sort field")

--- a/qp.1
+++ b/qp.1
@@ -87,7 +87,7 @@ See below for a list of all available query fields.
 .TP
 .BR \-O " " \fIfield:direction\fR ", " \-\-order=\fIfield:direction\fR
 Sort results. Default is \fBdate:asc\fR.
-Fields: \fIdate\fR, \fIname\fR, \fIsize\fR, \fIlicense\fR, \fIpkgbase\fR.
+Fields: \fIdate\fR, \fIbuild-date\fR, \fIname\fR, \fIsize\fR, \fIlicense\fR, \fIpkgbase\fR.
 .TP
 .B \-\-no-headers
 Omit column headers in output (useful for scripting).


### PR DESCRIPTION
Users can now sort by build date with `qp -O build-date`, `qp -O build-date:asc`, or `qp -O build-date:desc`.

Example:
```bash
> qp -s build-date,date,name -O build-date
BUILD DATE  DATE        NAME
2025-03-31  2025-03-31  kmod
2025-03-31  2025-03-31  util-linux
2025-03-31  2025-03-31  util-linux-libs
2025-03-31  2025-03-31  e2fsprogs
2025-03-31  2025-03-31  iptables
2025-03-31  2025-03-31  pacseek
2025-03-31  2025-03-31  downgrade
2025-03-31  2025-04-02  jansson
2025-04-01  2025-04-02  nss
2025-04-01  2025-04-02  ca-certificates-mozilla
2025-04-01  2025-04-02  libarchive
2025-04-01  2025-04-02  grub
2025-04-01  2025-04-02  libsysprof-capture
2025-04-01  2025-04-07  python-poetry-core
2025-04-01  2025-04-02  expat
2025-04-01  2025-04-02  gdbm
2025-04-01  2025-04-02  sdl3
2025-04-01  2025-04-02  sdl2-compat
2025-04-01  2025-04-02  openresolv
2025-04-18  2025-04-18  qp-git
```

Closes #222