### PR TITLE
Feature: Add URL sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ learn about installation [here](#installation)
 | ✓ | architecture query | ✓ | groups field |
 | ✓	| conflicts query | ✓ | package description sort |
 | ✓	| regenerate cache option | ✓ | validation query |
-| - | url sort | - | groups sort |
+| ✓ | url sort | - | groups sort |
 | ✓ | packager field | ✓ | optional dependency field |
 | ✓ | sort by size on disk | - | conflicts sort |
 | - | optional-for sort | - | provides sort |
@@ -358,6 +358,7 @@ qp w q has:depends or has:required-by p and not reason=explicit
 - `arch`
 - `license`
 - `description`
+- `url`
 - `validation`
 - `pkgtype`
 - `pkgbase`

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -35,10 +35,10 @@ func GetComparator(field consts.FieldType, asc bool) (PkgComparator, error) {
 	case consts.FieldDate, consts.FieldBuildDate, consts.FieldSize:
 		return makeComparator(func(p *PkgInfo) int64 { return p.GetInt(field) }, asc), nil
 
-	case consts.FieldName, consts.FieldReason, consts.FieldLicense,
-		consts.FieldDescription, consts.FieldPkgType,
-		consts.FieldPkgBase, consts.FieldPackager,
-		consts.FieldArch, consts.FieldValidation:
+	case consts.FieldName, consts.FieldReason, consts.FieldArch,
+		consts.FieldLicense, consts.FieldDescription, consts.FieldUrl,
+		consts.FieldValidation, consts.FieldPkgType, consts.FieldPkgBase,
+		consts.FieldPackager:
 		return makeComparator(func(p *PkgInfo) string {
 			return strings.ToLower(p.GetString(field))
 		}, asc), nil

--- a/qp.1
+++ b/qp.1
@@ -44,7 +44,7 @@ Existence check — \fBhas:field\fR or \fBno:field\fR
 
 .TP
 .B order <field>:<direction>, o <..>
-Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBsize\fR, \fBname\fR, \fBreason\fR, \fBarch\fR, \fBlicense\fR, \fBdescription\fR, \fBpkgbase\fR, \fBpkgtype\fR, \fBvalidation\fR, \fBpackager\fR
+Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBsize\fR, \fBname\fR, \fBreason\fR, \fBarch\fR, \fBlicense\fR, \fBdescription\fR, \fBurl\fR, \fBpkgbase\fR, \fBpkgtype\fR, \fBvalidation\fR, \fBpackager\fR
 
 .TP
 .B limit <number>, l <number>


### PR DESCRIPTION
Users can now sort by URL with `qp order url`, `qp order url:asc`, or `qp order url:desc`.

Example:
```
> qp s name,url o url
NAME              URL
flac              https://xiph.org/flac/
libxkbcommon-x11  https://xkbcommon.org/
libxkbcommon      https://xkbcommon.org/
libxi             https://xorg.freedesktop.org
libxxf86vm        https://xorg.freedesktop.org/
libxt             https://xorg.freedesktop.org/
libxv             https://xorg.freedesktop.org/
libxcomposite     https://xorg.freedesktop.org/
libxinerama       https://xorg.freedesktop.org/
libxft            https://xorg.freedesktop.org/
libxfixes         https://xorg.freedesktop.org/
libxdamage        https://xorg.freedesktop.org/
libxau            https://xorg.freedesktop.org/
libxrandr         https://xorg.freedesktop.org/
libice            https://xorg.freedesktop.org/
libxrender        https://xorg.freedesktop.org/
libxshmfence      https://xorg.freedesktop.org/
libsm             https://xorg.freedesktop.org/
xorgproto         https://xorg.freedesktop.org/
zellij            https://zellij.dev
```

Closes #258 