### PR TITLE
Feature: Add optdepends sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ learn about installation [here](#installation)
 | ✓  | groups query | – | streaming pipeline |
 | – | short-args for queries | – | key/value output |
 | ✓ | package base query | ✓ | required-by sort |
-| – | optdepends sort | – | depends sort |
+| ✓ | optdepends sort | – | depends sort |
 | ✓ | build-date field | ✓ | build-date query |
 | ✓ | build-date sort | ✓ | pkgtype field |
 | ✓ | url query | ✓ | pkgtype sort |
@@ -392,6 +392,7 @@ qp w q has:depends or has:required-by p and not reason=explicit
 - `packager`
 - `conflicts`
 - `depends`
+- `optdepends`
 - `required-by`
 
 ### JSON output

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -43,7 +43,9 @@ func GetComparator(field consts.FieldType, asc bool) (PkgComparator, error) {
 			return strings.ToLower(p.GetString(field))
 		}, asc), nil
 
-	case consts.FieldConflicts, consts.FieldDepends, consts.FieldRequiredBy:
+	case consts.FieldConflicts,
+		consts.FieldDepends, consts.FieldOptDepends,
+		consts.FieldRequiredBy:
 		return makeComparator(func(p *PkgInfo) int {
 			return len(GetRelationsByDepth(p.GetRelations(field), 1))
 		}, asc), nil


### PR DESCRIPTION
Users can now sort by the length of optdepends with `qp order optdepends`, `qp order optdepends:asc`, or `qp order optdepends:desc`.

