### PR TITLE
Fix: Deb origin symlink licensing

### DIFF
--- a/internal/origins/deb/parser.go
+++ b/internal/origins/deb/parser.go
@@ -113,9 +113,7 @@ func parseStatusBlock(block []byte, reasonMap map[string]string, origin string) 
 	if err := getInstallTime(pkg); err != nil {
 		collected = append(collected, err)
 	}
-	if err := extractLicense(pkg); err != nil {
-		collected = append(collected, err)
-	}
+	_ = extractLicense(pkg)
 
 	pkg.Origin = origin
 

--- a/internal/pipeline/phase/pipeline.go
+++ b/internal/pipeline/phase/pipeline.go
@@ -29,7 +29,7 @@ func NewPipeline(
 ) *Pipeline {
 	modTime, err := origin.SourceModified()
 	if err != nil {
-		out.WriteLine(fmt.Sprintf("Warning: failed to get mod time for origin %s", origin.Name()))
+		out.WriteLine(fmt.Sprintf("WARNING: failed to get mod time for origin %s", origin.Name()))
 		modTime = time.Now().Unix()
 	}
 

--- a/internal/pipeline/phase/steps.go
+++ b/internal/pipeline/phase/steps.go
@@ -40,10 +40,10 @@ func (p *Pipeline) fetchStep(
 
 	pkgs, err := p.Origin.Load()
 	if err != nil {
-		out.WriteLine(fmt.Sprintf(
-			"Warning: failed to fetch packages for origin %s: %v",
+		err = fmt.Errorf(
+			"failed to fetch packages for origin: %v",
 			p.Origin.Name(), err,
-		))
+		)
 		return nil, err
 	}
 


### PR DESCRIPTION
Packages like `openssl` have symlinked copyright notices that can be dead (i.e. `libssl3` is the symlink but the actual notice is at `libssl3t64`). We now both resolve the symlink and glob the suffix to ensure we can find it.