### PR TITLE
Feature: Add version sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ learn about installation [here](#installation)
 | - | optional-for sort | - | provides sort |
 | ✓ | validation field | ✓ | validation sort |
 | ✓ | packager sort | ✓ | architecture sort |
-| ✓ | reason sort | - |version sort |
+| ✓ | reason sort | ✓ |version sort |
 | ✓ | reverse optional dependencies field (optional for) | - | optdepends installation indicator |
 | ✓ | optional-for query | - | separate field for optdepends reason |
 | ✓ | fuzzy/strict querying | ✓ | existence querying |
@@ -355,6 +355,7 @@ qp w q has:depends or has:required-by p and not reason=explicit
 - `size`
 - `name`
 - `reason`
+- `version`
 - `arch`
 - `license`
 - `description`

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -35,10 +35,10 @@ func GetComparator(field consts.FieldType, asc bool) (PkgComparator, error) {
 	case consts.FieldDate, consts.FieldBuildDate, consts.FieldSize:
 		return makeComparator(func(p *PkgInfo) int64 { return p.GetInt(field) }, asc), nil
 
-	case consts.FieldName, consts.FieldReason, consts.FieldArch,
-		consts.FieldLicense, consts.FieldDescription, consts.FieldUrl,
-		consts.FieldValidation, consts.FieldPkgType, consts.FieldPkgBase,
-		consts.FieldPackager:
+	case consts.FieldName, consts.FieldReason, consts.FieldVersion,
+		consts.FieldArch, consts.FieldLicense, consts.FieldDescription,
+		consts.FieldUrl, consts.FieldValidation, consts.FieldPkgType,
+		consts.FieldPkgBase, consts.FieldPackager:
 		return makeComparator(func(p *PkgInfo) string {
 			return strings.ToLower(p.GetString(field))
 		}, asc), nil

--- a/qp.1
+++ b/qp.1
@@ -44,7 +44,7 @@ Existence check — \fBhas:field\fR or \fBno:field\fR
 
 .TP
 .B order <field>:<direction>, o <..>
-Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBsize\fR, \fBname\fR, \fBreason\fR, \fBarch\fR, \fBlicense\fR, \fBdescription\fR, \fBurl\fR, \fBpkgbase\fR, \fBpkgtype\fR, \fBvalidation\fR, \fBpackager\fR
+Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBsize\fR, \fBname\fR, \fBreason\fR, \fBversion\fR, \fBarch\fR, \fBlicense\fR, \fBdescription\fR, \fBurl\fR, \fBpkgbase\fR, \fBpkgtype\fR, \fBvalidation\fR, \fBpackager\fR
 
 .TP
 .B limit <number>, l <number>


### PR DESCRIPTION
Users can now sort by version with `qp order version`, `qp order version:asc`, or `qp order version:desc`.

Example:
```
> qp s name,version o version
NAME                   VERSION
ncurses                6.5-3
oniguruma              6.9.10-1
pacman                 7.0.0.r6.gc685ae6-2
imagemagick            7.1.1.47-1
texinfo                7.2-1
libplacebo             7.349.0-4
icu                    76.1-1
python-click           8.1.8-1
curl                   8.12.1-1
readline               8.2.013-1
python-setuptools-scm  8.2.1-1
gc                     8.2.8-2
nano                   8.3-1
pcre                   8.45-4
vim-runtime            9.1.1236-1
vim                    9.1.1236-1
coreutils              9.6-4
openssh                9.9p2-1
libyuv                 r2426+464c51a03-1
vapoursynth            R70-2
```

Closes #257 