### PR TITLE
Feature: Enforce logical operators between statements

### DIFF
--- a/internal/ast/tokenizer.go
+++ b/internal/ast/tokenizer.go
@@ -1,6 +1,7 @@
 package ast
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -22,24 +23,38 @@ type QueryToken struct {
 
 func tokenizeWhereTokens(rawTokens []string) ([]QueryToken, error) {
 	var tokens []QueryToken
+	lastWasQuery := false
 
 	for _, raw := range rawTokens {
 		switch strings.ToLower(raw) {
 		case "and":
 			tokens = append(tokens, QueryToken{Type: TokenAnd})
+			lastWasQuery = false
 		case "or":
 			tokens = append(tokens, QueryToken{Type: TokenOr})
+			lastWasQuery = false
 		case "not":
 			tokens = append(tokens, QueryToken{Type: TokenNot})
+			lastWasQuery = false
 		case "q":
 			tokens = append(tokens, QueryToken{Type: TokenOpenParen})
+			lastWasQuery = false
 		case "p":
 			tokens = append(tokens, QueryToken{Type: TokenCloseParen})
+			lastWasQuery = false
 		default:
+			if lastWasQuery {
+				return nil, fmt.Errorf(
+					"missing logical operator between '%s' and '%s'. Use 'and', 'or', 'not', or group with 'q'/'p'",
+					tokens[len(tokens)-1].Value, raw,
+				)
+			}
+
 			tokens = append(tokens, QueryToken{
 				Type:  TokenQuery,
 				Value: raw,
 			})
+			lastWasQuery = true
 		}
 	}
 


### PR DESCRIPTION
Logical operators (`and`, `or`, `not`, `q`, and `p`) are required between statements. 

Invalid:
```
qp where name=vim size=10MB:
```

Valid:
```
qp where name=vim and size=10MB:
```

#243 