### PR TITLE
Feature: Add validation query

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ learn about installation [here](#installation)
 | - | url query | - | pkgtype sort |
 | ✓ | architecture query | ✓ | groups field |
 | ✓	| conflicts query | - | package description sort |
-| ✓	| regenerate cache option | - | groups query |
+| ✓	| regenerate cache option | ✓ | validation query |
 | ✓ | packager field | ✓ | optional dependency field |
 | ✓ | sort by size on disk | - | conflicts sort |
 | ✓ | validation field | - | validation sort |
@@ -291,6 +291,7 @@ qp where name=python,cmake,yazi      # fuzzy match at least one of the three nam
 | pkgbase | string |
 | description | string |
 | url | string
+| validation | string |
 | pkgtype | string |
 | packager | string |
 | conflicts | relation |

--- a/internal/origins/pacman/parser.go
+++ b/internal/origins/pacman/parser.go
@@ -133,7 +133,9 @@ func applySingleLineField(pkg *pkgdata.PkgInfo, field string, value string) erro
 		pkg.Url = value
 
 	case fieldValidation:
-		pkg.Validation = value
+		if value != "none" {
+			pkg.Validation = value
+		}
 
 	case fieldDescription:
 		pkg.Description = value

--- a/internal/pipeline/filtering/builder.go
+++ b/internal/pipeline/filtering/builder.go
@@ -27,7 +27,7 @@ func QueriesToConditions(queries []syntax.FieldQuery) ([]*FilterCondition, error
 
 		case consts.FieldName, consts.FieldReason, consts.FieldArch,
 			consts.FieldLicense, consts.FieldPkgBase, consts.FieldDescription,
-			consts.FieldUrl, consts.FieldPkgType, consts.FieldPackager:
+			consts.FieldUrl, consts.FieldValidation, consts.FieldPkgType, consts.FieldPackager:
 			condition, err = parseStringCondition(query)
 
 		case consts.FieldDepends, consts.FieldOptDepends,

--- a/internal/pkgdata/cache.go
+++ b/internal/pkgdata/cache.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	cacheVersion    = 15 // bump when updating structure of PkgInfo/Relation/pkginfo.proto OR when dependency resolution is updated
+	cacheVersion    = 16 // bump when updating structure of PkgInfo/Relation/pkginfo.proto OR when dependency resolution is updated
 	xdgCacheHomeEnv = "XDG_CACHE_HOME"
 	homeEnv         = "HOME"
 	qpCacheDir      = "query-packages"

--- a/qp.1
+++ b/qp.1
@@ -113,7 +113,7 @@ Size:±0.3% tolerance:exact byte size
 date, build-date, size
 .TP
 .B String:
-name, reason, arch, license, pkgbase, description, url, pkgtype, packager
+name, reason, arch, license, pkgbase, description, url, validation, pkgtype, packager
 .TP
 .B Relations:
 conflicts, replaces, depends, optdepends, required-by, optional-for, provides


### PR DESCRIPTION
Users can now query by a package's validation with `where validation=<validation-type>`

```
> qp select name,validation where no:validation
NAME         VALIDATION
yay-bin      -
timg         -
moar         -
litecli      -
src-cli-bin  -
pacseek      -
downgrade    -
rogue        -
```

Closes #238 