### PR TITLE
Feature: Add depends sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ learn about installation [here](#installation)
 | ✓ | optional full timestamp | ✓ | package description field |
 | ✓  | groups query | – | streaming pipeline |
 | – | short-args for queries | – | key/value output |
-| ✓ | package base query | – | required-by sort |
+| ✓ | package base query | ✓ | required-by sort |
 | – | optdepends sort | – | depends sort |
 | ✓ | build-date field | ✓ | build-date query |
 | ✓ | build-date sort | ✓ | pkgtype field |
@@ -386,6 +386,7 @@ qp w q has:depends or has:required-by p and not reason=explicit
 - `pkgbase`
 - `packager`
 - `conflicts`
+- `depends`
 
 ### JSON output
 

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -43,9 +43,9 @@ func GetComparator(field consts.FieldType, asc bool) (PkgComparator, error) {
 			return strings.ToLower(p.GetString(field))
 		}, asc), nil
 
-	case consts.FieldConflicts:
+	case consts.FieldConflicts, consts.FieldDepends:
 		return makeComparator(func(p *PkgInfo) int {
-			return len(p.GetRelations(field))
+			return len(GetRelationsByDepth(p.GetRelations(field), 1))
 		}, asc), nil
 
 	default:

--- a/qp.1
+++ b/qp.1
@@ -44,7 +44,7 @@ Existence check — \fBhas:field\fR or \fBno:field\fR
 
 .TP
 .B order <field>:<direction>, o <..>
-Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBsize\fR, \fBname\fR, \fBreason\fR, \fBversion\fR, \fBorigin\fR, \fBarch\fR, \fBlicense\fR, \fBdescription\fR, \fBurl\fR, \fBpkgbase\fR, \fBpkgtype\fR, \fBvalidation\fR, \fBpackager\fR
+Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBsize\fR, \fBname\fR, \fBreason\fR, \fBversion\fR, \fBorigin\fR, \fBarch\fR, \fBlicense\fR, \fBdescription\fR, \fBurl\fR, \fBpkgbase\fR, \fBpkgtype\fR, \fBvalidation\fR, \fBpackager\fR, \fBconflicts\fR, \fBdepends\fR
 
 .TP
 .B limit <number>, l <number>


### PR DESCRIPTION
Users can now sort by the length of depends with `qp order depends`, `qp order depends:asc`, or `qp order depends:desc`.

