### PR TITLE
Feature: Packager sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ non-arch distros are planned!
   - package name
   - license
   - size on disk
-  - package base and package type
+  - package base, package type, and packager
 - output as:
   - table
   - JSON
@@ -119,7 +119,7 @@ learn about installation [here](#installation)
 | ✓ | sort by size on disk | - | conflicts sort |
 | - | optional-for sort | - | provides sort |
 | ✓ | validation field | - | validation sort |
-| - | packager sort | - | architecture sort |
+| ✓ | packager sort | - | architecture sort |
 | - | reason sort | - |version sort |
 | ✓ | reverse optional dependencies field (optional for) | - | optdepends installation indicator |
 | ✓ | optional-for query | - | separate field for optdepends reason |
@@ -356,6 +356,7 @@ qp w q has:depends or has:required-by p and not reason=explicit
 - `size`
 - `pkgtype`
 - `pkgbase`
+- `packager`
 
 ### JSON output
 

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -36,7 +36,8 @@ func GetComparator(field consts.FieldType, asc bool) (PkgComparator, error) {
 		return makeComparator(func(p *PkgInfo) int64 { return p.GetInt(field) }, asc), nil
 
 	case consts.FieldName, consts.FieldLicense,
-		consts.FieldPkgBase, consts.FieldPkgType:
+		consts.FieldPkgType, consts.FieldPkgBase,
+		consts.FieldPackager:
 		return makeComparator(func(p *PkgInfo) string {
 			return strings.ToLower(p.GetString(field))
 		}, asc), nil

--- a/qp.1
+++ b/qp.1
@@ -44,7 +44,7 @@ Existence check — \fBhas:field\fR or \fBno:field\fR
 
 .TP
 .B order <field>:<direction>, o <..>
-Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBname\fR, \fBsize\fR, \fBlicense\fR, \fBpkgbase\fR, \fBpkgtype\fR
+Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBname\fR, \fBsize\fR, \fBpkgtype\fR, \fBlicense\fR, \fBpkgbase\fR, \fBpackager\fR
 
 .TP
 .B limit <number>, l <number>


### PR DESCRIPTION
Users can now sort by packager with `qp order packager`, `qp order packager:asc`, or `qp order packager:desc`.

Example:
```
> qp select name,packager order packager
NAME                     PACKAGER
tree-sitter-query        Arch Linux ARM Build System <builder+seattle@archlinuxarm.org>
tree-sitter-lua          Arch Linux ARM Build System <builder+seattle@archlinuxarm.org>
yazi                     Arch Linux ARM Build System <builder+seattle@archlinuxarm.org>
tree-sitter-c            Arch Linux ARM Build System <builder+seattle@archlinuxarm.org>
zellij                   Arch Linux ARM Build System <builder+seattle@archlinuxarm.org>
tinysparql               Arch Linux ARM Build System <builder+seattle@archlinuxarm.org>
tree                     Arch Linux ARM Build System <builder+seattle@archlinuxarm.org>
zoxide                   Arch Linux ARM Build System <builder+seattle@archlinuxarm.org>
zeromq                   Arch Linux ARM Build System <builder+seattle@archlinuxarm.org>
zsh                      Arch Linux ARM Build System <builder+seattle@archlinuxarm.org>
texinfo                  Arch Linux ARM Build System <builder+seattle@archlinuxarm.org>
zstd                     Arch Linux ARM Build System <builder+seattle@archlinuxarm.org>
python-build             Kevin Mihelich <kevin@archlinuxarm.org>
python-autocommand       Kevin Mihelich <kevin@archlinuxarm.org>
python-packaging         Kevin Mihelich <kevin@archlinuxarm.org>
python-installer         Kevin Mihelich <kevin@archlinuxarm.org>
python-jaraco.functools  Kevin Mihelich <kevin@archlinuxarm.org>
python-jaraco.text       Kevin Mihelich <kevin@archlinuxarm.org>
python-pyproject-hooks   Kevin Mihelich <kevin@archlinuxarm.org>
python-platformdirs      Kevin Mihelich <kevin@archlinuxarm.org>
```

Closes #253 