### PR TITLE
Feature: Add URL query

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ qp where name=python,cmake,yazi      # fuzzy match at least one of the three nam
 | license | string |
 | pkgbase | string |
 | description | string |
+| url | string
 | pkgtype | string |
 | packager | string |
 | conflicts | relation |

--- a/internal/pipeline/filtering/builder.go
+++ b/internal/pipeline/filtering/builder.go
@@ -27,7 +27,7 @@ func QueriesToConditions(queries []syntax.FieldQuery) ([]*FilterCondition, error
 
 		case consts.FieldName, consts.FieldReason, consts.FieldArch,
 			consts.FieldLicense, consts.FieldPkgBase, consts.FieldDescription,
-			consts.FieldPkgType, consts.FieldPackager:
+			consts.FieldUrl, consts.FieldPkgType, consts.FieldPackager:
 			condition, err = parseStringCondition(query)
 
 		case consts.FieldDepends, consts.FieldOptDepends,

--- a/qp.1
+++ b/qp.1
@@ -113,7 +113,7 @@ Size:±0.3% tolerance:exact byte size
 date, build-date, size
 .TP
 .B String:
-name, reason, arch, license, pkgbase, description, pkgtype, packager
+name, reason, arch, license, pkgbase, description, url, pkgtype, packager
 .TP
 .B Relations:
 conflicts, replaces, depends, optdepends, required-by, optional-for, provides


### PR DESCRIPTION
Users can now query by a package's URL with `where url=<url>`

```
> qp where url=github
DATE        NAME                      REASON      SIZE
2025-04-02  sdl2-compat               dependency  3.14 MB
2025-04-02  python-absl               dependency  1.42 MB
2025-04-02  libutempter               dependency  135.11 KB
2025-04-02  lksctp-tools              dependency  561.61 KB
2025-04-02  iperf3                    explicit    399.86 KB
2025-04-07  python-lark-parser        dependency  1.24 MB
2025-04-07  python-poetry-core        dependency  1.40 MB
2025-04-07  python-fastjsonschema     dependency  274.70 KB
2025-04-07  python-typing_extensions  dependency  426.68 KB
2025-04-07  websocat                  explicit    3.51 MB
2025-04-09  python-jmespath           dependency  218.11 KB
2025-04-09  python-certifi            dependency  17.54 KB
2025-04-09  python-s3transfer         dependency  948.25 KB
2025-04-09  aws-cli                   explicit    12.81 MB
2025-04-09  python-botocore           dependency  101.26 MB
2025-04-09  python-yaml               dependency  1000.48 KB
2025-04-09  python-rsa                dependency  286.62 KB
2025-04-09  python-pyasn1             dependency  1.23 MB
2025-04-13  python-awscrt             explicit    4.06 MB
2025-04-20  qp                        explicit    4.07 MB
```

Closes #220 