### PR TITLE
Feature: Add validation sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ learn about installation [here](#installation)
 | ✓ | packager field | ✓ | optional dependency field |
 | ✓ | sort by size on disk | - | conflicts sort |
 | - | optional-for sort | - | provides sort |
-| ✓ | validation field | - | validation sort |
-| ✓ | packager sort | - | architecture sort |
+| ✓ | validation field | ✓ | validation sort |
+| ✓ | packager sort | ✓ | architecture sort |
 | - | reason sort | - |version sort |
 | ✓ | reverse optional dependencies field (optional for) | - | optdepends installation indicator |
 | ✓ | optional-for query | - | separate field for optdepends reason |
@@ -304,13 +304,13 @@ qp w q has:depends or has:required-by p and not reason=explicit
 | name | string |
 | reason | string |
 | version | string |
-| pkgtype | string |
 | arch | string |
 | license | string |
 | pkgbase | string |
 | description | string |
 | url | string
 | validation | string |
+| pkgtype | string |
 | packager | string |
 | groups | string |
 | conflicts | relation |
@@ -355,6 +355,7 @@ qp w q has:depends or has:required-by p and not reason=explicit
 - `name`
 - `arch`
 - `license`
+- `validation`
 - `pkgtype`
 - `pkgbase`
 - `packager`

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -37,7 +37,8 @@ func GetComparator(field consts.FieldType, asc bool) (PkgComparator, error) {
 
 	case consts.FieldName, consts.FieldLicense,
 		consts.FieldPkgType, consts.FieldPkgBase,
-		consts.FieldPackager, consts.FieldArch:
+		consts.FieldPackager, consts.FieldArch,
+		consts.FieldValidation:
 		return makeComparator(func(p *PkgInfo) string {
 			return strings.ToLower(p.GetString(field))
 		}, asc), nil

--- a/qp.1
+++ b/qp.1
@@ -44,7 +44,7 @@ Existence check — \fBhas:field\fR or \fBno:field\fR
 
 .TP
 .B order <field>:<direction>, o <..>
-Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBsize\fR, \fBname\fR, \fBarch\fR, \fBpkgtype\fR, \fBlicense\fR, \fBpkgbase\fR, \fBpackager\fR
+Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBsize\fR, \fBname\fR, \fBarch\fR, \fBlicense\fR, \fBpkgbase\fR, \fBpkgtype\fR, \fBvalidation\fR, \fBpackager\fR
 
 .TP
 .B limit <number>, l <number>


### PR DESCRIPTION
Users can now sort by package validation with `qp order validation`, `qp order validation:asc`, or `qp order validation:desc`.

Example:
```
> qp s name,validation o validation
NAME               VALIDATION
xclip              pgp
xkeyboard-config   pgp
xorg-xprop         pgp
xorgproto          pgp
xvidcore           pgp
websocat           pgp
xxhash             pgp
xz                 pgp
yazi               pgp
yyjson             pgp
zellij             pgp
zimg               pgp
zlib               pgp
zoxide             pgp
zeromq             pgp
zsh                pgp
zsh-completions    pgp
zstd               pgp
pacman-mirrorlist  sha256
libevent           sha256
```

Closes #263