### PR TITLE
Feature: Command based syntax

### DIFF
--- a/cmd/qp/main.go
+++ b/cmd/qp/main.go
@@ -109,8 +109,8 @@ func trimPackagesLen(
 	pkgPtrs []*pkgdata.PkgInfo,
 	cfg *config.Config,
 ) []*pkgdata.PkgInfo {
-	if cfg.Count > 0 && !cfg.AllPackages && len(pkgPtrs) > cfg.Count {
-		cutoffIdx := len(pkgPtrs) - cfg.Count
+	if cfg.Limit > 0 && len(pkgPtrs) > cfg.Limit {
+		cutoffIdx := len(pkgPtrs) - cfg.Limit
 		pkgPtrs = pkgPtrs[cutoffIdx:]
 	}
 

--- a/cmd/qp/main_test.go
+++ b/cmd/qp/main_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"qp/internal/config"
 	"qp/internal/consts"
+	"qp/internal/syntax"
 	"strings"
 	"testing"
 )
@@ -20,8 +21,8 @@ func (m *MockConfigProvider) GetConfig() (*config.Config, error) {
 // TODO: more testing, this is just validating if the depenendency injection works for testing
 func TestMainWithConfig(t *testing.T) {
 	mockCfg := config.Config{
-		Count:      5,
-		SortOption: config.SortOption{Field: consts.FieldSize, Asc: false},
+		Limit:      5,
+		SortOption: syntax.SortOption{Field: consts.FieldSize, Asc: false},
 		OutputJson: true,
 		Fields:     []consts.FieldType{consts.FieldName, consts.FieldSize},
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"qp/internal/consts"
+	"qp/internal/syntax"
 )
 
 const (
@@ -20,23 +21,9 @@ type Config struct {
 	DisableProgress   bool
 	NoCache           bool
 	RegenCache        bool
-	SortOption        SortOption
+	SortOption        syntax.SortOption
 	Fields            []consts.FieldType
-	FieldQueries      []FieldQuery
-}
-
-type FieldQuery struct {
-	IsExistence bool
-	Negate      bool
-	Field       consts.FieldType
-	Match       consts.MatchType
-	Depth       int32
-	Target      string
-}
-
-type SortOption struct {
-	Field consts.FieldType
-	Asc   bool
+	FieldQueries      []syntax.FieldQuery
 }
 
 type ConfigProvider interface {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,8 +11,7 @@ const (
 )
 
 type Config struct {
-	Count             int
-	AllPackages       bool
+	Limit             int
 	ShowHelp          bool
 	ShowVersion       bool
 	OutputJson        bool

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -2,70 +2,28 @@ package config
 
 import (
 	"fmt"
+	"qp/internal/syntax"
+	"strings"
 
 	"github.com/spf13/pflag"
 )
 
 func ParseFlags(args []string) (Config, error) {
-	var count int
-	var allPackages bool
-	var hasAllFields bool
-	var showHelp bool
-	var showVersion bool
-	var outputJson bool
-	var hasNoHeaders bool
-	var showFullTimestamp bool
-	var disableProgress bool
-	var noCache bool
-	var regenCache bool
+	var flagCfg Config
+	var legacyFieldInput, legacyAddFieldInput string
+	var legacySortInput string
+	var legacyFilterInputs []string
 
-	var filterInputs []string
-	var sortInput string
-	var fieldInput string
-	var addFieldInput string
+	var explicitOnly, dependenciesOnly, legacyHasAllFields bool
+	var dateFilter, sizeFilter, nameFilter, requiredByFilter string
 
-	// legacy hidden flags
-	var explicitOnly bool
-	var dependenciesOnly bool
-	var dateFilter string
-	var sizeFilter string
-	var nameFilter string
-	var requiredByFilter string
-
-	pflag.CommandLine.SortFlags = false
-
-	pflag.IntVarP(&count, "limit", "l", 20, "Number of packages to show")
-	pflag.BoolVarP(&allPackages, "all", "a", false, "Show all packages (ignores -l)")
-	pflag.StringArrayVarP(&filterInputs, "where", "w", []string{}, "Query by one or more fields (e.g. -w size=2KB:3KB -w name=vim)")
-	pflag.StringVarP(&sortInput, "order", "O", "date", "Order results by field")
-
-	pflag.BoolVar(&hasNoHeaders, "no-headers", false, "Hide headers for table output (useful for scripts/automation)")
-	pflag.BoolVarP(&hasAllFields, "select-all", "A", false, "Display all available fields")
-	pflag.StringVarP(&fieldInput, "select", "s", "", "Select exact fields to display")
-	pflag.StringVarP(&addFieldInput, "select-add", "S", "", "Add fields to the default output")
-
-	pflag.BoolVar(&showFullTimestamp, "full-timestamp", false, "Show full timestamp instead of just the date")
-	pflag.BoolVar(&outputJson, "json", false, "Output results in JSON format")
-	pflag.BoolVar(&disableProgress, "no-progress", false, "Force suppress progress output")
-	pflag.BoolVar(&noCache, "no-cache", false, "Disable cache loading/saving and force fresh package data loading")
-	pflag.BoolVar(&regenCache, "regen-cache", false, "Disable cache loading, force fresh package data loading, and save fresh cache")
-
-	pflag.BoolVarP(&showHelp, "help", "h", false, "Show help information")
-	pflag.BoolVar(&showVersion, "version", false, "Show version, author, and license information")
-
-	// legacy hidden flags (still functional but hidden)
-	pflag.IntVarP(&count, "number", "n", 20, "Number of packages to show")
-	pflag.StringArrayVarP(&filterInputs, "filter", "f", []string{}, "Apply multiple filters (e.g. --filter size=2KB:3KB --filter name=vim)")
-	pflag.StringVar(&sortInput, "sort", "date", "Sort packages by: 'date', 'alphabetical', 'size:desc', 'size:asc'")
-	pflag.BoolVar(&hasAllFields, "all-columns", false, "Show all available columns/fields in the output (overrides defaults)")
-	pflag.StringVar(&fieldInput, "columns", "", "Comma-separated list of columns to display (overrides defaults)")
-	pflag.StringVar(&addFieldInput, "add-columns", "", "Comma-separated list of columns to add to defaults")
-	pflag.BoolVarP(&explicitOnly, "explicit", "e", false, "Show only explicitly installed packages")
-	pflag.BoolVarP(&dependenciesOnly, "dependencies", "d", false, "Show only packages installed as dependencies")
-	pflag.StringVar(&dateFilter, "date", "", "Filter packages by installation date")
-	pflag.StringVar(&sizeFilter, "size", "", "Filter packages by size")
-	pflag.StringVar(&nameFilter, "name", "", "Filter packages by name")
-	pflag.StringVar(&requiredByFilter, "required-by", "", "Show only packages required by the specified package")
+	registerCommonFlags(&flagCfg)
+	registerLegacyFlags(
+		&flagCfg, &legacyFieldInput, &legacyAddFieldInput,
+		&legacySortInput, &legacyFilterInputs,
+		&explicitOnly, &dependenciesOnly, &legacyHasAllFields,
+		&dateFilter, &sizeFilter, &nameFilter, &requiredByFilter,
+	)
 
 	markHiddenFlags()
 
@@ -73,56 +31,65 @@ func ParseFlags(args []string) (Config, error) {
 		return Config{}, fmt.Errorf("error parsing flags: %v", err)
 	}
 
-	if err := validateFlagCombinations(fieldInput, addFieldInput, hasAllFields, explicitOnly, dependenciesOnly); err != nil {
-		return Config{}, err
+	if flagCfg.AllPackages {
+		flagCfg.Count = 0
 	}
 
-	if allPackages {
-		count = 0
+	remainingArgs := pflag.Args()
+	newSyntaxParser := func() (syntax.ParsedInput, error) {
+		return syntax.ParseSyntax(remainingArgs)
 	}
 
-	fieldsParsed, err := parseSelection(fieldInput, addFieldInput, hasAllFields)
+	parser := newSyntaxParser
+	if !isNewSyntax(args) {
+		if err := validateFlagCombinations(legacyFieldInput, legacyAddFieldInput, legacyHasAllFields, explicitOnly, dependenciesOnly); err != nil {
+			return Config{}, err
+		}
+
+		parser = func() (syntax.ParsedInput, error) {
+			return ParseLegacyConfig(
+				legacyFieldInput,
+				legacyAddFieldInput,
+				legacyHasAllFields,
+				legacySortInput,
+				legacyFilterInputs,
+				dateFilter, nameFilter, sizeFilter, requiredByFilter,
+				explicitOnly, dependenciesOnly,
+			)
+		}
+	}
+
+	parsedInput, err := parser()
 	if err != nil {
 		return Config{}, err
 	}
 
-	sortOption, err := parseSortOption(sortInput)
-	if err != nil {
-		return Config{}, err
+	mergeTopLevelOptions(&flagCfg, &parsedInput)
+	return flagCfg, nil
+}
+
+func isNewSyntax(args []string) bool {
+	for _, arg := range args {
+		lower := strings.ToLower(arg)
+		if expanded, exists := syntax.ShorthandMap[lower]; exists {
+			lower = expanded
+		}
+
+		switch lower {
+		case syntax.CmdSelect, syntax.CmdWhere, syntax.CmdOrder:
+			return true
+		default:
+			return false
+		}
 	}
 
-	fieldQueries, err := parseQueries(filterInputs)
-	if err != nil {
-		return Config{}, err
-	}
+	return false
+}
 
-	fieldQueries = convertLegacyQueries(
-		fieldQueries,
-		dateFilter,
-		nameFilter,
-		sizeFilter,
-		requiredByFilter,
-		explicitOnly,
-		dependenciesOnly,
-	)
-
-	cfg := Config{
-		Count:             count,
-		AllPackages:       allPackages,
-		ShowHelp:          showHelp,
-		ShowVersion:       showVersion,
-		OutputJson:        outputJson,
-		HasNoHeaders:      hasNoHeaders,
-		ShowFullTimestamp: showFullTimestamp,
-		NoCache:           noCache,
-		RegenCache:        regenCache,
-		DisableProgress:   disableProgress,
-		SortOption:        sortOption,
-		Fields:            fieldsParsed,
-		FieldQueries:      fieldQueries,
-	}
-
-	return cfg, nil
+func mergeTopLevelOptions(dst *Config, src *syntax.ParsedInput) {
+	dst.SortOption = src.SortOption
+	dst.Fields = src.Fields
+	dst.FieldQueries = src.FieldQueries
 }
 
 func markHiddenFlags() {
@@ -144,4 +111,50 @@ func markHiddenFlags() {
 	for _, flag := range hiddenFlags {
 		_ = pflag.CommandLine.MarkHidden(flag)
 	}
+}
+
+func registerCommonFlags(cfg *Config) {
+	pflag.IntVarP(&cfg.Count, "limit", "l", 20, "Number of packages to show")
+	pflag.BoolVarP(&cfg.AllPackages, "all", "a", false, "Show all packages")
+	pflag.BoolVar(&cfg.HasNoHeaders, "no-headers", false, "Hide headers")
+	pflag.BoolVar(&cfg.OutputJson, "json", false, "Output in JSON format")
+	pflag.BoolVar(&cfg.ShowHelp, "help", false, "Show help")
+	pflag.BoolVar(&cfg.ShowVersion, "version", false, "Show version")
+	pflag.BoolVar(&cfg.ShowFullTimestamp, "full-timestamp", false, "Show full timestamp")
+	pflag.BoolVar(&cfg.DisableProgress, "no-progress", false, "Disable progress bar")
+	pflag.BoolVar(&cfg.NoCache, "no-cache", false, "Disable cache")
+	pflag.BoolVar(&cfg.RegenCache, "regen-cache", false, "Force fresh cache")
+}
+
+func registerLegacyFlags(
+	cfg *Config,
+	fieldInput *string,
+	addFieldInput *string,
+	sortInput *string,
+	filterInputs *[]string,
+	explicitOnly *bool,
+	dependenciesOnly *bool,
+	hasAllFields *bool,
+	dateFilter, sizeFilter, nameFilter, requiredByFilter *string,
+) {
+	pflag.BoolVarP(hasAllFields, "select-all", "A", false, "Show all fields")
+	pflag.StringVarP(fieldInput, "select", "s", "", "Select fields")
+	pflag.StringVarP(addFieldInput, "select-add", "S", "", "Add to selected fields")
+	pflag.StringVarP(sortInput, "order", "O", "date", "Sort order")
+	pflag.StringArrayVarP(filterInputs, "where", "w", []string{}, "Filter")
+
+	// hidden legacy flags
+	pflag.IntVarP(&cfg.Count, "number", "n", 20, "")
+	pflag.StringVar(fieldInput, "columns", "", "")
+	pflag.StringVar(addFieldInput, "add-columns", "", "")
+	pflag.BoolVar(hasAllFields, "all-columns", false, "")
+	pflag.StringArrayVarP(filterInputs, "filter", "f", []string{}, "")
+	pflag.StringVar(sortInput, "sort", "date", "")
+
+	pflag.BoolVarP(explicitOnly, "explicit", "e", false, "")
+	pflag.BoolVarP(dependenciesOnly, "dependencies", "d", false, "")
+	pflag.StringVar(dateFilter, "date", "", "")
+	pflag.StringVar(sizeFilter, "size", "", "")
+	pflag.StringVar(nameFilter, "name", "", "")
+	pflag.StringVar(requiredByFilter, "required-by", "", "")
 }

--- a/internal/config/legacy_parser.go
+++ b/internal/config/legacy_parser.go
@@ -11,7 +11,8 @@ func ParseLegacyConfig(
 	sortInput string,
 	filterInputs []string,
 	dateFilter, nameFilter, sizeFilter, requiredByFilter string,
-	explicitOnly, dependenciesOnly bool,
+	explicitOnly, dependenciesOnly, allPackages bool,
+	count int,
 ) (syntax.ParsedInput, error) {
 	fields, err := parseSelection(fieldInput, addFieldInput, allFields)
 	if err != nil {
@@ -28,6 +29,10 @@ func ParseLegacyConfig(
 		return syntax.ParsedInput{}, err
 	}
 
+	if allPackages {
+		count = 0
+	}
+
 	queries = convertLegacyQueries(
 		queries,
 		dateFilter,
@@ -42,6 +47,7 @@ func ParseLegacyConfig(
 		Fields:       fields,
 		FieldQueries: queries,
 		SortOption:   sortOpt,
+		Limit:        count,
 	}, nil
 }
 

--- a/internal/pipeline/filtering/builder.go
+++ b/internal/pipeline/filtering/builder.go
@@ -2,9 +2,9 @@ package filtering
 
 import (
 	"fmt"
-	"qp/internal/config"
 	"qp/internal/consts"
 	"qp/internal/pkgdata"
+	"qp/internal/syntax"
 	"sort"
 	"strings"
 )
@@ -14,7 +14,7 @@ type (
 	FilterCondition = pkgdata.FilterCondition
 )
 
-func QueriesToConditions(queries []config.FieldQuery) ([]*FilterCondition, error) {
+func QueriesToConditions(queries []syntax.FieldQuery) ([]*FilterCondition, error) {
 	conditions := make([]*FilterCondition, 0, len(queries))
 
 	for _, query := range queries {
@@ -57,7 +57,7 @@ func QueriesToConditions(queries []config.FieldQuery) ([]*FilterCondition, error
 	return conditions, nil
 }
 
-func parseRelationCondition(query config.FieldQuery) (*FilterCondition, error) {
+func parseRelationCondition(query syntax.FieldQuery) (*FilterCondition, error) {
 	if query.IsExistence {
 		return newRelationExistsCondition(query.Field, query.Depth, query.Negate)
 	}
@@ -70,7 +70,7 @@ func parseRelationCondition(query config.FieldQuery) (*FilterCondition, error) {
 	return newRelationCondition(query.Field, targets, query.Depth, query.Match, query.Negate)
 }
 
-func parseStringCondition(query config.FieldQuery) (*FilterCondition, error) {
+func parseStringCondition(query syntax.FieldQuery) (*FilterCondition, error) {
 	if query.IsExistence {
 		return newStringExistsCondition(query.Field, query.Negate)
 	}
@@ -83,7 +83,7 @@ func parseStringCondition(query config.FieldQuery) (*FilterCondition, error) {
 	return newStringCondition(query.Field, targets, query.Match, query.Negate)
 }
 
-func parseRangeCondition(query config.FieldQuery) (*FilterCondition, error) {
+func parseRangeCondition(query syntax.FieldQuery) (*FilterCondition, error) {
 	if query.IsExistence {
 		return nil, nil
 	}

--- a/internal/pipeline/filtering/conditions.go
+++ b/internal/pipeline/filtering/conditions.go
@@ -2,9 +2,9 @@ package filtering
 
 import (
 	"fmt"
-	"qp/internal/config"
 	"qp/internal/consts"
 	"qp/internal/pkgdata"
+	"qp/internal/syntax"
 	"strings"
 )
 
@@ -94,7 +94,7 @@ func newRelationExistsCondition(
 }
 
 func newRangeCondition(
-	query config.FieldQuery,
+	query syntax.FieldQuery,
 	selector RangeSelector,
 ) (*FilterCondition, error) {
 	matchersByField, ok := RangeMatchers[query.Field]

--- a/internal/syntax/explain.go
+++ b/internal/syntax/explain.go
@@ -1,0 +1,1 @@
+package syntax

--- a/internal/syntax/macro_engine.go
+++ b/internal/syntax/macro_engine.go
@@ -1,0 +1,56 @@
+package syntax
+
+import (
+	"qp/internal/consts"
+	"strings"
+)
+
+type MacroExpander func(token string) ([]string, bool)
+
+var macroRegistry = map[CmdType][]MacroExpander{
+	BlockSelect: {expandSelectMacro},
+	BlockWhere:  {expandWhereMacro},
+	BlockOrder:  {},
+}
+
+func macroExpansion(token string, cmd CmdType) ([]string, bool) {
+	expanders := macroRegistry[cmd]
+	for _, expander := range expanders {
+		if replacement, exists := expander(token); exists {
+			return replacement, true
+		}
+	}
+
+	return []string{token}, false
+}
+
+func expandSelectMacro(token string) ([]string, bool) {
+	switch strings.ToLower(token) {
+	case "default":
+		return fieldTypesToNames(consts.DefaultFields), true
+	case "all":
+		return fieldTypesToNames(consts.ValidFields), true
+	default:
+		return nil, false
+	}
+}
+
+func fieldTypesToNames(fields []consts.FieldType) []string {
+	fieldNames := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if fieldName, ok := consts.FieldNameLookup[field]; ok {
+			fieldNames = append(fieldNames, fieldName)
+		}
+	}
+
+	return fieldNames
+}
+
+func expandWhereMacro(token string) ([]string, bool) {
+	switch strings.ToLower(token) {
+	case "orphan":
+		return []string{"not:required-by", "reason=dependency"}, true
+	default:
+		return nil, false
+	}
+}

--- a/internal/syntax/macro_engine.go
+++ b/internal/syntax/macro_engine.go
@@ -11,12 +11,13 @@ var macroRegistry = map[CmdType][]MacroExpander{
 	BlockSelect: {expandSelectMacro},
 	BlockWhere:  {expandWhereMacro},
 	BlockOrder:  {},
+	BlockLimit:  {expandLimitMacro},
 }
 
 func macroExpansion(token string, cmd CmdType) ([]string, bool) {
 	expanders := macroRegistry[cmd]
 	for _, expander := range expanders {
-		if replacement, exists := expander(token); exists {
+		if replacement, exists := expander(strings.ToLower(token)); exists {
 			return replacement, true
 		}
 	}
@@ -25,7 +26,7 @@ func macroExpansion(token string, cmd CmdType) ([]string, bool) {
 }
 
 func expandSelectMacro(token string) ([]string, bool) {
-	switch strings.ToLower(token) {
+	switch token {
 	case "default":
 		return fieldTypesToNames(consts.DefaultFields), true
 	case "all":
@@ -47,9 +48,18 @@ func fieldTypesToNames(fields []consts.FieldType) []string {
 }
 
 func expandWhereMacro(token string) ([]string, bool) {
-	switch strings.ToLower(token) {
+	switch token {
 	case "orphan":
 		return []string{"not:required-by", "reason=dependency"}, true
+	default:
+		return nil, false
+	}
+}
+
+func expandLimitMacro(token string) ([]string, bool) {
+	switch token {
+	case "all":
+		return []string{"0"}, true
 	default:
 		return nil, false
 	}

--- a/internal/syntax/preprocessor.go
+++ b/internal/syntax/preprocessor.go
@@ -1,0 +1,44 @@
+package syntax
+
+import "fmt"
+
+func Preprocess(args []string) ([]string, error) {
+	args = ExpandShortSyntax(args)
+
+	var processed []string
+	currentBlock := BlockNone
+
+	for _, token := range args {
+		if block := lookupCommand(token); block != BlockNone {
+			currentBlock = block
+			processed = append(processed, token)
+			continue
+		}
+
+		if currentBlock == BlockNone {
+			return nil, fmt.Errorf("unexpected token: %q (expected in a command block like 'select', 'where', or 'order')", token)
+		}
+
+		expanded, _ := macroExpansion(token, currentBlock)
+		if len(expanded) == 0 {
+			return nil, fmt.Errorf("macro expansion for %q in block %q produced no output", token, cmdTypeName(currentBlock))
+		}
+
+		processed = append(processed, expanded...)
+	}
+
+	return processed, nil
+}
+
+func cmdTypeName(cmd CmdType) string {
+	switch cmd {
+	case BlockSelect:
+		return CmdSelect
+	case BlockWhere:
+		return CmdWhere
+	case BlockOrder:
+		return CmdOrder
+	}
+
+	return "[INVALID BLOCK COMMAND]"
+}

--- a/internal/syntax/query_parser.go
+++ b/internal/syntax/query_parser.go
@@ -1,4 +1,4 @@
-package config
+package syntax
 
 import (
 	"fmt"
@@ -7,7 +7,16 @@ import (
 	"strings"
 )
 
-func parseQueries(queryInputs []string) ([]FieldQuery, error) {
+type FieldQuery struct {
+	IsExistence bool
+	Negate      bool
+	Field       consts.FieldType
+	Match       consts.MatchType
+	Depth       int32
+	Target      string
+}
+
+func ParseQueries(queryInputs []string) ([]FieldQuery, error) {
 	queries := make([]FieldQuery, 0, len(queryInputs))
 
 	for _, input := range queryInputs {
@@ -86,7 +95,7 @@ func parseExistenceQuery(input string, colonIdx int) (FieldQuery, error) {
 
 	switch prefix {
 	case "has":
-	case "no", "not":
+	case "no", "not": // TODO: "not" is legacy, to deprecate
 		negation = true
 	default:
 		return FieldQuery{}, fmt.Errorf("invalid existence query: %s", input)

--- a/internal/syntax/query_parser.go
+++ b/internal/syntax/query_parser.go
@@ -16,6 +16,46 @@ type FieldQuery struct {
 	Target      string
 }
 
+// TODO: stopgap before logic is fleshed out
+func ParseQueriesBlock(tokens []string) ([]FieldQuery, error) {
+	var queries []FieldQuery
+	expectQuery := true
+
+	for i, token := range tokens {
+		token = strings.TrimSpace(token)
+		if token == "" {
+			continue
+		}
+
+		if strings.ToLower(token) == "and" {
+			if expectQuery {
+				return nil, fmt.Errorf("unexpected 'and' at position %d", i)
+			}
+
+			expectQuery = true
+			continue
+		}
+
+		if !expectQuery {
+			return nil, fmt.Errorf("missing 'and' between queries near: %q", token)
+		}
+
+		query, err := parseQueryInput(token)
+		if err != nil {
+			return nil, err
+		}
+
+		queries = append(queries, query)
+		expectQuery = false
+	}
+
+	if expectQuery && len(tokens) > 0 {
+		return nil, fmt.Errorf("trailing 'and' with no following condition")
+	}
+
+	return queries, nil
+}
+
 func ParseQueries(queryInputs []string) ([]FieldQuery, error) {
 	queries := make([]FieldQuery, 0, len(queryInputs))
 

--- a/internal/syntax/shorthand.go
+++ b/internal/syntax/shorthand.go
@@ -6,6 +6,7 @@ var ShorthandMap = map[string]string{
 	"s": CmdSelect,
 	"w": CmdWhere,
 	"o": CmdOrder,
+	"l": CmdLimit,
 }
 
 func ExpandShortSyntax(args []string) []string {

--- a/internal/syntax/shorthand.go
+++ b/internal/syntax/shorthand.go
@@ -1,0 +1,24 @@
+package syntax
+
+import "strings"
+
+var ShorthandMap = map[string]string{
+	"s": CmdSelect,
+	"w": CmdWhere,
+	"o": CmdOrder,
+}
+
+func ExpandShortSyntax(args []string) []string {
+	expanded := make([]string, 0, len(args))
+
+	for _, arg := range args {
+		if cmd, ok := ShorthandMap[strings.ToLower(arg)]; ok {
+			expanded = append(expanded, cmd)
+			continue
+		}
+
+		expanded = append(expanded, arg)
+	}
+
+	return expanded
+}

--- a/internal/syntax/sort_parser.go
+++ b/internal/syntax/sort_parser.go
@@ -1,4 +1,4 @@
-package config
+package syntax
 
 import (
 	"fmt"
@@ -6,7 +6,12 @@ import (
 	"strings"
 )
 
-func parseSortOption(sortInput string) (SortOption, error) {
+type SortOption struct {
+	Field consts.FieldType
+	Asc   bool
+}
+
+func ParseSortOption(sortInput string) (SortOption, error) {
 	parts := strings.Split(sortInput, ":")
 	fieldKey := strings.ToLower(parts[0])
 	fieldType, exists := consts.FieldTypeLookup[fieldKey]

--- a/internal/syntax/syntax_parser.go
+++ b/internal/syntax/syntax_parser.go
@@ -1,0 +1,111 @@
+package syntax
+
+import (
+	"fmt"
+	"qp/internal/consts"
+	"strings"
+)
+
+type CmdType int
+
+const (
+	BlockNone CmdType = iota
+	BlockSelect
+	BlockWhere
+	BlockOrder
+)
+
+const (
+	CmdSelect = "select"
+	CmdWhere  = "where"
+	CmdOrder  = "order"
+)
+
+type ParsedInput struct {
+	Fields       []consts.FieldType
+	FieldQueries []FieldQuery
+	SortOption   SortOption
+}
+
+func ParseSyntax(args []string) (ParsedInput, error) {
+	preprocessedArgs, err := Preprocess(args)
+	if err != nil {
+		return ParsedInput{}, err
+	}
+
+	var fields []consts.FieldType
+	var queries []FieldQuery
+	var sortOption SortOption
+
+	currentBlock := BlockNone
+
+	for _, token := range preprocessedArgs {
+		cmd := lookupCommand(token)
+		if cmd != BlockNone {
+			currentBlock = cmd
+			continue
+		}
+
+		switch currentBlock {
+		case BlockSelect:
+			fieldTokens := strings.Split(token, ",")
+			for _, fieldStr := range fieldTokens {
+				fieldStr = strings.TrimSpace(fieldStr)
+
+				fieldType, ok := consts.FieldTypeLookup[fieldStr]
+				if !ok {
+					return ParsedInput{}, fmt.Errorf("unknown field: %q", fieldStr)
+				}
+
+				fields = append(fields, fieldType)
+			}
+
+		case BlockWhere:
+			query, err := parseQueryInput(token)
+			if err != nil {
+				return ParsedInput{}, err
+			}
+			queries = append(queries, query)
+
+		case BlockOrder:
+			opt, err := ParseSortOption(token)
+			if err != nil {
+				return ParsedInput{}, err
+			}
+			sortOption = opt
+
+		default:
+			return ParsedInput{}, fmt.Errorf("unexpected token: %q (expected in a command block like 'select', 'where', or 'order')", token)
+		}
+	}
+
+	if len(fields) == 0 {
+		fields = consts.DefaultFields
+	}
+
+	if sortOption == (SortOption{}) {
+		sortOption = SortOption{
+			Field: consts.FieldDate,
+			Asc:   true,
+		}
+	}
+
+	return ParsedInput{
+		Fields:       fields,
+		FieldQueries: queries,
+		SortOption:   sortOption,
+	}, nil
+}
+
+func lookupCommand(input string) CmdType {
+	switch strings.ToLower(input) {
+	case CmdSelect:
+		return BlockSelect
+	case CmdWhere:
+		return BlockWhere
+	case CmdOrder:
+		return BlockOrder
+	default:
+		return BlockNone
+	}
+}

--- a/qp.1
+++ b/qp.1
@@ -1,279 +1,174 @@
 .\" Man page for qp
 .TH qp 1 "@DATE@" "qp @VERSION@" "User Commands"
 .SH NAME
-qp \- Query Packages. A CLI utility for querying installed packages.
+qp \- query packages. A CLI utility for querying installed packages.
+
 .SH SYNOPSIS
-.B qp [options]
+.B qp [command] [args] [options]
 
 .SH DESCRIPTION
 .B qp
-is a standalone CLI utility for Arch and Arch-based Linux distributions to list and query installed packages. It works with any package manager that uses ALPM, like pacman and others.
+is a fast, flexible, and standalone CLI utility for querying installed packages on Arch Linux and Arch-based distributions. It supports advanced querying, sorting, and formatting features including:
 
-The utility provides powerful querying capabilities, including:
-.br
-- Existence queries
-.br
-- Installation date queries
-.br
-- Build date queries
-.br
-- Package size queries
-.br
-- Install reason queries
-.br
-- License queries
-.br
-- Reverse dependency queries (requirements or required-by)
-.br
-- Conflict queries
-.br
-- Dependency queries
-.br
-- Provision queries
-.br
-- Package name queries
-.br
-- Architecture queries
-.br
-- Description queries
-.br
-- Package base queries
-.br
-- Package type queries
-.br
-- Package packager queries
-.br
-- Sorting and JSON output
+- Existence checks
+- Field filtering
+- Date and size range queries
+- Reverse dependencies and provisions
+- Conflicts, optional dependencies, and groups
+- Sorting and output as table or JSON
+
+.SH COMMANDS
+.TP
+.B select <list>, s <list>
+Select fields to display (comma-separated). Use:
+.RS
+.IP \[bu] 
+select all — show all fields
+.IP \[bu] 
+select default — show default fields
+.IP \[bu] 
+select default,version — add to default
+.RE
+
+.TP
+.B where <query>, w <query>
+Apply one or more queries. Supported:
+.RS
+.IP \[bu] 
+String match — \fIfield=value\fR (fuzzy), \fIfield==value\fR (strict)
+.IP \[bu] 
+Range match — \fIfield=start:end\fR or \fIfield==start:end\fR (works with \fBdate\fR, \fBsize\fR)
+.IP \[bu] 
+Existence check — \fBhas:field\fR or \fBno:field\fR
+.RE
+
+.TP
+.B order <field>:<direction>, o <..>
+Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBname\fR, \fBsize\fR, \fBlicense\fR, \fBpkgbase\fR
+
+.TP
+.B limit <number>, l <number>
+Limit number of displayed results. Use \fBlimit all\fR to show all.
 
 .SH OPTIONS
 .TP
-.BR \-l " " \fInumber\fR ", " \-\-limit=\fInumber\fR
-Limit the number of recent packages displayed (default: 20).
-.TP
-.BR \-a ", " \-\-all
-Show all installed packages, ignoring \-l/--limit.
-.TP
-.BR \-w " " \fIquery\fR ", " \-\-where=\fIquery\fR
-Apply one or more filters to refine package results.
-
-Supported query types:
-.RS
-.TP
-.B string match
-\fIfield=value\fR -> fuzzy match
-.br
-\fIfield==value\fR -> strict match
-
-.TP
-.B range match
-\fIfield=start:end\fR -> fuzzy match
-.br
-\fIfield==start:end\fR -> strict match
-.br
-Supports full ranges (\fBstart:end\fR), open-ended ranges (\fBstart:\fR or \fB:end\fR), and exact values.
-.br
-Only supported for \fBdate\fR and \fBsize\fR.
-
-.TP
-.B existence check
-\fBhas:field\fR -> field must exist or be non-empty
-.br
-\fBno:field\fR -> field must be missing or empty
-.RE
-
-This flag can be used multiple times and mixed freely.
-
-See below for a list of all available query fields.
-.TP
-.BR \-O " " \fIfield:direction\fR ", " \-\-order=\fIfield:direction\fR
-Sort results. Default is \fBdate:asc\fR.
-Fields: \fIdate\fR, \fIbuild-date\fR, \fIname\fR, \fIsize\fR, \fIlicense\fR, \fIpkgbase\fR.
-.TP
 .B \-\-no-headers
-Omit column headers in output (useful for scripting).
-.TP
-.BR \-s " " \fIlist\fR ", " \-\-select=\fIlist\fR
-Comma-separated list of fields to display.
-Cannot be used with \fB--select-all\fR or \fB--select-add\fR.
-.TP
-.BR \-S " " \fIlist\fR ", " \-\-select-add=\fIlist\fR
-Add comma-separated fields to the default selection.
-.TP
-.BR \-A ", " \-\-select-all
-Display all available fields.
-.TP
-.B \-\-full-timestamp
-Show full install and build timestamps.
+Omit column headers (useful in scripts).
 .TP
 .B \-\-json
 Output results in JSON format.
 .TP
+.B \-\-full-timestamp
+Show full date+time for install/build.
+.TP
 .B \-\-no-progress
-Disable the progress bar in non-interactive environments.
+Disable progress bar.
 .TP
 .B \-\-no-cache
-Disable cache loading/saving and force fresh package data loading.
+Skip using cache, force fresh data load.
 .TP
 .B \-\-regen-cache
-Force fresh data loading and update the cache.
+Reload package data and regenerate cache.
 .TP
-.BR \-h ", " \-\-help
-Display help information.
+.B \-h, \-\-help
+Show help message.
 
-.SH QUERYING WITH --where
-The \fB--where\fR or \fB-w\fR option allows complex filtering by package metadata.
-
-You can provide multiple \fB-w\fR flags to combine different filters. Each query must follow one of the supported types:
+.SH QUERYING
+Use \fBwhere\fR (or \fBw\fR) one or more times to filter results.
 
 .TP
-.B string match
-\fIfield=value\fR -> fuzzy match
-.br
-\fIfield==value\fR -> strict match
-.br
-Applies to string fields like \fBname\fR, \fBlicense\fR, \fBdescription\fR, etc.
+.B String Match
+\fIfield=value\fR — fuzzy (substring, case-insensitive)  
+\fIfield==value\fR — strict (exact, case-insensitive)
 
 .TP
-.B range match
-\fIfield=start:end\fR -> fuzzy match
-.br
-\fIfield==start:end\fR -> strict match
-.br
-Supported for fields like \fBdate\fR and \fBsize\fR.
-.br
-Ranges can be:
-.br
-- Full range: \fBstart:end\fR
-.br
-- Open-ended: \fBstart:\fR or \fB:end\fR
-.br
-- Exact: \fBvalue\fR
+.B Range Match
+\fIfield=start:end\fR — fuzzy  
+\fIfield==start:end\fR — strict  
+Applies to \fBdate\fR and \fBsize\fR.  
+Supports full (e.g., 1GB:5GB), open-ended (e.g., 1GB:, :5GB), or exact values.
 
 .TP
-.B existence check
-\fBhas:field\fR -> filter for fields that exist or are non-empty
+.B Existence Check
+\fBhas:field\fR — must be non-empty  
+\fBno:field\fR — must be empty or missing
 
-.PP
-Multiple comma-separated values can be supplied for any query (e.g., \fBname=vim,nano\fR).
-
-.PP
-.B Match Behavior by Field Type:
-
+.TP
+.B Match Behavior Summary:
 .TS
 box, tab(:);
 cb cb cb
 l l l.
-Field Type: Fuzzy Match: Strict Match
+Field Type:Fuzzy Match:Strict Match
 _
-Strings & Relations: substring (case-insensitive): exact match (case-insensitive)
-Dates: matches by day (ignores time): exact timestamp (to the second)
-Size: ±0.3% byte tolerance (approximate): exact byte size
+Strings / Relations:substring (case-insensitive):exact (case-insensitive)
+Date:match by day:exact timestamp
+Size:±0.3% tolerance:exact byte size
 .TE
 
-Supported query types:
+.SH SUPPORTED QUERY FIELDS
 .TP
-.B date=<value>
-Installation date (exact, range, or open-ended).
+.B Range:
+date, build-date, size
 .TP
-.B build-date=<value>
-Build date (exact, range, or open-ended).
+.B String:
+name, reason, arch, license, pkgbase, description, url, pkgtype, packager
 .TP
-.B size=<value>
-Package size (exact, range, or open-ended).
-.TP
-.B name=<package>
-Filter by package name.
-.TP
-.B reason=explicit|dependencies
-Filter by installation reason.
-.TP
-.B arch=<arch>
-Filter by architecture.
-.TP
-.B license=<license>
-Filter by license name.
-.TP
-.B pkgbase=<pkgbase>
-Filter by package base.
-.TP
-.B description=<text>
-Filter by package description.
-.TP 
-.B pkgtype=<pkgtype>
-Filter by package type.
-.TP
-.B packager=<packager>
-Filter by package packager
-.TP
-.B conflicts=<package>
-Filter by conflicting packages.
-.TP
-.B depends=<package>
-Filter by dependencies.
-.TP
-.B required-by=<package>
-Filter by dependent packages.
-.TP
-.B provides=<package>
-Filter by provided libraries/packages.
+.B Relations:
+depends, provides, required-by, optional-for, optdepends, conflicts, replaces
 
 .SH AVAILABLE FIELDS
-Available fields for \fB--select\fR, \fB--select-add\fR, or \fB--select-all\fR:
-.IP
-date, build-date, size, name, reason, version, arch, license, pkgbase,
-description, url, validation, packager, pkgtype, groups, conflicts,
-replaces, depends, optdepends, required-by, optional-for, provides.
+Available for use with \fBselect\fR, \fBselect all\fR, etc:
 
-.SH JSON OUTPUT
-Use \fB--json\fR to output query results in structured JSON format for scripts.
+date, build-date, size, name, reason, version, arch, license, pkgbase,  
+description, url, validation, packager, pkgtype, groups, conflicts,  
+replaces, depends, optdepends, required-by, optional-for, provides
 
 .SH EXAMPLES
-Display all packages:
+List 10 smallest explicitly installed packages:
 .br
-\fBqp --all\fR
-.PP
-Query packages by size and output JSON:
+\fBqp w reason=explicit o size:asc l 10\fR
+
+Query packages larger than 500MB:
 .br
-\fBqp -Aw size=10MB:100MB --json\fR
-.PP
-Select specific fields:
+\fBqp w size=500MB:\fR
+
+Search packages that depend on \fBgtk3\fR:
 .br
-\fBqp -s name,version,size\fR
-.PP
-Order packages by name:
+\fBqp w required-by=gtk3\fR
+
+Get all fields for \fBgtk3\fR in JSON:
 .br
-\fBqp --order=name\fR
-.PP
-Complex query:
-.br
-\fBqp -Aw arch=x86_64 depends=glibc --order=size:desc --select name,size\fR
+\fBqp s all w name==gtk3 --json\fR
 
 .SH TIPS
-.TP
-Group short flags:
-\fBqp -aw name=yay\fR
-.TP
-Pipe output for long lists:
-\fBqp -s name,depends | less\fR
-.TP
-Use --flag=value for clarity:
-\fBqp --select=name,size --limit=50\fR
-.TP
-Use --no-headers in scripts for clean output.
+- Pipe long outputs:
+  \fBqp s name,depends | less\fR
+.br
+- Use comma-separated values:
+  \fBqp w arch=x86_64,any\fR
+.br
+- Omit headers for scripts:
+  \fBqp --no-headers s name,size\fR
+
+.SH FILES
+Cache is stored in:
+.br
+\fB$XDG_CACHE_HOME/query-packages\fR or \fB~/.cache/query-packages\fR
 
 .SH AUTHOR
-Written by Fernando Nunez <me@fernandonunez.io>.
+Written by Fernando Nunez <me@fernandonunez.io>
 
 .SH LICENSE
-GPLv3-only License. See
-.B LICENSE
-for details.
+GPLv3-only. For commercial licensing, see LICENSE.commercial.
 
 .SH BUGS
-Report bugs at:
+Report issues at:
 .UR https://github.com/Zweih/qp
 .UE
 
 .SH SEE ALSO
 .BR pacman(8),
+.BR yay(1),
+.BR paru(1)
 


### PR DESCRIPTION
As querying has become more and more powerful, the flag-based syntax has become more and more of a barrier to building the fully flexible system this project aims for.

As such, we are now moving forward with a command-based syntax. This will evolve into a language of it's own. This is the first stage of rolling out this querying language, and it is best to make this change sooner rather than later to ease the migration.

The `and` syntax is currently a stop-gap to ensure that going forward, boolean logical operations are explicit. A full boolean abstract syntax tree is planned.

Flag-based syntax will be deprecated, but is still functional for now. It will not be getting direct updates, but it will benefit from the updates to the new syntax.

There are too many changes to document in this PR. The docs (README, man page, `--help` menu) have been fully been updated to reflect the new syntax.

As this is a major update, it will necessitate a major version bump. This will be v5.0.0.

For the current release schedule, this is planned to roll out on the evening of April 20th.