### PR TITLE
Feature: Add required-by sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ qp w q has:depends or has:required-by p and not reason=explicit
 - `packager`
 - `conflicts`
 - `depends`
+- `required-by`
 
 ### JSON output
 

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -43,7 +43,7 @@ func GetComparator(field consts.FieldType, asc bool) (PkgComparator, error) {
 			return strings.ToLower(p.GetString(field))
 		}, asc), nil
 
-	case consts.FieldConflicts, consts.FieldDepends:
+	case consts.FieldConflicts, consts.FieldDepends, consts.FieldRequiredBy:
 		return makeComparator(func(p *PkgInfo) int {
 			return len(GetRelationsByDepth(p.GetRelations(field), 1))
 		}, asc), nil


### PR DESCRIPTION
Users can now sort by the length of depends with `qp order required-by`, `qp order required-by:asc`, or `qp order required-by:desc`.

```
> qp s name,required-by o required-by
NAME           REQUIRED BY
bzip2          base, ffmpeg, file, freetype2, gnupg, graphicsmagick, imagemagick, libarchive, libelf, pcre, pcre2, python, unzip
libpng         cairo, freetype2, gdk-pixbuf2, graphicsmagick, gst-plugins-base-libs, gtk4, imagemagick, libavif, libjxl, libsixel, libwebp, openjpeg2, poppler
libjpeg-turbo  gdk-pixbuf2, gst-plugins-base-libs, gtk4, libavif, libjxl, libsixel, libtiff, libwebp, libyuv, poppler, python-pillow, timg, v4l-utils
zstd           binutils, curl, file, gcc, gnutls, kmod, libarchive, libelf, libtiff, llvm-libs, mesa, mkinitcpio, systemd-libs
libxml2        ffmpeg, gettext, glusterfs, gupnp, imagemagick, libarchive, libbluray, librsvg, libxkbcommon, libxslt, llvm-libs, shared-mime-info, tinysparql, wayland
freetype2      cairo, ffmpeg, fontconfig, graphicsmagick, harfbuzz, imagemagick, libass=6-64, libbluray=6-64, libraqm, librsvg, libxft, pango, poppler, poppler-glib, python-matplotlib, python-pillow
xz             base, ffmpeg, file, graphicsmagick, grub, imagemagick, kmod, libarchive, libelf, libtiff, libunwind, libxml2, libxslt, systemd, systemd-libs, zstd
ncurses        bash, cmake, gettext, guile, htop, lame, less, libedit=6-64, nano, pinentry, pipewire, procps-ng, psmisc, readline, rogue, texinfo, util-linux, vi
systemd-libs   at-spi2-core, dbus, dbus-broker, device-mapper, dhcpcd, docker, hidapi, jack2, libgudev=1-64, libpulse, libusb, p11-kit, pam, pipewire, procps-ng, rpcbind, systemd=257.4, util-linux, v4l-utils
libxext        cairo, ffmpeg, graphicsmagick, gst-plugins-base-libs, gtk3, gtk4, imagemagick, libglvnd, libva, libvdpau, libxi, libxinerama, libxmu, libxrandr, libxss, libxtst, libxv, libxxf86vm, mesa, sdl3
xorgproto      libice, libsm, libx11, libxau, libxcomposite, libxcursor, libxdamage, libxdmcp, libxext, libxfixes, libxft, libxi, libxinerama, libxkbfile, libxmu, libxrender, libxss, libxt, libxtst, libxv, libxxf86vm
openssl        coreutils, cryptsetup, curl, dhcpcd, git, iperf3, kmod, krb5, ldns, libarchive, libevent, libsasl, libssh, libssh2, mosh, openssh, python, python-awscrt, python-cryptography, rust, srt, sudo, systemd, tpm2-tss, websocat
perl           autoconf, automake, cloc, git, groff, perl-algorithm-diff, perl-class-method-modifiers, perl-data-optlist, perl-devel-globaldestruction, perl-error, perl-import-into>=5.006, perl-mime-charset, perl-module-runtime, perl-parallel-forkmanager, perl-params-util, perl-regexp-common, perl-role-tiny, perl-sub-exporter, perl-sub-install, perl-sub-quote, perl-timedate, perl-unicode-linebreak, perl-yaml-tiny, po4a, texinfo
libx11         at-spi2-core, cairo, ffmpeg, gst-plugins-bad-libs, gst-plugins-base-libs, gtk3, gtk4, ibus, libepoxy, libva, libxcomposite, libxcursor, libxdamage, libxext, libxfixes, libxft, libxi, libxinerama, libxkbfile, libxmu, libxrandr, libxrender, libxss, libxt, libxtst, libxv, libxxf86vm, mesa, pango, sdl3, vulkan-broadcom, xorg-xprop
glib2          at-spi2-core, avahi, cairo, dconf, desktop-file-utils, enchant, ffmpeg, gdk-pixbuf2, glib-networking, gpgme, graphene, gssdp, gst-plugins-bad-libs, gst-plugins-base-libs, gstreamer, gtk-update-icon-cache, gtk3, gtk4, gupnp, gupnp-igd=0-64, harfbuzz, ibus, imagemagick, json-glib, libcloudproviders, libcolord, libdbusmenu-glib, libgirepository, libgudev, libibus=0-64, liblqr, libnice, libnotify, libproxy, libpulse, librsvg, libsecret, libsixel, libsoup3, pango, pinentry, pipewire, poppler-glib, python-gobject, shared-mime-info, tinysparql
zlib           binutils, cairo, cmake, curl, ffmpeg, file, freetype2, git, glib2, gnupg, gnutls, gst-plugins-bad-libs, gst-plugins-base-libs, imagemagick, kmod, libarchive, libbpf, libcups, libelf, libopenmpt, libpciaccess, libpng, libsoup3, libssh, libssh2, libtiff, libunwind, libxml2, llvm-libs, man-db, mesa, nss, openssh, pcre, pcre2, poppler, protobuf, python, python-pillow, rust, sqlite, sudo, util-linux, vim, wget, zstd
python         aws-cli, fio, glusterfs, ibus, litecli, python-attrs, python-autocommand, python-awscrt, python-botocore, python-build, python-certifi, python-charset-normalizer, python-cli_helpers, python-click, python-colorama, python-configobj, python-contourpy, python-cryptography, python-cycler, python-docutils, python-fastjsonschema, python-filelock, python-fonttools, python-gobject, python-idna, python-installer, python-jaraco.collections, python-jaraco.context, python-jaraco.functools, python-jaraco.text, python-jmespath, python-kiwisolver, python-lark-parser, python-lxml, python-matplotlib, python-more-itertools, python-numpy, python-packaging, python-pillow, python-pip, python-platformdirs, python-poetry-core, python-pooch, python-prompt_toolkit, python-pyasn1, python-pycparser, python-pygments, python-pyparsing, python-pyproject-hooks, python-pytz, python-s3transfer, python-scipy, python-setuptools, python-six, python-sqlparse, python-tabulate, python-typing_extensions, python-urllib3, python-wcwidth, python-wheel, python-yaml, vapoursynth
bash           at-spi2-core, autoconf, automake, base, bison, bzip2, ca-certificates-utils, cairo, db5.3, dhcpcd, diffutils, e2fsprogs, fakeroot, fftw, findutils, fio, flex, fontconfig, fzf, gawk, gdbm, gettext, glib2, gnupg, gpm, grub, gtk-update-icon-cache, gtk4, gzip, icu, iptables, keyutils, krb5, libassuan, libcups, libgpg-error, libksba, libpcap, libpng, libpulse, libtool, libxml2, libxslt, lksctp-tools, lm_sensors, m4, man-db, mkinitcpio, npth, nspr, nss, openresolv, p7zip, pacman, pcre, pkgconf, rbenv, ruby-build, rust, spirv-tools, srt, systemd, texinfo, unzip, which, xz
gcc-libs       abseil-cpp, aom, at-spi2-core, base, blas, btop, cmake, cppdap, db5.3, enchant, fd, fftw, flac, gc, gcc=14.2.1+r753+g1cd744a6828f-1, gettext, glslang, gmp, gnutls, gperftools, gpgme, graphite, groff, gssdp, gst-plugins-bad-libs, gstreamer, gtest, gtk4, gupnp, highway, hyperfine, icu, imagemagick, jack2, jsoncpp, lapack, libavif, libbs2b, libdovi, libimagequant, libmodplug, libnl, libopenmpt, libpipewire, libplacebo, libproxy, librsvg, libsoxr, libtiff, libvpx, libyuv, llvm-libs, luajit, mandown, mesa, mpdecimal, ncurses, ninja, p7zip, pcre, pipewire, poppler, poppler-glib, portaudio, protobuf, python-awscrt, python-contourpy, python-cryptography, python-matplotlib, python-scipy, rav1e, ripgrep, rubberband, rust, shaderc, shared-mime-info, snappy, speex, speexdsp, spirv-tools, srt, systemd-libs, tinysparql, v4l-utils, vid.stab, websocat, x265, yazi, zellij, zeromq, zimg, zoxide, zstd
glibc          abseil-cpp, acl, alsa-lib, aom, argon2, at-spi2-core, attr, audit, base, bash, binutils, bison, blas, bridge-utils, brotli, btop, bzip2, cairo, cblas, cmake, coreutils, cppdap, cryptsetup, dav1d, dbus, debugedit, desktop-file-utils, device-mapper, dhcpcd, diffutils, docker, docker-buildx, duktape, efibootmgr, efivar, enchant, expat, fakeroot, fastfetch, ffmpeg, fftw, file, findutils, flac, flex, fontconfig, freetype2, fribidi, fuse2, gawk, gcc-libs>=2.27, gdbm, gdk-pixbuf2, gdu, giflib, github-cli, glib-networking, glib2, glow, gmp, gnupg, gnutls, gperftools, gpgme, graphene, graphite, grep, gsm, gssdp, gst-plugins-bad-libs, gst-plugins-base-libs, gstreamer, gtest, gtk-update-icon-cache, gtk3, gtk4, gupnp, gzip, harfbuzz, icu, imagemagick, iperf3, iproute2, jack2, jansson, jbigkit, jq, json-c, json-glib, kbd, keyutils, kmod, krb5, l-smash, lapack, lazygit, leancrypto, less, libaio, libarchive, libass, libassuan, libasyncns, libavc1394, libavif, libbluray, libbpf, libcap, libcap-ng, libcups, libdaemon, libdatrie, libdeflate, libdovi, libdrm, libdvdnav, libdvdread, libedit, libelf, libepoxy, libexif, libffi, libgcrypt, libgirepository, libgpg-error, libice, libjpeg-turbo, libksba, liblqr, libmnl, libmpc, libnfnetlink, libnghttp2, libnghttp3, libnl, libnotify, libnsl, libogg, libopenmpt, libp11-kit, libpcap, libpciaccess, libpgm, libpipeline, libpipewire, libplacebo, libproxy, libpulse, libraqm, libraw1394, librsvg, libsamplerate, libsasl, libseccomp, libsecret, libsixel, libsm, libsndfile, libsodium, libsoup3, libssh, libstemmer, libtasn1, libthai, libtheora, libtiff, libtirpc, libtool, libunibreak, libunistring, libunwind, liburcu, libusb, libutempter, libutf8proc, libuv, libverto, libvorbis, libvpx, libvterm, libwebp, libx11, libxau, libxcb, libxcomposite, libxcrypt, libxcursor, libxdamage, libxdmcp, libxext, libxfixes, libxft, libxi, libxinerama, libxkbcommon, libxkbcommon-x11, libxkbfile, libxml2, libxmu, libxrandr, libxrender, libxshmfence, libxslt, libxss, libxt, libxtst, libxv, libxxf86vm, libyaml, lksctp-tools, lm_sensors, lmdb, lsof, lua51-lpeg, lz4, lzo, m4, make, man-db, mandown, mesa, mkinitcpio-busybox, moar, mpdecimal, mpfr, msgpack-c, nano, ncurses, net-tools, nettle, npth, nspr, nss, numactl, ocl-icd, opencore-amr, openjpeg2, openssh, openssl, opus, orc, p11-kit, pacman, pam, pango, patch, pciutils, pcre, pcre2, perl, perl-io-tty, pinentry, pipewire, pixman, pkgconf, pkgstats, poppler, poppler-glib, popt, portaudio, procps-ng, protobuf, python-awscrt, python-contourpy, python-cryptography, python-gobject, python-matplotlib, python-pillow, python-scipy, python-yaml, qhull, rav1e, readline, rhash, rpcbind, rubberband, rust, sdl2-compat, sdl3, sed, shaderc, shadow, shared-mime-info, snappy, spirv-tools, sqlite, srt, sudo, systemd-libs, tar, time, tinysparql, tree, unibilium, util-linux, util-linux-libs, vid.stab, vim, vulkan-icd-loader, wayland, websocat, wget, which, x264, xcb-util, xcb-util-keysyms, xcb-util-wm, xorg-xprop, xvidcore, xxhash, yyjson, zellij, zeromq, zimg, zlib, zoxide, zstd
```

Closes #294 