### PR TITLE
Feature: Improve reason resolution in minimal envs

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,11 +7,6 @@ import (
 	"qp/internal/syntax"
 )
 
-const (
-	ReasonExplicit   = "explicit"
-	ReasonDependency = "dependency"
-)
-
 type Config struct {
 	Limit             int
 	ShowHelp          bool

--- a/internal/config/legacy_query_parser.go
+++ b/internal/config/legacy_query_parser.go
@@ -97,7 +97,7 @@ func convertLegacyQueries(
 	if explicitOnly {
 		queries = append(queries, query.FieldQuery{
 			Field:  consts.FieldReason,
-			Target: ReasonExplicit,
+			Target: consts.ReasonExplicit,
 			Match:  consts.MatchFuzzy,
 		})
 	}
@@ -105,7 +105,7 @@ func convertLegacyQueries(
 	if dependenciesOnly {
 		queries = append(queries, query.FieldQuery{
 			Field:  consts.FieldReason,
-			Target: ReasonDependency,
+			Target: consts.ReasonDependency,
 			Match:  consts.MatchFuzzy,
 		})
 	}

--- a/internal/consts/reasons.go
+++ b/internal/consts/reasons.go
@@ -1,0 +1,6 @@
+package consts
+
+const (
+	ReasonExplicit   = "explicit"
+	ReasonDependency = "dependency"
+)

--- a/internal/origins/deb/constants.go
+++ b/internal/origins/deb/constants.go
@@ -1,6 +1,7 @@
 package deb
 
 const (
+	fieldStatus        = "Status"
 	fieldInstalledSize = "Installed-Size"
 	fieldPackage       = "Package"
 	fieldVersion       = "Version"

--- a/internal/origins/deb/fetch.go
+++ b/internal/origins/deb/fetch.go
@@ -7,7 +7,7 @@ import (
 	"qp/internal/pkgdata"
 )
 
-func fetchPackages(origin string) ([]*pkgdata.PkgInfo, error) {
+func fetchPackages(origin string, reasonMap map[string]string) ([]*pkgdata.PkgInfo, error) {
 	file, err := os.Open(dpkgPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open status file: %w", err)
@@ -19,5 +19,5 @@ func fetchPackages(origin string) ([]*pkgdata.PkgInfo, error) {
 		return nil, fmt.Errorf("failed to read status file: %w", err)
 	}
 
-	return parseStatusFile(data, origin)
+	return parseStatusFile(data, origin, reasonMap)
 }

--- a/internal/origins/pacman/parser.go
+++ b/internal/origins/pacman/parser.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"qp/internal/consts"
 	"qp/internal/pkgdata"
 	"strconv"
 	"strings"
@@ -115,9 +116,9 @@ func applySingleLineField(pkg *pkgdata.PkgInfo, field string, value string) erro
 		pkg.Name = value
 
 	case fieldReason:
-		pkg.Reason = "explicit"
+		pkg.Reason = consts.ReasonExplicit
 		if value == "1" {
-			pkg.Reason = "dependency"
+			pkg.Reason = consts.ReasonDependency
 		}
 
 	case fieldVersion:


### PR DESCRIPTION
Dependencies are inferred when no `/var/lib/apt/extended_states` files exists (e.g. docker containers, `dpkg` only environments). The `system` reason has been dropped to be more in line with the pacman driver as well as to remove potentially misleading output.