### PR TITLE
Fix: Limit condition

### DIFF
--- a/cmd/qp/main.go
+++ b/cmd/qp/main.go
@@ -110,7 +110,7 @@ func trimPackagesLen(
 	pkgs []*pkgdata.PkgInfo,
 	cfg *config.Config,
 ) []*pkgdata.PkgInfo {
-	if cfg.Limit < 0 && len(pkgs) < cfg.Limit {
+	if cfg.Limit < 0 || len(pkgs) <= cfg.Limit {
 		return pkgs
 	}
 


### PR DESCRIPTION
When the condition was inverted, the or was not changed to an and.