### PR TITLE
Feature: Add deprecation notice for flag syntax

### DIFF
--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -122,6 +122,7 @@ func markHiddenFlags() {
 
 	for _, flag := range hiddenFlags {
 		_ = pflag.CommandLine.MarkHidden(flag)
+		pflag.CommandLine.MarkDeprecated(flag, "please use command syntax instead. Run `man qp` for more info. Flag syntax will be removed in the future.")
 	}
 }
 


### PR DESCRIPTION
Flag syntax will be deprecated at the very latest by the end of the month. Until then, this warning will show.