### PR TITLE
Feature: Add description sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ learn about installation [here](#installation)
 | ✓ | build-date sort | ✓ | pkgtype field |
 | ✓ | url query | ✓ | pkgtype sort |
 | ✓ | architecture query | ✓ | groups field |
-| ✓	| conflicts query | - | package description sort |
+| ✓	| conflicts query | ✓ | package description sort |
 | ✓	| regenerate cache option | ✓ | validation query |
 | - | url sort | - | groups sort |
 | ✓ | packager field | ✓ | optional dependency field |
@@ -332,12 +332,12 @@ qp w q has:depends or has:required-by p and not reason=explicit
 - `origin` - the package ecosystem or source the package belongs to (e.g., pacman); reflects which package manager or backend maintains it
 - `arch` - architecture the package was built for (e.g., x86_64, aarch64, any)
 - `license` - package software license
-- `pkgbase` - name of the base package used to group split packages; for non-split packages, it is the same as the package name. 
 - `description` - package description
 - `url` - the URL of the official site of the software being packaged
 - `validation` - package integrity validation method (e.g., sha256, pgp)
 - `pkgtype` - package type (pkg, split, debug, src)
     - ***note**: older packages may have no pkgtype if built before pacman introduced XDATA
+- `pkgbase` - name of the base package used to group split packages; for non-split packages, it is the same as the package name. 
 - `packager` - person/entity who built the package (if available)
 - `groups` - package groups or categories (e.g., base, gnome, xfce4)
 - `conflicts` - list of packages that conflict, or cause problems, with the package
@@ -356,6 +356,7 @@ qp w q has:depends or has:required-by p and not reason=explicit
 - `name`
 - `arch`
 - `license`
+- `description`
 - `validation`
 - `pkgtype`
 - `pkgbase`

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -36,9 +36,9 @@ func GetComparator(field consts.FieldType, asc bool) (PkgComparator, error) {
 		return makeComparator(func(p *PkgInfo) int64 { return p.GetInt(field) }, asc), nil
 
 	case consts.FieldName, consts.FieldLicense,
-		consts.FieldPkgType, consts.FieldPkgBase,
-		consts.FieldPackager, consts.FieldArch,
-		consts.FieldValidation:
+		consts.FieldDescription, consts.FieldPkgType,
+		consts.FieldPkgBase, consts.FieldPackager,
+		consts.FieldArch, consts.FieldValidation:
 		return makeComparator(func(p *PkgInfo) string {
 			return strings.ToLower(p.GetString(field))
 		}, asc), nil

--- a/qp.1
+++ b/qp.1
@@ -44,7 +44,7 @@ Existence check — \fBhas:field\fR or \fBno:field\fR
 
 .TP
 .B order <field>:<direction>, o <..>
-Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBsize\fR, \fBname\fR, \fBarch\fR, \fBlicense\fR, \fBpkgbase\fR, \fBpkgtype\fR, \fBvalidation\fR, \fBpackager\fR
+Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBsize\fR, \fBname\fR, \fBarch\fR, \fBlicense\fR, \fBdescription\fR, \fBpkgbase\fR, \fBpkgtype\fR, \fBvalidation\fR, \fBpackager\fR
 
 .TP
 .B limit <number>, l <number>


### PR DESCRIPTION
Users can now sort by description with `qp order description`, `qp order description:asc`, or `qp order description:desc`.

Example:
```
> qp s name,description o description
NAME          DESCRIPTION
libice        X11 Inter-Client Exchange library
libxkbfile    X11 keyboard file manipulation library
libxfixes     X11 miscellaneous 'fixes' extension library
libxext       X11 miscellaneous extensions library
libxmu        X11 miscellaneous micro-utility library
libpciaccess  X11 PCI access library
libxrandr     X11 RandR extension library
libxss        X11 Screen Saver extension library
libsm         X11 Session Management library
libxt         X11 toolkit intrinsics library
libxv         X11 Video extension library
libxxf86vm    X11 XFree86 video mode extension library
libxinerama   X11 Xinerama extension library
libxml2       XML C parser and toolkit
libxslt       XML stylesheet transformation library
xcb-proto     XML-XCB protocol descriptions
xvidcore      XviD is an open source MPEG-4 video codec
libyaml       YAML 1.1 library
yay-bin       Yet another yogurt. Pacman wrapper and AUR helper written in go. Pre-compiled.
zstd          Zstandard - Fast real-time compression algorithm
```

Closes #255