### PR TITLE
Feature: Add optional-for query

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ learn about installation [here](#installation)
 | ✓ | sort by size on disk | - | conflicts sort |
 | ✓ | validation field | - | validation sort |
 | ✓ | reverse optional dependencies field (optional for) | - | optdepends installation indicator |
-| - | optional-for query | - | separate field for optdepends reason |
+| ✓ | optional-for query | - | separate field for optdepends reason |
 | ✓ | fuzzy/strict querying | ✓ | existence querying |
 | ✓ | existence querying | - | depth querying |
 | ✓ | pkgtype query | ✓ | optdepends query |
@@ -295,8 +295,9 @@ qp where name=python,cmake,yazi      # fuzzy match at least one of the three nam
 | conflicts | relation |
 | replaces | relation |
 | depends | relation |
-| optdepnds | relation |
+| optdepends | relation |
 | required-by | relation |
+| optional-for | relation |
 | provides | relation |
 
 ### available selectors

--- a/internal/pipeline/filtering/builder.go
+++ b/internal/pipeline/filtering/builder.go
@@ -31,7 +31,8 @@ func QueriesToConditions(queries []syntax.FieldQuery) ([]*FilterCondition, error
 			condition, err = parseStringCondition(query)
 
 		case consts.FieldDepends, consts.FieldOptDepends,
-			consts.FieldRequiredBy, consts.FieldProvides, consts.FieldConflicts:
+			consts.FieldRequiredBy, consts.FieldOptionalFor,
+			consts.FieldProvides, consts.FieldConflicts:
 			condition, err = parseRelationCondition(query)
 
 		default:

--- a/qp.1
+++ b/qp.1
@@ -116,7 +116,7 @@ date, build-date, size
 name, reason, arch, license, pkgbase, description, pkgtype, packager
 .TP
 .B Relations:
-conflicts, replaces, depends, optdepends, required-by, provides
+conflicts, replaces, depends, optdepends, required-by, optional-for, provides
 
 .SH AVAILABLE FIELDS
 Available for use with \fBselect\fR, \fBselect all\fR, etc:


### PR DESCRIPTION
Users can now query by packages that optionally require a package with `where optional-for=relation>`.

Example:
```
> qp where optional-for=yazi
DATE        NAME         REASON      SIZE
2025-01-15  chafa        dependency  1.67 MB
2025-01-15  ripgrep      dependency  4.61 MB
2025-01-15  fd           dependency  3.41 MB
2025-01-15  jq           dependency  983.71 KB
2025-03-31  ffmpeg       dependency  37.08 MB
2025-03-31  fzf          dependency  4.55 MB
2025-03-31  imagemagick  dependency  28.33 MB
2025-03-31  poppler      dependency  7.21 MB
2025-03-31  zoxide       dependency  1.05 MB
```

Closes #232 