### PR TITLE
Feature: Add arch sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,9 +351,10 @@ qp w q has:depends or has:required-by p and not reason=explicit
 
 - `date`
 - `build-date`
-- `name`
-- `license`
 - `size`
+- `name`
+- `arch`
+- `license`
 - `pkgtype`
 - `pkgbase`
 - `packager`

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -37,7 +37,7 @@ func GetComparator(field consts.FieldType, asc bool) (PkgComparator, error) {
 
 	case consts.FieldName, consts.FieldLicense,
 		consts.FieldPkgType, consts.FieldPkgBase,
-		consts.FieldPackager:
+		consts.FieldPackager, consts.FieldArch:
 		return makeComparator(func(p *PkgInfo) string {
 			return strings.ToLower(p.GetString(field))
 		}, asc), nil

--- a/qp.1
+++ b/qp.1
@@ -44,7 +44,7 @@ Existence check — \fBhas:field\fR or \fBno:field\fR
 
 .TP
 .B order <field>:<direction>, o <..>
-Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBname\fR, \fBsize\fR, \fBpkgtype\fR, \fBlicense\fR, \fBpkgbase\fR, \fBpackager\fR
+Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBsize\fR, \fBname\fR, \fBarch\fR, \fBpkgtype\fR, \fBlicense\fR, \fBpkgbase\fR, \fBpackager\fR
 
 .TP
 .B limit <number>, l <number>


### PR DESCRIPTION
Users can now sort by architecture with `qp order arch`, `qp order arch:asc`, or `qp order arch:desc`.

Example:
```
> qp w arch s name,arch
NAME                           ARCH
ca-certificates-utils          any
autoconf                       any
asciinema                      any
automake                       any
alsa-ucm-conf                  any
alsa-topology-conf             any
adwaita-icon-theme-legacy      any
adwaita-icon-theme             any
adobe-source-code-pro-fonts    any
adwaita-fonts                  any
adwaita-cursors                any
xorgproto                      any
wayland-protocols              any
xkeyboard-config               any
xcb-proto                      any
vulkan-headers                 any
ttf-nerd-fonts-symbols         any
ttf-nerd-fonts-symbols-common  any
zsh-completions                any
timg                           any
```

Closes #254 