### PR TITLE
Feature: Add conflicts sort

### DIFF
--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -16,7 +16,7 @@ const ConcurrentSortThreshold = 500
 type PkgComparator func(a *PkgInfo, b *PkgInfo) bool
 
 type ordered interface {
-	~int64 | ~string
+	~int64 | ~string | ~int
 }
 
 func makeComparator[T ordered](
@@ -41,6 +41,11 @@ func GetComparator(field consts.FieldType, asc bool) (PkgComparator, error) {
 		consts.FieldPkgBase, consts.FieldPackager, consts.FieldOrigin:
 		return makeComparator(func(p *PkgInfo) string {
 			return strings.ToLower(p.GetString(field))
+		}, asc), nil
+
+	case consts.FieldConflicts:
+		return makeComparator(func(p *PkgInfo) int {
+			return len(p.GetRelations(field))
 		}, asc), nil
 
 	default:


### PR DESCRIPTION
Users can now sort by the length of conflicts with `qp order conflicts`, `qp order conflicts:asc`, or `qp order conflicts:desc`.

```
> qp s name,conflicts o conflicts
NAME                    CONFLICTS
yay-bin                 yay
util-linux-libs         libutil-linux
tinysparql              tracker3<=3.7.3-2
systemd-libs            libsystemd
systemd-sysvcompat      sysvinit
src-cli-bin             sourcegraph-cli
at-spi2-core            at-spi2-atk<=2.38.0-2, atk<=2.38.0-2
libverto                krb5<1.19.3-2, libverto-libevent<0.3.2-4
iputils                 arping, netkit-base
qp-git                  qp, qp-bin
procps-ng               procps, sysvinit-tools
poppler                 poppler-qt3<25.03.0, poppler-qt4<25.03.0
vim                     gvim, vim-minimal
util-linux              hardlink, rfkill
ttf-nerd-fonts-symbols  ttf-nerd-fonts-symbols-1000-em, ttf-nerd-fonts-symbols-2048-em
rust                    cargo, rust-docs<1:1.56.1-3, rustfmt
mesa                    libva-mesa-driver<1:24.2.7-1, mesa-libgl<17.0.1-2, mesa-vdpau<1:24.2.7-1
x264                    libx264, libx264-10bit, libx264-all
systemd                 nss-myhostname, systemd-tools, udev
grub                    grub-bios, grub-common, grub-efi-aarch64, grub-emu, grub-legacy
```

Closes #259 