### PR TITLE
Feature: Add origin field

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ learn about installation [here](#installation)
 | ✓ | fuzzy/strict querying | ✓ | existence querying |
 | ✓ | existence querying | - | depth querying |
 | ✓ | pkgtype query | ✓ | optdepends query |
-| ✓ | packager query | - | origin field |
+| ✓ | packager query | ✓ | origin field |
 | - | origin sort | - | origin query |
 | ✓ | command-based syntax | ✓ | full boolean logic |
 | ✓ | abstract syntax tree | ✓ | directed acyclical graph for filtering |
@@ -329,6 +329,7 @@ qp w q has:depends or has:required-by p and not reason=explicit
 - `name` - package name
 - `reason` - installation reason (explicit/dependency)
 - `version` - installed package version
+- `origin` - the package ecosystem or source the package belongs to (e.g., pacman); reflects which package manager or backend maintains it
 - `arch` - architecture the package was built for (e.g., x86_64, aarch64, any)
 - `license` - package software license
 - `pkgbase` - name of the base package used to group split packages; for non-split packages, it is the same as the package name. 
@@ -381,13 +382,14 @@ output format:
     "name": "gtk3",
     "reason": "dependency",
     "version": "1:3.24.49-1",
-    "pkgtype": "split",
-    "arch": "aarch64",
+    "origin": "pacman",
+    "arch": "x86_64",
     "license": "LGPL-2.1-or-later",
-    "pkgbase": "gtk3",
     "description": "GObject-based multi-platform GUI toolkit",
     "url": "https://www.gtk.org/",
     "validation": "pgp",
+    "pkgtype": "split",
+    "pkgbase": "gtk3",
     "packager": "Jan Alexander Steffens (heftig) <heftig@archlinux.org>",
     "conflicts": [
       "gtk3-print-backends"

--- a/internal/consts/fields.go
+++ b/internal/consts/fields.go
@@ -5,10 +5,11 @@ type FieldType int
 // ordered by filter efficiency
 const (
 	FieldReason FieldType = iota
-	FieldPkgType
 	FieldArch
-	FieldLicense
 	FieldName
+	FieldOrigin
+	FieldPkgType
+	FieldLicense
 	FieldPkgBase
 	FieldValidation
 	FieldPackager
@@ -35,13 +36,14 @@ const (
 	name        = "name"
 	reason      = "reason"
 	version     = "version"
-	pkgType     = "pkgtype"
+	origin      = "origin"
 	arch        = "arch"
 	license     = "license"
-	pkgBase     = "pkgbase"
 	description = "description"
 	url         = "url"
 	validation  = "validation"
+	pkgType     = "pkgtype"
+	pkgBase     = "pkgbase"
 	packager    = "packager"
 	groups      = "groups"
 	conflicts   = "conflicts"
@@ -70,16 +72,17 @@ var FieldTypeLookup = map[string]FieldType{
 	date:        FieldDate,
 	buildDate:   FieldBuildDate,
 	size:        FieldSize,
-	pkgType:     FieldPkgType,
 	name:        FieldName,
 	reason:      FieldReason,
 	version:     FieldVersion,
+	origin:      FieldOrigin,
 	arch:        FieldArch,
 	license:     FieldLicense,
-	pkgBase:     FieldPkgBase,
 	description: FieldDescription,
 	url:         FieldUrl,
 	validation:  FieldValidation,
+	pkgType:     FieldPkgType,
+	pkgBase:     FieldPkgBase,
 	packager:    FieldPackager,
 	groups:      FieldGroups,
 	conflicts:   FieldConflicts,
@@ -95,16 +98,17 @@ var FieldNameLookup = map[FieldType]string{
 	FieldDate:        date,
 	FieldBuildDate:   buildDate,
 	FieldSize:        size,
-	FieldPkgType:     pkgType,
 	FieldName:        name,
 	FieldReason:      reason,
 	FieldVersion:     version,
+	FieldOrigin:      origin,
 	FieldArch:        arch,
 	FieldLicense:     license,
-	FieldPkgBase:     pkgBase,
 	FieldDescription: description,
 	FieldUrl:         url,
 	FieldValidation:  validation,
+	FieldPkgType:     pkgType,
+	FieldPkgBase:     pkgBase,
 	FieldPackager:    packager,
 	FieldGroups:      groups,
 	FieldConflicts:   conflicts,
@@ -128,16 +132,17 @@ var (
 		FieldDate,
 		FieldBuildDate,
 		FieldSize,
-		FieldPkgType,
 		FieldName,
 		FieldReason,
 		FieldVersion,
+		FieldOrigin,
 		FieldArch,
 		FieldLicense,
-		FieldPkgBase,
 		FieldDescription,
 		FieldUrl,
 		FieldValidation,
+		FieldPkgType,
+		FieldPkgBase,
 		FieldPackager,
 		FieldGroups,
 		FieldConflicts,
@@ -151,16 +156,16 @@ var (
 )
 
 var StringFields = map[FieldType]struct{}{
-	FieldPkgType:     {},
 	FieldName:        {},
 	FieldReason:      {},
 	FieldVersion:     {},
 	FieldArch:        {},
 	FieldLicense:     {},
-	FieldPkgBase:     {},
 	FieldDescription: {},
 	FieldUrl:         {},
 	FieldValidation:  {},
+	FieldPkgType:     {},
+	FieldPkgBase:     {},
 	FieldPackager:    {},
 }
 

--- a/internal/display/render_json.go
+++ b/internal/display/render_json.go
@@ -15,13 +15,14 @@ type PkgInfoJSON struct {
 	Name             string   `json:"name,omitempty"`
 	Reason           string   `json:"reason,omitempty"`
 	Version          string   `json:"version,omitempty"`
-	PkgType          string   `json:"pkgtype,omitempty"`
+	Origin           string   `json:"origin,omitempty"`
 	Arch             string   `json:"arch,omitempty"`
 	License          string   `json:"license,omitempty"`
-	PkgBase          string   `json:"pkgbase,omitempty"`
 	Description      string   `json:"description,omitempty"`
 	Url              string   `json:"url,omitempty"`
 	Validation       string   `json:"validation,omitempty"`
+	PkgType          string   `json:"pkgtype,omitempty"`
+	PkgBase          string   `json:"pkgbase,omitempty"`
 	Packager         string   `json:"packager,omitempty"`
 	Groups           []string `json:"groups,omitempty"`
 	Conflicts        []string `json:"conflicts,omitempty"`
@@ -86,30 +87,32 @@ func getJsonValues(pkg *pkgdata.PkgInfo, fields []consts.FieldType) *PkgInfoJSON
 			filteredPackage.BuildTimestamp = pkg.GetInt(field)
 		case consts.FieldSize:
 			filteredPackage.Size = pkg.GetInt(field)
-		case consts.FieldPkgType:
-			filteredPackage.PkgType = pkg.GetString(field)
 		case consts.FieldName:
 			filteredPackage.Name = pkg.GetString(field)
 		case consts.FieldReason:
 			filteredPackage.Reason = pkg.GetString(field)
 		case consts.FieldVersion:
 			filteredPackage.Version = pkg.GetString(field)
+		case consts.FieldOrigin:
+			filteredPackage.Origin = pkg.GetString(field)
 		case consts.FieldArch:
 			filteredPackage.Arch = pkg.GetString(field)
 		case consts.FieldLicense:
 			filteredPackage.License = pkg.GetString(field)
-		case consts.FieldPkgBase:
-			filteredPackage.PkgBase = pkg.GetString(field)
 		case consts.FieldDescription:
 			filteredPackage.Description = pkg.GetString(field)
 		case consts.FieldUrl:
 			filteredPackage.Url = pkg.GetString(field)
-		case consts.FieldGroups:
-			filteredPackage.Groups = pkg.Groups
 		case consts.FieldValidation:
 			filteredPackage.Validation = pkg.GetString(field)
+		case consts.FieldPkgType:
+			filteredPackage.PkgType = pkg.GetString(field)
+		case consts.FieldPkgBase:
+			filteredPackage.PkgBase = pkg.GetString(field)
 		case consts.FieldPackager:
 			filteredPackage.Packager = pkg.GetString(field)
+		case consts.FieldGroups:
+			filteredPackage.Groups = pkg.Groups
 		case consts.FieldConflicts:
 			filteredPackage.Conflicts = flattenRelations(pkg.GetRelations(field))
 		case consts.FieldReplaces:

--- a/internal/display/render_table.go
+++ b/internal/display/render_table.go
@@ -20,13 +20,14 @@ var columnHeaders = map[consts.FieldType]string{
 	consts.FieldReason:      "REASON",
 	consts.FieldSize:        "SIZE",
 	consts.FieldVersion:     "VERSION",
-	consts.FieldPkgType:     "PKGTYPE",
+	consts.FieldOrigin:      "ORIGIN",
 	consts.FieldArch:        "ARCH",
 	consts.FieldLicense:     "LICENSE",
 	consts.FieldPkgBase:     "PKGBASE",
 	consts.FieldDescription: "DESCRIPTION",
 	consts.FieldUrl:         "URL",
 	consts.FieldValidation:  "VALIDATION",
+	consts.FieldPkgType:     "PKGTYPE",
 	consts.FieldPackager:    "PACKAGER",
 	consts.FieldGroups:      "GROUPS",
 	consts.FieldConflicts:   "CONFLICTS",
@@ -85,8 +86,8 @@ func renderRows(
 	ctx tableContext,
 ) {
 	row := make([]string, len(fields))
-	for i, fields := range fields {
-		value := getTableValue(pkg, fields, ctx)
+	for i, field := range fields {
+		value := getTableValue(pkg, field, ctx)
 		if value == "" {
 			value = "-"
 		}
@@ -101,17 +102,18 @@ func getTableValue(pkg *pkgdata.PkgInfo, field consts.FieldType, ctx tableContex
 	switch field {
 	case consts.FieldDate, consts.FieldBuildDate:
 		return formatDate(pkg.GetInt(field), ctx)
+
 	case consts.FieldSize:
 		return formatSize(pkg.GetInt(field))
 
 	case consts.FieldName, consts.FieldReason, consts.FieldVersion,
-		consts.FieldArch, consts.FieldLicense, consts.FieldUrl,
-		consts.FieldDescription, consts.FieldPkgBase, consts.FieldValidation,
-		consts.FieldPackager, consts.FieldPkgType:
+		consts.FieldOrigin, consts.FieldArch, consts.FieldLicense,
+		consts.FieldUrl, consts.FieldDescription, consts.FieldValidation,
+		consts.FieldPkgType, consts.FieldPkgBase, consts.FieldPackager:
 		return pkg.GetString(field)
 
 	case consts.FieldGroups:
-		return strings.Join(pkg.Groups, ", ")
+		return strings.Join(pkg.GetStrArr(field), ", ")
 
 	case consts.FieldConflicts, consts.FieldReplaces, consts.FieldDepends,
 		consts.FieldOptDepends, consts.FieldRequiredBy, consts.FieldOptionalFor,

--- a/internal/origins/pacman/driver.go
+++ b/internal/origins/pacman/driver.go
@@ -18,7 +18,7 @@ func (d *PacmanDriver) Detect() bool {
 }
 
 func (d *PacmanDriver) Load() ([]*pkgdata.PkgInfo, error) {
-	return fetchPackages()
+	return fetchPackages(d.Name())
 }
 
 func (d *PacmanDriver) ResolveDeps(pkgs []*pkgdata.PkgInfo) ([]*pkgdata.PkgInfo, error) {

--- a/internal/pipeline/filtering/builder.go
+++ b/internal/pipeline/filtering/builder.go
@@ -26,9 +26,9 @@ func QueriesToConditions(queries []query.FieldQuery) ([]*FilterCondition, error)
 			condition, err = parseRangeCondition(query)
 
 		case consts.FieldName, consts.FieldReason, consts.FieldVersion,
-			consts.FieldArch, consts.FieldLicense, consts.FieldPkgBase,
-			consts.FieldDescription, consts.FieldUrl, consts.FieldValidation,
-			consts.FieldPkgType, consts.FieldPackager:
+			consts.FieldArch, consts.FieldLicense, consts.FieldDescription,
+			consts.FieldUrl, consts.FieldValidation, consts.FieldPkgType,
+			consts.FieldPkgBase, consts.FieldPackager:
 			condition, err = parseStringCondition(query)
 
 		case consts.FieldConflicts, consts.FieldReplaces,

--- a/internal/pkgdata/cache.go
+++ b/internal/pkgdata/cache.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	cacheVersion    = 16 // bump when updating structure of PkgInfo/Relation/pkginfo.proto OR when dependency resolution is updated
+	cacheVersion    = 17 // bump when updating structure of PkgInfo/Relation/pkginfo.proto OR when dependency resolution is updated
 	xdgCacheHomeEnv = "XDG_CACHE_HOME"
 	homeEnv         = "HOME"
 	qpCacheDir      = "query-packages"
@@ -105,14 +105,15 @@ func pkgsToProtos(pkgs []*PkgInfo) []*pb.PkgInfo {
 			Name:             pkg.Name,
 			Reason:           pkg.Reason,
 			Version:          pkg.Version,
+			Origin:           pkg.Origin,
 			Arch:             pkg.Arch,
 			License:          pkg.License,
 			Url:              pkg.Url,
 			Description:      pkg.Description,
-			PkgBase:          pkg.PkgBase,
 			Validation:       pkg.Validation,
-			Packager:         pkg.Packager,
 			PkgType:          pkg.PkgType,
+			PkgBase:          pkg.PkgBase,
+			Packager:         pkg.Packager,
 			Groups:           pkg.Groups,
 			Conflicts:        relationsToProtos(pkg.Conflicts),
 			Replaces:         relationsToProtos(pkg.Replaces),
@@ -153,14 +154,15 @@ func protosToPkgs(pbPkgs []*pb.PkgInfo) []*PkgInfo {
 			Name:             pbPkg.Name,
 			Reason:           pbPkg.Reason,
 			Version:          pbPkg.Version,
+			Origin:           pbPkg.Origin,
 			Arch:             pbPkg.Arch,
 			License:          pbPkg.License,
 			Url:              pbPkg.Url,
 			Description:      pbPkg.Description,
-			PkgBase:          pbPkg.PkgBase,
 			Validation:       pbPkg.Validation,
-			Packager:         pbPkg.Packager,
 			PkgType:          pbPkg.PkgType,
+			PkgBase:          pbPkg.PkgBase,
+			Packager:         pbPkg.Packager,
 			Groups:           pbPkg.Groups,
 			Conflicts:        protosToRelations(pbPkg.Conflicts),
 			Replaces:         protosToRelations(pbPkg.Replaces),

--- a/internal/pkgdata/packageinfo.go
+++ b/internal/pkgdata/packageinfo.go
@@ -33,14 +33,15 @@ type PkgInfo struct {
 	Name        string
 	Reason      string
 	Version     string
+	Origin      string
 	Arch        string
 	License     string
-	PkgBase     string
 	Description string
 	Url         string
 	Validation  string
-	Packager    string
 	PkgType     string
+	PkgBase     string
+	Packager    string
 
 	Groups []string
 
@@ -74,22 +75,24 @@ func (pkg *PkgInfo) GetString(field consts.FieldType) string {
 		return pkg.Reason
 	case consts.FieldVersion:
 		return pkg.Version
+	case consts.FieldOrigin:
+		return pkg.Origin
 	case consts.FieldArch:
 		return pkg.Arch
 	case consts.FieldLicense:
 		return pkg.License
-	case consts.FieldPkgBase:
-		return pkg.PkgBase
 	case consts.FieldDescription:
 		return pkg.Description
 	case consts.FieldUrl:
 		return pkg.Url
 	case consts.FieldValidation:
 		return pkg.Validation
-	case consts.FieldPackager:
-		return pkg.Packager
 	case consts.FieldPkgType:
 		return pkg.PkgType
+	case consts.FieldPkgBase:
+		return pkg.PkgBase
+	case consts.FieldPackager:
+		return pkg.Packager
 	default:
 		panic("invalid field passed to GetString: " + consts.FieldNameLookup[field])
 	}

--- a/internal/protobuf/pkginfo.pb.go
+++ b/internal/protobuf/pkginfo.pb.go
@@ -173,14 +173,15 @@ type PkgInfo struct {
 	Name             string                 `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
 	Reason           string                 `protobuf:"bytes,4,opt,name=reason,proto3" json:"reason,omitempty"`
 	Version          string                 `protobuf:"bytes,5,opt,name=version,proto3" json:"version,omitempty"`
+	Origin           string                 `protobuf:"bytes,25,opt,name=origin,proto3" json:"origin,omitempty"`
 	Arch             string                 `protobuf:"bytes,6,opt,name=arch,proto3" json:"arch,omitempty"`
 	License          string                 `protobuf:"bytes,7,opt,name=license,proto3" json:"license,omitempty"`
 	Url              string                 `protobuf:"bytes,8,opt,name=url,proto3" json:"url,omitempty"`
 	Description      string                 `protobuf:"bytes,13,opt,name=description,proto3" json:"description,omitempty"`
-	PkgBase          string                 `protobuf:"bytes,14,opt,name=pkg_base,json=pkgBase,proto3" json:"pkg_base,omitempty"`
 	Validation       string                 `protobuf:"bytes,20,opt,name=validation,proto3" json:"validation,omitempty"`
-	Packager         string                 `protobuf:"bytes,21,opt,name=packager,proto3" json:"packager,omitempty"`
 	PkgType          string                 `protobuf:"bytes,24,opt,name=pkg_type,json=pkgType,proto3" json:"pkg_type,omitempty"`
+	PkgBase          string                 `protobuf:"bytes,14,opt,name=pkg_base,json=pkgBase,proto3" json:"pkg_base,omitempty"`
+	Packager         string                 `protobuf:"bytes,21,opt,name=packager,proto3" json:"packager,omitempty"`
 	Groups           []string               `protobuf:"bytes,19,rep,name=groups,proto3" json:"groups,omitempty"`
 	Conflicts        []*Relation            `protobuf:"bytes,12,rep,name=conflicts,proto3" json:"conflicts,omitempty"`
 	Replaces         []*Relation            `protobuf:"bytes,15,rep,name=replaces,proto3" json:"replaces,omitempty"`
@@ -265,6 +266,13 @@ func (x *PkgInfo) GetVersion() string {
 	return ""
 }
 
+func (x *PkgInfo) GetOrigin() string {
+	if x != nil {
+		return x.Origin
+	}
+	return ""
+}
+
 func (x *PkgInfo) GetArch() string {
 	if x != nil {
 		return x.Arch
@@ -293,13 +301,6 @@ func (x *PkgInfo) GetDescription() string {
 	return ""
 }
 
-func (x *PkgInfo) GetPkgBase() string {
-	if x != nil {
-		return x.PkgBase
-	}
-	return ""
-}
-
 func (x *PkgInfo) GetValidation() string {
 	if x != nil {
 		return x.Validation
@@ -307,16 +308,23 @@ func (x *PkgInfo) GetValidation() string {
 	return ""
 }
 
-func (x *PkgInfo) GetPackager() string {
+func (x *PkgInfo) GetPkgType() string {
 	if x != nil {
-		return x.Packager
+		return x.PkgType
 	}
 	return ""
 }
 
-func (x *PkgInfo) GetPkgType() string {
+func (x *PkgInfo) GetPkgBase() string {
 	if x != nil {
-		return x.PkgType
+		return x.PkgBase
+	}
+	return ""
+}
+
+func (x *PkgInfo) GetPackager() string {
+	if x != nil {
+		return x.Packager
 	}
 	return ""
 }
@@ -448,24 +456,25 @@ const file_protobuf_pkginfo_proto_rawDesc = "" +
 	"\boperator\x18\x03 \x01(\x0e2\x13.pkginfo.RelationOpR\boperator\x12\x14\n" +
 	"\x05depth\x18\x04 \x01(\x05R\x05depth\x12\"\n" +
 	"\fproviderName\x18\x05 \x01(\tR\fproviderName\x12\x10\n" +
-	"\x03why\x18\x06 \x01(\tR\x03why\"\x8b\x06\n" +
+	"\x03why\x18\x06 \x01(\tR\x03why\"\xa3\x06\n" +
 	"\aPkgInfo\x12+\n" +
 	"\x11install_timestamp\x18\x11 \x01(\x03R\x10installTimestamp\x12'\n" +
 	"\x0fbuild_timestamp\x18\x10 \x01(\x03R\x0ebuildTimestamp\x12\x12\n" +
 	"\x04size\x18\x02 \x01(\x03R\x04size\x12\x12\n" +
 	"\x04name\x18\x03 \x01(\tR\x04name\x12\x16\n" +
 	"\x06reason\x18\x04 \x01(\tR\x06reason\x12\x18\n" +
-	"\aversion\x18\x05 \x01(\tR\aversion\x12\x12\n" +
+	"\aversion\x18\x05 \x01(\tR\aversion\x12\x16\n" +
+	"\x06origin\x18\x19 \x01(\tR\x06origin\x12\x12\n" +
 	"\x04arch\x18\x06 \x01(\tR\x04arch\x12\x18\n" +
 	"\alicense\x18\a \x01(\tR\alicense\x12\x10\n" +
 	"\x03url\x18\b \x01(\tR\x03url\x12 \n" +
-	"\vdescription\x18\r \x01(\tR\vdescription\x12\x19\n" +
-	"\bpkg_base\x18\x0e \x01(\tR\apkgBase\x12\x1e\n" +
+	"\vdescription\x18\r \x01(\tR\vdescription\x12\x1e\n" +
 	"\n" +
 	"validation\x18\x14 \x01(\tR\n" +
-	"validation\x12\x1a\n" +
-	"\bpackager\x18\x15 \x01(\tR\bpackager\x12\x19\n" +
-	"\bpkg_type\x18\x18 \x01(\tR\apkgType\x12\x16\n" +
+	"validation\x12\x19\n" +
+	"\bpkg_type\x18\x18 \x01(\tR\apkgType\x12\x19\n" +
+	"\bpkg_base\x18\x0e \x01(\tR\apkgBase\x12\x1a\n" +
+	"\bpackager\x18\x15 \x01(\tR\bpackager\x12\x16\n" +
 	"\x06groups\x18\x13 \x03(\tR\x06groups\x12/\n" +
 	"\tconflicts\x18\f \x03(\v2\x11.pkginfo.RelationR\tconflicts\x12-\n" +
 	"\breplaces\x18\x0f \x03(\v2\x11.pkginfo.RelationR\breplaces\x12+\n" +

--- a/protobuf/pkginfo.proto
+++ b/protobuf/pkginfo.proto
@@ -32,14 +32,15 @@ message PkgInfo {
   string name = 3;
   string reason = 4;
   string version = 5;
+  string origin = 25;
   string arch = 6;
   string license = 7;
   string url = 8;
   string description = 13;
-  string pkg_base = 14;
   string validation = 20;
-  string packager = 21;
   string pkg_type = 24;
+  string pkg_base = 14;
+  string packager = 21;
 
   repeated string groups = 19;
 

--- a/qp.1
+++ b/qp.1
@@ -139,8 +139,8 @@ conflicts, replaces, depends, optdepends, required-by, optional-for, provides
 .SH AVAILABLE FIELDS
 Available for use with \fBselect\fR, \fBselect all\fR, etc:
 
-date, build-date, size, name, reason, version, arch, license, pkgbase,  
-description, url, validation, packager, pkgtype, groups, conflicts,  
+date, build-date, size, name, reason, version, origin, arch, license, 
+description, url, validation, pkgbase, pkgtype, packager, groups, conflicts,
 replaces, depends, optdepends, required-by, optional-for, provides
 
 .SH EXAMPLES


### PR DESCRIPTION
Users can now list the origin of packages with `qp select origin`, `qp select all,origin`, `qp select all`, or `qp select default,origin`.

An origin is the package ecosystem or source the package belongs to (e.g., pacman). It reflects which package manager or backend maintains it.

Example:
```
> qp s name,origin
NAME                      ORIGIN
iperf3                    pacman
python-lark-parser        pacman
python-poetry-core        pacman
python-fastjsonschema     pacman
python-typing_extensions  pacman
websocat                  pacman
python-certifi            pacman
python-jmespath           pacman
aws-cli                   pacman
libyaml                   pacman
python-botocore           pacman
python-rsa                pacman
python-s3transfer         pacman
python-docutils           pacman
python-pyasn1             pacman
python-colorama           pacman
python-yaml               pacman
python-awscrt             pacman
rogue                     pacman
qp-git                    pacman
```

Closes #265 