### PR TITLE
Feature: Add origin sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ learn about installation [here](#installation)
 | ✓ | existence querying | - | depth querying |
 | ✓ | pkgtype query | ✓ | optdepends query |
 | ✓ | packager query | ✓ | origin field |
-| - | origin sort | - | origin query |
+| ✓ | origin sort | - | origin query |
 | ✓ | command-based syntax | ✓ | full boolean logic |
 | ✓ | abstract syntax tree | ✓ | directed acyclical graph for filtering |
 | - | user-defined macros | ✓ | parentetical (grouping) logic |
@@ -356,6 +356,7 @@ qp w q has:depends or has:required-by p and not reason=explicit
 - `name`
 - `reason`
 - `version`
+- `origin`
 - `arch`
 - `license`
 - `description`

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -38,7 +38,7 @@ func GetComparator(field consts.FieldType, asc bool) (PkgComparator, error) {
 	case consts.FieldName, consts.FieldReason, consts.FieldVersion,
 		consts.FieldArch, consts.FieldLicense, consts.FieldDescription,
 		consts.FieldUrl, consts.FieldValidation, consts.FieldPkgType,
-		consts.FieldPkgBase, consts.FieldPackager:
+		consts.FieldPkgBase, consts.FieldPackager, consts.FieldOrigin:
 		return makeComparator(func(p *PkgInfo) string {
 			return strings.ToLower(p.GetString(field))
 		}, asc), nil

--- a/qp.1
+++ b/qp.1
@@ -44,7 +44,7 @@ Existence check — \fBhas:field\fR or \fBno:field\fR
 
 .TP
 .B order <field>:<direction>, o <..>
-Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBsize\fR, \fBname\fR, \fBreason\fR, \fBversion\fR, \fBarch\fR, \fBlicense\fR, \fBdescription\fR, \fBurl\fR, \fBpkgbase\fR, \fBpkgtype\fR, \fBvalidation\fR, \fBpackager\fR
+Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBsize\fR, \fBname\fR, \fBreason\fR, \fBversion\fR, \fBorigin\fR, \fBarch\fR, \fBlicense\fR, \fBdescription\fR, \fBurl\fR, \fBpkgbase\fR, \fBpkgtype\fR, \fBvalidation\fR, \fBpackager\fR
 
 .TP
 .B limit <number>, l <number>


### PR DESCRIPTION
Users can now sort by origin with `qp order origin`, `qp order origin:asc`, or `qp order origin:desc`.

```
> qp s name,origin o origin
NAME                         ORIGIN
xkeyboard-config             pacman
xvidcore                     pacman
xorgproto                    pacman
xxhash                       pacman
xz                           pacman
yay-bin                      pacman
yazi                         pacman
yyjson                       pacman
zellij                       pacman
zimg                         pacman
zeromq                       pacman
zlib                         pacman
zoxide                       pacman
zsh-completions              pacman
zstd                         pacman
adwaita-fonts                pacman
zsh                          pacman
adwaita-icon-theme           pacman
adobe-source-code-pro-fonts  pacman
adwaita-icon-theme-legacy    pacman
```

Closes #272 