### PR TITLE
Feature: Add replaces query

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,8 +301,9 @@ qp w q has:depends or has:required-by p and not reason=explicit
 | validation | string |
 | pkgtype | string |
 | packager | string |
-| conflicts | relation |
 | groups | string |
+| conflicts | relation |
+| replaces | relation |
 | depends | relation |
 | optdepends | relation |
 | required-by | relation |

--- a/internal/pipeline/filtering/builder.go
+++ b/internal/pipeline/filtering/builder.go
@@ -30,7 +30,7 @@ func QueriesToConditions(queries []query.FieldQuery) ([]*FilterCondition, error)
 			consts.FieldUrl, consts.FieldValidation, consts.FieldPkgType, consts.FieldPackager:
 			condition, err = parseStringCondition(query)
 
-		case consts.FieldConflicts,
+		case consts.FieldConflicts, consts.FieldReplaces,
 			consts.FieldDepends, consts.FieldOptDepends,
 			consts.FieldRequiredBy, consts.FieldOptionalFor,
 			consts.FieldProvides:

--- a/qp.1
+++ b/qp.1
@@ -134,7 +134,7 @@ date, build-date, size
 name, reason, arch, license, pkgbase, description, url, groups, validation, pkgtype, packager
 .TP
 .B Relations:
-conflicts, depends, optdepends, required-by, optional-for, provides
+conflicts, replaces, depends, optdepends, required-by, optional-for, provides
 
 .SH AVAILABLE FIELDS
 Available for use with \fBselect\fR, \fBselect all\fR, etc:


### PR DESCRIPTION
Users can now query by what a package replaces with `where replaces=<relation>`

Example:
```
> qp select name,replaces where replaces=yaylog
NAME  REPLACES
qp    yaylog, yaylog-bin, yaylog-git
```

Closes #245 