### PR TITLE
Feature: Add version query

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ qp w q has:depends or has:required-by p and not reason=explicit
 | size | range |
 | name | string |
 | reason | string |
+| version | string |
 | arch | string |
 | license | string |
 | pkgbase | string |

--- a/internal/pipeline/filtering/builder.go
+++ b/internal/pipeline/filtering/builder.go
@@ -25,9 +25,10 @@ func QueriesToConditions(queries []query.FieldQuery) ([]*FilterCondition, error)
 		case consts.FieldDate, consts.FieldBuildDate, consts.FieldSize:
 			condition, err = parseRangeCondition(query)
 
-		case consts.FieldName, consts.FieldReason, consts.FieldArch,
-			consts.FieldLicense, consts.FieldPkgBase, consts.FieldDescription,
-			consts.FieldUrl, consts.FieldValidation, consts.FieldPkgType, consts.FieldPackager:
+		case consts.FieldName, consts.FieldReason, consts.FieldVersion,
+			consts.FieldArch, consts.FieldLicense, consts.FieldPkgBase,
+			consts.FieldDescription, consts.FieldUrl, consts.FieldValidation,
+			consts.FieldPkgType, consts.FieldPackager:
 			condition, err = parseStringCondition(query)
 
 		case consts.FieldConflicts, consts.FieldReplaces,

--- a/qp.1
+++ b/qp.1
@@ -131,7 +131,7 @@ Group and combine logic:
 date, build-date, size
 .TP
 .B String:
-name, reason, arch, license, pkgbase, description, url, groups, validation, pkgtype, packager
+name, reason, arch, version, license, pkgbase, description, url, groups, validation, pkgtype, packager
 .TP
 .B Relations:
 conflicts, replaces, depends, optdepends, required-by, optional-for, provides


### PR DESCRIPTION
Users can now query by a package's version with `where version=<version>`

```
> qp select name,version where version=5.6.0
NAME  VERSION
qp    5.6.0-1
```