```
NAME               OPT DEPENDS
graphicsmagick     ghostscript (pdf, ps modules), jasper (jp2 module), libheif (heic module), libjxl (jpeg-xl module), libwmf (wmf module), libxml2 (msl, svg, url modules)
jack2              a2jmidid (for ALSA MIDI to JACK MIDI bridging), jack-example-tools (for official JACK example-clients and tools), jack2-dbus (for dbus integration), jack2-docs (for developer documentation), libffado (for firewire support using FFADO), realtime-privileges (for realtime privileges)
mkinitcpio         bzip2 (Use bzip2 compression for the initramfs image), lz4 (Use lz4 compression for the initramfs image), lzop (Use lzo compression for the initramfs image), mkinitcpio-nfs-utils (Support for root filesystem on NFS), systemd-ukify (alternative UKI generator), xz (Use lzma or xz compression for the initramfs image)
pinentry           gcr (GNOME backend), gtk3 (GTK backend), kguiaddons (Qt6 backend), kwayland5 (Qt5 backend), kwindowsystem (Qt6 backend), qt5-x11extras (Qt5 backend)
sdl3               alsa-lib (ALSA audio driver), jack (JACK audio driver), libdecor (Wayland client decorations), libpulse (PulseAudio audio driver), pipewire (PipeWire audio driver), sndio (sndio audio driver), vulkan-driver (vulkan renderer)
gdk-pixbuf2        libavif (Load .avif), libheif (Load .heif, .heic, and .avif), libjxl (Load .jxl), libopenraw (Load .dng, .cr2, .crw, .nef, .orf, .pef, .arw, .erf, .mrw, and .raf), librsvg (Load .svg, .svgz, and .svg.gz), libwmf (Load .wmf and .apm), webp-pixbuf-loader (Load .webp)
avahi              gtk3 (avahi-discover, avahi-discover-standalone, bshell, bssh, bvnc), libevent (libevent bindings), nss-mdns (NSS support for mDNS), python-dbus (avahi-bookmarks, avahi-discover), python-gobject (avahi-bookmarks, avahi-discover), python-twisted (avahi-bookmarks), qt5-base (qt5 bindings)
pacman-contrib     diffutils (for pacdiff), fakeroot (for checkupdates), findutils (for pacdiff --find), mlocate (for pacdiff --locate), perl (for pacsearch), sudo (privilege elevation for several scripts), vim (default merge program for pacdiff)
grub               dosfstools (For grub-mkrescue FAT FS and EFI support), efibootmgr (For grub-install EFI support), freetype2 (For grub-mkfont usage), fuse3 (For grub-mount usage), libisoburn (Provides xorriso for generating grub rescue iso using grub-mkrescue), lzop (For grub-mkrescue LZO support), mtools (For grub-mkrescue FAT FS support), os-prober (To detect other OSes when generating grub.cfg in BIOS systems)
netctl             dhclient (for DHCP support (or dhcpcd)), dhcpcd (for DHCP support (or dhclient)), dialog (for the menu based wifi assistant), ifplugd (for automatic wired connections through netctl-ifplugd), openvswitch (for Open vSwitch connections), ppp (for PPP connections), wireguard-tools (for WireGuard connections), wpa_supplicant (for wireless networking support)
zsh                grml-zsh-config (grml's zsh setup), zsh-autosuggestions (Fish-like autosuggestions for zsh), zsh-completions (Additional completion definitions for Zsh), zsh-doc (Info, HTML and PDF format of the ZSH documentation), zsh-history-substring-search (ZSH port of Fish history search (up arrow)), zsh-lovers (A collection of tips, tricks and examples for the Z shell.), zsh-syntax-highlighting (Fish shell like syntax highlighting for Zsh), zshdb (A debugger for zsh scripts)
yazi               7zip (for archive preview), chafa (for previewing images), fd (for file searching), ffmpeg (for video thumbnails), fzf (for directory jumping), imagemagick (for previewing fonts), jq (for JSON preview), poppler (for PDF preview), ripgrep (for file content searching), zoxide (for directory jumping)
python-fonttools   python-brotli (to compress/decompress WOFF 2.0 web fonts), python-fs (to read/write UFO source files), python-lxml (faster backend for XML files reading/writing), python-lz4 (for graphite type tables in ttLib/tables), python-matplotlib (for visualizing DesignSpaceDocument and resulting VariationModel), python-pyqt5 (for drawing glyphs with Qt’s QPainterPath), python-reportlab (to drawing glyphs as PNG images), python-scipy (for finding wrong contour/component order between different masters), python-sympy (for symbolic font statistics analysis), python-uharfbuzz (to use the Harfbuzz Repacker for packing GSUB/GPOS tables), python-unicodedata2 (for displaying the Unicode character names when dumping the cmap table with ttx), python-zopfli (faster backend fom WOFF 1.0 web fonts compression)
python-matplotlib  ffmpeg (for saving movies), ghostscript (usetex dependencies), imagemagick (for saving animated gifs), pyside6 (alternative for Qt6{Agg,Cairo} backends), python-cairo ({GTK{3,4},Qt{5,6},Tk,WX}Cairo backends), python-certifi (https support), python-gobject (for GTK{3,4}{Agg,Cairo} backend), python-pyqt5 (Qt5{Agg,Cairo} backends), python-pyqt6 (Qt6{Agg,Cairo} backends), python-tornado (WebAgg backend), python-wxpython (WX{Agg,Cairo} backend), texlive-binextra (usetex dependencies), texlive-fontsrecommended (usetex dependencies), texlive-latexrecommended (usetex usage with pdflatex), tk (Tk{Agg,Cairo} backends)
systemd            curl (systemd-journal-upload, machinectl pull-tar and pull-raw), gnutls (systemd-journal-gatewayd and systemd-journal-remote), iptables (firewall features), libarchive (convert DDIs to tarballs), libbpf (support BPF programs), libfido2 (unlocking LUKS2 volumes with FIDO2 token), libmicrohttpd (systemd-journal-gatewayd and systemd-journal-remote), libp11-kit (support PKCS#11), libpwquality (check password quality), polkit (allow administration as unprivileged user), qrencode (show QR codes), quota-tools (kernel-level quota management), systemd-sysvcompat (symlink package to provide sysvinit binaries), systemd-ukify (combine kernel and initrd into a signed Unified Kernel Image), tpm2-tss (unlocking LUKS2 volumes with TPM2)
git                git-zsh-completion (upstream zsh completion), libsecret (libsecret credential helper), man (show help with `git command --help`), openssh (ssh transport and crypto), org.freedesktop.secrets (keyring credential helper), perl-authen-sasl (git send-email TLS support), perl-cgi (gitweb (web interface) support), perl-datetime-format-iso8601 (git mediawiki support), perl-io-socket-ssl (git send-email TLS support), perl-libwww (git svn), perl-lwp-protocol-https (git mediawiki https support), perl-mediawiki-api (git mediawiki support), perl-term-readkey (git svn and interactive.singlekey setting), python (git svn & git p4), subversion (git svn), tk (gitk and git gui)
pipewire           gst-plugin-pipewire (GStreamer plugin), pipewire-alsa (ALSA configuration), pipewire-audio (Audio support), pipewire-docs (Documentation), pipewire-ffado (FireWire support), pipewire-jack (JACK replacement), pipewire-jack-client (PipeWire as JACK client), pipewire-libcamera (Libcamera support), pipewire-pulse (PulseAudio replacement), pipewire-roc (ROC streaming), pipewire-session-manager (Session manager), pipewire-v4l2 (V4L2 interceptor), pipewire-x11-bell (X11 bell), pipewire-zeroconf (Zeroconf support), realtime-privileges (realtime privileges with rt module), rtkit (realtime privileges with rtkit module)
fastfetch          chafa (Image output as ascii art), dbus (Bluetooth, Player & Media detection), dconf (Needed for values that are only stored in DConf + Fallback for GSettings), ddcutil (Brightness detection of external displays), directx-headers (GPU detection in WSL), glib2 (Output for values that are only stored in GSettings), hwdata (GPU output), imagemagick (Image output using sixel or kitty graphics protocol), libdrm (Displays detection), libelf (st term font detection and fast path of systemd version detection), libpulse (Sound detection), libxrandr (Multi monitor support), ocl-icd (OpenCL module), python (Needed for zsh and fish completions), vulkan-icd-loader (Vulkan module & fallback for GPU output), xfconf (Needed for XFWM theme and XFCE Terminal font), zlib (Faster image output when using kitty graphics protocol)
imagemagick        djvulibre (DJVU support), ghostscript (PS/PDF support), jbigkit (JBIG support), libheif (HEIF support), libjpeg-turbo (JPEG support), libjxl (JPEG XL support), libraw (DNG support), librsvg (SVG support), libtiff (TIFF support), libultrahdr (UHDR support), libwebp (WEBP support), libwmf (WMF support), libzip (OpenRaster support), ocl-icd (OpenCL support), openexr (OpenEXR support), openjpeg2 (JPEG2000 support), pango (Text rendering)
python-pandas      python-beautifulsoup4 (read_html function (in any case)), python-blosc (for msgpack compression using blosc), python-bottleneck (accelerating certain types of nan evaluations (recommended)), python-brotli (Brotli compression), python-fsspec (handling files aside from local and HTTP), python-html5lib (read_html function (and/or python-lxml)), python-jinja (conditional formatting with DataFrame.style), python-lxml (read_xml, to_xml and read_html function (and/or python-html5lib)), python-matplotlib (plotting), python-numba (alternative execution engine), python-numexpr (accelerating certain numerical operations (recommended)), python-openpyxl (Excel XLSX input/output), python-pandas-datareader (pandas.io.data replacement (recommended)), python-psycopg2 (PostgreSQL engine for sqlalchemy), python-pyarrow (Parquet, ORC and feather reading/writing), python-pymysql (MySQL engine for sqlalchemy), python-pyqt5 (read_clipboard function (only one needed)), python-pytables (HDF5-based reading / writing), python-qtpy (read_clipboard function (only one needed)), python-scipy (miscellaneous statistical functions), python-snappy (Snappy compression), python-sqlalchemy (SQL database support), python-tabulate (printing in Markdown-friendly format), python-xarray (pandas-like API for N-dimensional data), python-xlrd (Excel XLS input), python-xlsxwriter (alternative Excel XLSX output), python-xlwt (Excel XLS output), python-zstandard (Zstandard (zstd) compression), xclip (read_clipboard function (only one needed)), xsel (read_clipboard function (only one needed)), zlib (compression for msgpack)
```

Closes #297 