### PR TITLE
Feature: Add reason sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ learn about installation [here](#installation)
 | - | optional-for sort | - | provides sort |
 | ✓ | validation field | ✓ | validation sort |
 | ✓ | packager sort | ✓ | architecture sort |
-| - | reason sort | - |version sort |
+| ✓ | reason sort | - |version sort |
 | ✓ | reverse optional dependencies field (optional for) | - | optdepends installation indicator |
 | ✓ | optional-for query | - | separate field for optdepends reason |
 | ✓ | fuzzy/strict querying | ✓ | existence querying |
@@ -354,6 +354,7 @@ qp w q has:depends or has:required-by p and not reason=explicit
 - `build-date`
 - `size`
 - `name`
+- `reason`
 - `arch`
 - `license`
 - `description`

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -35,7 +35,7 @@ func GetComparator(field consts.FieldType, asc bool) (PkgComparator, error) {
 	case consts.FieldDate, consts.FieldBuildDate, consts.FieldSize:
 		return makeComparator(func(p *PkgInfo) int64 { return p.GetInt(field) }, asc), nil
 
-	case consts.FieldName, consts.FieldLicense,
+	case consts.FieldName, consts.FieldReason, consts.FieldLicense,
 		consts.FieldDescription, consts.FieldPkgType,
 		consts.FieldPkgBase, consts.FieldPackager,
 		consts.FieldArch, consts.FieldValidation:

--- a/qp.1
+++ b/qp.1
@@ -44,7 +44,7 @@ Existence check — \fBhas:field\fR or \fBno:field\fR
 
 .TP
 .B order <field>:<direction>, o <..>
-Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBsize\fR, \fBname\fR, \fBarch\fR, \fBlicense\fR, \fBdescription\fR, \fBpkgbase\fR, \fBpkgtype\fR, \fBvalidation\fR, \fBpackager\fR
+Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBsize\fR, \fBname\fR, \fBreason\fR, \fBarch\fR, \fBlicense\fR, \fBdescription\fR, \fBpkgbase\fR, \fBpkgtype\fR, \fBvalidation\fR, \fBpackager\fR
 
 .TP
 .B limit <number>, l <number>


### PR DESCRIPTION
Users can now sort by reason with `qp order reason`, `qp order reason:asc`, or `qp order reason:desc`.

Example:
```
> qp s name,reason o reason
NAME             REASON
grub             explicit
iperf3           explicit
hyperfine        explicit
go               explicit
zellij           explicit
yazi             explicit
wget             explicit
which            explicit
websocat         explicit
yay-bin          explicit
vim              explicit
src-cli-bin      explicit
vi               explicit
xclip            explicit
unzip            explicit
tree             explicit
timg             explicit
zsh              explicit
zsh-completions  explicit
sudo             explicit
```

Closes #256 