### PR TITLE
Feature: Add groups query

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ learn about installation [here](#installation)
 | ✓ | required-by query | ✓ | no cache option |
 | ✓ | optional full timestamp | ✓ | package description field |
 | – | list possibly or confirmed stale/abandoned packages | – | self-referencing field |
-| – | groups query | – | streaming pipeline |
+| ✓  | groups query | – | streaming pipeline |
 | – | short-args for queries | – | key/value output |
 | – | XML output | – | package description sort |
 | ✓ | package base query | – | required-by sort |
@@ -302,7 +302,7 @@ qp w q has:depends or has:required-by p and not reason=explicit
 | pkgtype | string |
 | packager | string |
 | conflicts | relation |
-| replaces | relation |
+| groups | string |
 | depends | relation |
 | optdepends | relation |
 | required-by | relation |
@@ -323,9 +323,9 @@ qp w q has:depends or has:required-by p and not reason=explicit
 - `description` - package description
 - `url` - the URL of the official site of the software being packaged
 - `validation` - package integrity validation method (e.g., sha256, pgp)
-- `packager` - person/entity who built the package (if available)
 - `pkgtype` - package type (pkg, split, debug, src)
     - ***note**: older packages may have no pkgtype if built before pacman introduced XDATA
+- `packager` - person/entity who built the package (if available)
 - `groups` - package groups or categories (e.g., base, gnome, xfce4)
 - `conflicts` - list of packages that conflict, or cause problems, with the package
 - `replaces` - list of packages that are replaced by the package

--- a/internal/pipeline/filtering/builder.go
+++ b/internal/pipeline/filtering/builder.go
@@ -22,7 +22,7 @@ func QueriesToConditions(queries []query.FieldQuery) ([]*FilterCondition, error)
 		var err error
 
 		switch query.Field {
-		case consts.FieldDate, consts.FieldSize, consts.FieldBuildDate:
+		case consts.FieldDate, consts.FieldBuildDate, consts.FieldSize:
 			condition, err = parseRangeCondition(query)
 
 		case consts.FieldName, consts.FieldReason, consts.FieldArch,
@@ -30,9 +30,10 @@ func QueriesToConditions(queries []query.FieldQuery) ([]*FilterCondition, error)
 			consts.FieldUrl, consts.FieldValidation, consts.FieldPkgType, consts.FieldPackager:
 			condition, err = parseStringCondition(query)
 
-		case consts.FieldDepends, consts.FieldOptDepends,
+		case consts.FieldConflicts,
+			consts.FieldDepends, consts.FieldOptDepends,
 			consts.FieldRequiredBy, consts.FieldOptionalFor,
-			consts.FieldProvides, consts.FieldConflicts:
+			consts.FieldProvides:
 			condition, err = parseRelationCondition(query)
 
 		case consts.FieldGroups:

--- a/internal/pipeline/filtering/builder.go
+++ b/internal/pipeline/filtering/builder.go
@@ -35,6 +35,9 @@ func QueriesToConditions(queries []query.FieldQuery) ([]*FilterCondition, error)
 			consts.FieldProvides, consts.FieldConflicts:
 			condition, err = parseRelationCondition(query)
 
+		case consts.FieldGroups:
+			condition, err = parseStrArrCondition(query)
+
 		default:
 			err = fmt.Errorf("unsupported filter type: %s", consts.FieldNameLookup[query.Field])
 		}
@@ -69,6 +72,19 @@ func parseRelationCondition(query query.FieldQuery) (*FilterCondition, error) {
 
 	targets := strings.Split(query.Target, ",")
 	return newRelationCondition(query.Field, targets, query.Depth, query.Match, query.Negate)
+}
+
+func parseStrArrCondition(query query.FieldQuery) (*FilterCondition, error) {
+	if query.IsExistence {
+		return newStrArrExistsCondition(query.Field, query.Negate)
+	}
+
+	if query.Target == "" {
+		return nil, fmt.Errorf("query %s requires a target", consts.FieldNameLookup[query.Field])
+	}
+
+	targets := strings.Split(query.Target, ",")
+	return newStrArrCondition(query.Field, targets, query.Match, query.Negate)
 }
 
 func parseStringCondition(query query.FieldQuery) (*FilterCondition, error) {

--- a/internal/pipeline/filtering/conditions.go
+++ b/internal/pipeline/filtering/conditions.go
@@ -50,6 +50,45 @@ func newStringExistsCondition(field consts.FieldType, mask bool) (*FilterConditi
 	return &condition, nil
 }
 
+func newStrArrCondition(
+	field consts.FieldType,
+	targets []string,
+	match consts.MatchType,
+	mask bool,
+) (*FilterCondition, error) {
+	condition := newCondition(field)
+	matcher := StringMatchers[match]
+
+	for i, target := range targets {
+		targets[i] = strings.ToLower(target)
+	}
+
+	condition.Filter = func(pkg *pkgdata.PkgInfo) bool {
+		for _, s := range pkg.GetStrArr(field) {
+			if matcher(s, targets) {
+				return !mask
+			}
+		}
+
+		return mask
+	}
+
+	return &condition, nil
+}
+
+func newStrArrExistsCondition(
+	field consts.FieldType,
+	mask bool,
+) (*FilterCondition, error) {
+	condition := newCondition(field)
+
+	condition.Filter = func(pkg *pkgdata.PkgInfo) bool {
+		return pkgdata.SliceExists(pkg.GetStrArr(field)) != mask
+	}
+
+	return &condition, nil
+}
+
 func newRelationCondition(
 	field consts.FieldType,
 	targets []string,

--- a/internal/pkgdata/filter_logic.go
+++ b/internal/pkgdata/filter_logic.go
@@ -8,10 +8,6 @@ import (
 
 const fuzzySizeTolerancePercent = 0.3
 
-func FilterByReason(installReason string, targetReason string) bool {
-	return installReason == targetReason
-}
-
 func GetRelationsByDepth(relations []Relation, targetDepth int32) []Relation {
 	filteredRelations := []Relation{}
 
@@ -72,16 +68,6 @@ func StrictSizeRange(value int64, startSize int64, endSize int64) bool {
 	return !(value < startSize || value > endSize)
 }
 
-func FilterSliceByStrings(pkgStrings []string, targetStrings []string) bool {
-	for _, pkgString := range pkgStrings {
-		if FuzzyStrings(pkgString, targetStrings) {
-			return true
-		}
-	}
-
-	return false
-}
-
 func FuzzyStrings(pkgString string, targetStrings []string) bool {
 	pkgString = strings.ToLower(pkgString)
 
@@ -100,10 +86,14 @@ func StrictStrings(pkgString string, targetStrings []string) bool {
 	return slices.Contains(targetStrings, pkgString)
 }
 
-func RelationExists(relations []Relation) bool {
-	return len(relations) > 0
+func SliceExists[T any](s []T) bool {
+	return len(s) > 0
 }
 
 func StringExists(pkgString string) bool {
 	return pkgString != ""
+}
+
+func RelationExists(relations []Relation) bool {
+	return len(relations) > 0
 }

--- a/internal/pkgdata/packageinfo.go
+++ b/internal/pkgdata/packageinfo.go
@@ -95,6 +95,15 @@ func (pkg *PkgInfo) GetString(field consts.FieldType) string {
 	}
 }
 
+func (pkg *PkgInfo) GetStrArr(field consts.FieldType) []string {
+	switch field {
+	case consts.FieldGroups:
+		return pkg.Groups
+	default:
+		panic("invalid field passed to GetStringSlice: " + consts.FieldNameLookup[field])
+	}
+}
+
 func (pkg *PkgInfo) GetRelations(field consts.FieldType) []Relation {
 	switch field {
 	case consts.FieldConflicts:

--- a/qp.1
+++ b/qp.1
@@ -131,10 +131,10 @@ Group and combine logic:
 date, build-date, size
 .TP
 .B String:
-name, reason, arch, license, pkgbase, description, url, validation, pkgtype, packager
+name, reason, arch, license, pkgbase, description, url, groups, validation, pkgtype, packager
 .TP
 .B Relations:
-conflicts, replaces, depends, optdepends, required-by, optional-for, provides
+conflicts, depends, optdepends, required-by, optional-for, provides
 
 .SH AVAILABLE FIELDS
 Available for use with \fBselect\fR, \fBselect all\fR, etc:


### PR DESCRIPTION
Users can now query by the groups of with `where groups=<group>`.

Example:
```
> qp select name,groups where has:groups
NAME                    GROUPS
pacman-mirrorlist       base
archlinuxarm-keyring    base-devel
tree-sitter-lua         tree-sitter-grammars
tree-sitter-markdown    tree-sitter-grammars
tree-sitter-vimdoc      tree-sitter-grammars
tree-sitter-vim         tree-sitter-grammars
ttf-nerd-fonts-symbols  nerd-fonts
xorg-xprop              xorg-apps, xorg
fcitx5                  fcitx5-im
spirv-tools             vulkan-devel
vulkan-icd-loader       vulkan-devel
tree-sitter-query       tree-sitter-grammars
tree-sitter-c           tree-sitter-grammars
python-setuptools       python-build-backend
vulkan-headers          vulkan-devel
python-poetry-core      python-build-backend
```

Example 2:
```
> qp select name,groups where groups=xorg
NAME        GROUPS
xorg-xprop  xorg-apps, xorg
```

Closes #233 