### PR TITLE
Refactor: Extract worker pool for all origins

### DIFF
--- a/internal/origins/drivers/pacman/fetch.go
+++ b/internal/origins/drivers/pacman/fetch.go
@@ -1,13 +1,11 @@
 package pacman
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"qp/internal/origins/worker"
 	"qp/internal/pkgdata"
-	"runtime"
-	"sync"
 )
 
 func fetchPackages(origin string) ([]*pkgdata.PkgInfo, error) {
@@ -17,75 +15,32 @@ func fetchPackages(origin string) ([]*pkgdata.PkgInfo, error) {
 	}
 
 	numPkgs := len(pkgPaths)
-
-	var wg sync.WaitGroup
 	descPathChan := make(chan string, numPkgs)
-	pkgChan := make(chan *pkgdata.PkgInfo, numPkgs)
-	errorsChan := make(chan error, numPkgs)
 
-	// fun fact: NumCPU() does account for hyperthreading
-	numWorkers := getWorkerCount(runtime.NumCPU(), numPkgs)
-
-	for range numWorkers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for descPath := range descPathChan {
-				pkg, err := parseDescFile(descPath)
-				if err != nil {
-					errorsChan <- err
-					continue
-				}
-
-				pkg.Origin = origin
-				pkgChan <- pkg
+	go func() {
+		for _, packagePath := range pkgPaths {
+			if packagePath.IsDir() {
+				descPath := filepath.Join(PacmanDbPath, packagePath.Name(), "desc")
+				descPathChan <- descPath
 			}
-		}()
-	}
-
-	for _, packagePath := range pkgPaths {
-		if packagePath.IsDir() {
-			descPath := filepath.Join(PacmanDbPath, packagePath.Name(), "desc")
-			descPathChan <- descPath
-		}
-	}
-
-	close(descPathChan)
-
-	wg.Wait()
-	close(pkgChan)
-	close(errorsChan)
-
-	if len(errorsChan) > 0 {
-		var collectedErrors []error
-
-		for err := range errorsChan {
-			collectedErrors = append(collectedErrors, err)
 		}
 
-		return nil, errors.Join(collectedErrors...)
-	}
+		close(descPathChan)
+	}()
 
-	pkgs := make([]*pkgdata.PkgInfo, 0, numPkgs)
-	for pkg := range pkgChan {
-		pkgs = append(pkgs, pkg)
-	}
+	return worker.RunWorkers(
+		descPathChan,
+		func(path string) (*pkgdata.PkgInfo, error) {
+			pkg, err := parseDescFile(path)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse %s: %w", path, err)
+			}
 
-	return pkgs, nil
-}
+			pkg.Origin = origin
 
-func getWorkerCount(numCPUs int, numFiles int) int {
-	var numWorkers int
-
-	numWorkers = numCPUs * 2
-	if numCPUs <= 2 {
-		// let's keep it simple for devices like rPi zeroes
-		numWorkers = numCPUs
-	}
-
-	if numWorkers > numFiles {
-		return numFiles // don't use more workers than files
-	}
-
-	return min(numWorkers, 12) // avoid overthreading on high-core systems
+			return pkg, nil
+		},
+		0,
+		numPkgs,
+	)
 }

--- a/internal/origins/worker/worker.go
+++ b/internal/origins/worker/worker.go
@@ -1,0 +1,81 @@
+package worker
+
+import (
+	"errors"
+	"fmt"
+	"qp/internal/pkgdata"
+	"runtime"
+	"sync"
+)
+
+const DefaultBufferSize = 64
+
+func RunWorkers[T any](
+	inputChan <-chan T,
+	workerFunc func(T) (*pkgdata.PkgInfo, error),
+	numWorkers int, // pass 0 unless testing or intentionally limiting
+	bufferSize int,
+) ([]*pkgdata.PkgInfo, error) {
+	if bufferSize < 1 {
+		return nil, fmt.Errorf("invalid buffer size: %d (must be >= 1)", bufferSize)
+	}
+
+	if numWorkers <= 0 {
+		// fun fact: NumCPU() does account for hyperthreading
+		numWorkers = getWorkerCount(runtime.NumCPU())
+	}
+
+	outputChan := make(chan *pkgdata.PkgInfo, bufferSize)
+	errChan := make(chan error, DefaultBufferSize)
+
+	var wg sync.WaitGroup
+
+	for range numWorkers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for item := range inputChan {
+				pkg, err := workerFunc(item)
+				if err != nil {
+					errChan <- err
+					continue
+				}
+
+				outputChan <- pkg
+			}
+		}()
+	}
+
+	go func() {
+		wg.Wait()
+		close(outputChan)
+		close(errChan)
+	}()
+
+	var pkgs []*pkgdata.PkgInfo
+	var errs []error
+
+	for pkg := range outputChan {
+		pkgs = append(pkgs, pkg)
+	}
+
+	for err := range errChan {
+		errs = append(errs, err)
+	}
+
+	if len(errs) > 0 {
+		return pkgs, errors.Join(errs...)
+	}
+
+	return pkgs, nil
+}
+
+func getWorkerCount(numCPUs int) int {
+	numWorkers := numCPUs * 2
+	if numCPUs <= 2 {
+		// let's keep it simple for embedded devices
+		numWorkers = numCPUs
+	}
+
+	return min(numWorkers, 12) // avoid overthreading on high-core systems
+}


### PR DESCRIPTION
The worker pool pattern originally made for the pacman origin is now available for all origins.