```
> qp select name,depends order depends
NAME                   DEPENDS
neovim                 libluv, libutf8proc, libuv, libvterm>=0.3.3, lua51-lpeg, luajit, msgpack-c, tree-sitter, tree-sitter-c, tree-sitter-lua, tree-sitter-markdown, tree-sitter-query, tree-sitter-vim, tree-sitter-vimdoc, unibilium
mkinitcpio             awk → gawk, bash, binutils, coreutils, diffutils, filesystem, findutils, grep, gzip, kmod, libarchive, mkinitcpio-busybox, systemd, util-linux, zstd
poppler                cairo, curl, fontconfig, freetype2, gcc-libs, glibc, gpgme, lcms2, libjpeg-turbo, libpng, libtiff, nspr, nss, openjpeg2, zlib
pipewire               dbus, gcc-libs, glib2, glibc, libdbus-1.so=3-64 → dbus, libglib-2.0.so=0-64 → glib2, libncursesw.so=6-64 → ncurses, libpipewire=1:1.4.1-1, libpipewire-0.3.so=0-64 → libpipewire, libreadline.so=8-64 → readline, libsystemd.so=0-64 → systemd-libs, libudev.so=1-64 → systemd-libs, ncurses, readline, systemd-libs
libarchive             acl, bzip2, glibc, libacl.so=1-64 → acl, libbz2.so=1.0-64 → bzip2, libcrypto.so=3-64 → openssl, liblzma.so=5-64 → xz, libxml2, libxml2.so=16-64 → libxml2, libz.so=1-64 → zlib, libzstd.so=1-64 → zstd, lz4, openssl, xz, zlib, zstd
libsoup3               brotli, glib-networking, glib2, glibc, krb5, libbrotlidec.so=1-64 → brotli, libgio-2.0.so=0-64 → glib2, libglib-2.0.so=0-64 → glib2, libgobject-2.0.so=0-64 → glib2, libgssapi_krb5.so=2-64 → krb5, libnghttp2, libpsl, libpsl.so=5-64 → libpsl, libsysprof-capture, sqlite, zlib
mesa                   expat, gcc-libs, glibc, libdrm, libelf, libglvnd, libx11, libxcb, libxext, libxshmfence, libxxf86vm, llvm-libs, lm_sensors, spirv-tools, wayland, zlib, zstd
imagemagick            bzip2, cairo, fftw, fontconfig, freetype2, gcc-libs, glib2, glibc, lcms2, liblqr, libltdl → libtool, libpng, libraqm, libxext, libxml2, xz, zlib
util-linux             coreutils, file, glibc, libcap-ng, libcrypt.so=2-64 → libxcrypt, libmagic.so=1-64 → file, libncursesw.so=6-64 → ncurses, libsystemd.so=0-64 → systemd-libs, libudev.so=1-64 → systemd-libs, libxcrypt, ncurses, pam, readline, shadow, systemd-libs, util-linux-libs=2.41, zlib
gst-plugins-base-libs  glib2, glibc, graphene, gstreamer=1.26.0-2, iso-codes, libdrm, libglvnd, libgudev, libjpeg-turbo, libpng, libx11, libxcb, libxext, libxi, libxv, mesa, orc, wayland, zlib
gst-plugins-bad-libs   gcc-libs, glib2, glibc, gst-plugins-base-libs=1.26.0-2, gstreamer=1.26.0-2, libdrm, libglvnd, libgudev, libnice, libusb, libva, libx11, libxcb, libxkbcommon, libxkbcommon-x11, mesa, orc, vulkan-icd-loader, wayland, zlib
gnupg                  bzip2, glibc, gnutls, libassuan, libassuan.so=9-64 → libassuan, libbz2.so=1.0-64 → bzip2, libgcrypt, libgpg-error, libksba, libldap, libnpth.so=0-64 → npth, libreadline.so=8-64 → readline, libusb, npth, pinentry, readline, sh → bash, sqlite, tpm2-tss, zlib
ibus                   at-spi2-core, cairo, dconf, gdk-pixbuf2, glib2, graphene, gtk3, gtk4, hicolor-icon-theme, libdbusmenu-glib, libdbusmenu-gtk3, libibus=1.5.31, libnotify, libx11, libxfixes, libxi, libxkbcommon, pango, python, python-gobject, wayland
curl                   brotli, ca-certificates → ca-certificates-utils, krb5, libbrotlidec.so=1-64 → brotli, libcrypto.so=3-64 → openssl, libgssapi_krb5.so=2-64 → krb5, libidn2, libidn2.so=0-64 → libidn2, libnghttp2, libnghttp2.so=14-64 → libnghttp2, libnghttp3, libnghttp3.so=9-64 → libnghttp3, libpsl, libpsl.so=5-64 → libpsl, libssh2, libssh2.so=1-64 → libssh2, libssl.so=3-64 → openssl, libz.so=1-64 → zlib, libzstd.so=1-64 → zstd, openssl, zlib, zstd
base-devel             archlinux-keyring, autoconf, automake, binutils, bison, debugedit, fakeroot, file, findutils, flex, gawk, gcc, gettext, grep, groff, gzip, libtool, m4, make, pacman, patch, pkgconf, sed, sudo, texinfo, which
base                   archlinux-keyring, bash, bzip2, coreutils, file, filesystem, findutils, gawk, gcc-libs, gettext, glibc, grep, gzip, iproute2, iputils, licenses, pacman, pciutils, procps-ng, psmisc, sed, shadow, systemd, systemd-sysvcompat, tar, util-linux, xz
systemd                acl, audit, bash, cryptsetup, dbus, dbus-units → dbus-broker-units, hwdata, kbd, kmod, libacl.so=1-64 → acl, libaudit.so=1-64 → audit, libblkid.so=1-64 → util-linux-libs, libcap, libcap.so=2-64 → libcap, libcrypt.so=2-64 → libxcrypt, libcrypto.so=3-64 → openssl, libcryptsetup.so=12-64 → cryptsetup, libelf, libgcrypt, libidn2, libmount.so=1-64 → util-linux-libs, libseccomp, libseccomp.so=2-64 → libseccomp, libssl.so=3-64 → openssl, libxcrypt, lz4, openssl, pam, pcre2, systemd-libs=257.4, util-linux, xz
gtk3                   adwaita-icon-theme, at-spi2-core, cairo, cantarell-fonts, dconf, desktop-file-utils, fontconfig, fribidi, gdk-pixbuf2, glib2, glibc, gtk-update-icon-cache, harfbuzz, iso-codes, libcloudproviders, libcolord, libcups, libegl → libglvnd, libepoxy, libgl → libglvnd, librsvg, libx11, libxcomposite, libxcursor, libxdamage, libxext, libxfixes, libxi, libxinerama, libxkbcommon, libxrandr, libxrender, pango, shared-mime-info, tinysparql, wayland
gtk4                   adwaita-icon-theme, at-spi2-core, bash, cairo, cantarell-fonts, dconf, desktop-file-utils, fontconfig, fribidi, gcc-libs, gdk-pixbuf2, glib2, glibc, graphene, gst-plugins-bad-libs, gst-plugins-base-libs, gstreamer, gtk-update-icon-cache, harfbuzz, iso-codes, libcloudproviders, libcolord, libcups, libegl → libglvnd, libepoxy, libgl → libglvnd, libjpeg-turbo, libpng, librsvg, libtiff, libx11, libxcursor, libxdamage, libxext, libxfixes, libxi, libxinerama, libxkbcommon, libxrandr, libxrender, pango, shared-mime-info, tinysparql, vulkan-icd-loader, wayland
ffmpeg                 alsa-lib, bzip2, cairo, dav1d, fontconfig, freetype2, fribidi, glib2, glibc, glslang, gmp, gnutls, gsm, harfbuzz, jack → jack2, lame, libass, libass.so=9-64 → libass, libavc1394, libbluray, libbluray.so=2-64 → libbluray, libbs2b, libbs2b.so=0-64 → libbs2b, libdav1d.so=7-64 → dav1d, libdrm, libdvdnav, libdvdread, libfreetype.so=6-64 → freetype2, libgl → libglvnd, libharfbuzz.so=0-64 → harfbuzz, libiec61883, libjxl, libjxl.so=0.11-64 → libjxl, libmodplug, libopenmpt, libopenmpt.so=0-64 → libopenmpt, libplacebo, libplacebo.so=349-64 → libplacebo, libpulse, libraw1394, librsvg, librsvg-2.so=2-64 → librsvg, librubberband.so=3-64 → rubberband, libsoxr, libssh, libtheora, libva, libva-drm.so=2-64 → libva, libva-x11.so=2-64 → libva, libva.so=2-64 → libva, libvdpau, libvidstab.so=1.2-64 → vid.stab, libvorbis, libvorbis.so=0-64 → libvorbis, libvorbisenc.so=2-64 → libvorbis, libvpx, libvpx.so=9-64 → libvpx, libwebp, libx11, libx264.so=164-64 → x264, libx265.so=212-64 → x265, libxcb, libxext, libxml2, libxv, libxvidcore.so=4-64 → xvidcore, libzimg.so=2-64 → zimg, libzmq.so=5-64 → zeromq, ocl-icd, opencore-amr, openjpeg2, opus, rubberband, sdl2 → sdl2-compat, snappy, speex, srt, v4l-utils, vapoursynth, vid.stab, vulkan-icd-loader, x264, x265, xvidcore, xz, zeromq, zimg, zlib
```

Closes #290 