### PR TITLE
Feature: Add provides sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ qp w q has:depends or has:required-by p and not reason=explicit
 - `depends`
 - `optdepends`
 - `required-by`
+- `provides`
 
 ### JSON output
 

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -45,7 +45,7 @@ func GetComparator(field consts.FieldType, asc bool) (PkgComparator, error) {
 
 	case consts.FieldConflicts,
 		consts.FieldDepends, consts.FieldOptDepends,
-		consts.FieldRequiredBy:
+		consts.FieldRequiredBy, consts.FieldProvides:
 		return makeComparator(func(p *PkgInfo) int {
 			return len(GetRelationsByDepth(p.GetRelations(field), 1))
 		}, asc), nil

--- a/qp.1
+++ b/qp.1
@@ -44,7 +44,7 @@ Existence check — \fBhas:field\fR or \fBno:field\fR
 
 .TP
 .B order <field>:<direction>, o <..>
-Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBsize\fR, \fBname\fR, \fBreason\fR, \fBversion\fR, \fBorigin\fR, \fBarch\fR, \fBlicense\fR, \fBdescription\fR, \fBurl\fR, \fBpkgbase\fR, \fBpkgtype\fR, \fBvalidation\fR, \fBpackager\fR, \fBconflicts\fR, \fBdepends\fR
+Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBsize\fR, \fBname\fR, \fBreason\fR, \fBversion\fR, \fBorigin\fR, \fBarch\fR, \fBlicense\fR, \fBdescription\fR, \fBurl\fR, \fBpkgbase\fR, \fBpkgtype\fR, \fBvalidation\fR, \fBpackager\fR, \fBconflicts\fR, \fBdepends\fR,\fBoptdepends\fR, \fBrequired-by\fR, \fBprovides\fR 
 
 .TP
 .B limit <number>, l <number>


### PR DESCRIPTION
Users can now sort by the length of provides with `qp order provides`, `qp order provides:asc`, or `qp order provides:desc`.

```
> qp s name,provides o provides
NAME             PROVIDES
pcre             libpcre.so=1-64, libpcre16.so=0-64, libpcre32.so=0-64, libpcrecpp.so=0-64, libpcreposix.so=0-64
ncurses          libformw.so=6-64, libmenuw.so=6-64, libncurses++w.so=6-64, libncursesw.so=6-64, libpanelw.so=6-64
libwebp          libsharpyuv.so=0-64, libwebp.so=7-64, libwebpdecoder.so=3-64, libwebpdemux.so=2-64, libwebpmux.so=3-64
libevent         libevent-2.1.so=7-64, libevent_core-2.1.so=7-64, libevent_extra-2.1.so=7-64, libevent_openssl-2.1.so=7-64, libevent_pthreads-2.1.so=7-64
libunwind        libunwind-coredump.so=0-64, libunwind-ptrace.so=0-64, libunwind-setjmp.so=0-64, libunwind-x86_64.so, libunwind.so=8-64
libva            libva-drm.so=2-64, libva-glx.so=2-64, libva-wayland.so=2-64, libva-x11.so=2-64, libva.so=2-64
at-spi2-core     at-spi2-atk=2.56.1-1, atk=2.56.1-1, libatk-1.0.so=0-64, libatk-bridge-2.0.so=0-64, libatspi.so=0-64
mesa             libva-driver, libva-mesa-driver=1:25.0.2-2, mesa-libgl=1:25.0.2-2, mesa-vdpau=1:25.0.2-2, opengl-driver, vdpau-driver
icu              libicudata.so=76-64, libicui18n.so=76-64, libicuio.so=76-64, libicutest.so=76-64, libicutu.so=76-64, libicuuc.so=76-64
glib2            libgio-2.0.so=0-64, libgirepository-2.0.so=0-64, libglib-2.0.so=0-64, libgmodule-2.0.so=0-64, libgobject-2.0.so=0-64, libgthread-2.0.so=0-64
tpm2-tss         libtss2-esys.so=0-64, libtss2-fapi.so=1-64, libtss2-mu.so=0-64, libtss2-rc.so=0-64, libtss2-sys.so=1-64, libtss2-tctildr.so=0-64
util-linux-libs  libblkid.so=1-64, libfdisk.so=1-64, libmount.so=1-64, libsmartcols.so=1-64, libutil-linux, libuuid.so=1-64
libnl            libnl-3.so=200-64, libnl-cli-3.so=200-64, libnl-genl-3.so=200-64, libnl-idiag-3.so=200-64, libnl-nf-3.so=200-64, libnl-route-3.so=200-64, libnl-xfrm-3.so=200-64
gcc-libs         libasan.so=8-64, libgfortran.so=5-64, libgo.so=23-64, libgphobos.so=5-64, liblsan.so=0-64, libtsan.so=2-64, libubsan.so=1-64
ffmpeg           libavcodec.so=61-64, libavdevice.so=61-64, libavfilter.so=10-64, libavformat.so=61-64, libavutil.so=59-64, libpostproc.so=58-64, libswresample.so=5-64, libswscale.so=8-64
libglvnd         libEGL.so=1-64, libGL.so=1-64, libGLESv2.so=2-64, libGLX.so=0-64, libGLdispatch.so=0-64, libOpenGL.so=0-64, libegl, libgl, libgles
avahi            libavahi-client.so=3-64, libavahi-common.so=3-64, libavahi-core.so=7-64, libavahi-glib.so=1-64, libavahi-gobject.so=0-64, libavahi-libevent.so=1-64, libavahi-qt5.so=1-64, libavahi-ui-gtk3.so=0-64, libdns_sd.so=1-64
krb5             libgssapi_krb5.so=2-64, libgssrpc.so=4-64, libk5crypto.so=3-64, libkadm5clnt_mit.so=12-64, libkadm5srv_mit.so=12-64, libkdb5.so=10-64, libkdb_ldap.so=1-64, libkrad.so=0-64, libkrb5.so=3-64, libkrb5support.so=0-64
fftw             libfftw3.so=3-64, libfftw3_omp.so=3-64, libfftw3_threads.so=3-64, libfftw3f.so=3-64, libfftw3f_omp.so=3-64, libfftw3f_threads.so=3-64, libfftw3l.so=3-64, libfftw3l_omp.so=3-64, libfftw3l_threads.so=3-64, libfftw3q.so, libfftw3q_omp.so, libfftw3q_threads.so
perl             perl-archive-tar=3.02_001, perl-attribute-handlers=1.03, perl-autodie=2.37, perl-autoloader=5.74, perl-autouse=1.11, perl-base=2.27, perl-bignum=0.67, perl-carp=1.54, perl-compress-raw-bzip2=2.212, perl-compress-raw-zlib=2.212, perl-config-perl-v=0.36, perl-constant=1.33, perl-cpan=2.36, perl-cpan-meta=2.150010, perl-cpan-meta-requirements=2.143, perl-cpan-meta-yaml=0.018, perl-data-dumper=2.189, perl-db_file=1.859, perl-devel-ppport=3.72, perl-devel-selfstubber=1.06, perl-digest=1.20, perl-digest-md5=2.58_01, perl-digest-sha=6.04, perl-dumpvalue=1.21, perl-encode=3.21, perl-encoding-warnings=0.14, perl-env=1.06, perl-experimental=0.032, perl-exporter=5.78, perl-extutils-cbuilder=0.280240, perl-extutils-constant=0.25, perl-extutils-install=2.22, perl-extutils-makemaker=7.70, perl-extutils-manifest=1.75, perl-extutils-parsexs=3.51, perl-extutils-pl2bat=0.005, perl-file-fetch=1.04, perl-file-path=2.18, perl-file-temp=0.2311, perl-filter-simple=0.96, perl-filter-util-call=1.64, perl-findbin=1.54, perl-getopt-long=2.57, perl-http-tiny=0.088, perl-i18n-collate=1.02, perl-i18n-langtags=0.45, perl-if=0.0610, perl-io=1.55, perl-io-compress=2.212, perl-io-socket-ip=0.42, perl-io-zlib=1.15, perl-ipc-cmd=1.04, perl-ipc-sysv=2.09, perl-json-pp=4.16, perl-lib=0.65, perl-libnet=3.15, perl-locale-maketext=1.33, perl-locale-maketext-simple=0.21_01, perl-math-bigint=2.003002, perl-math-bigint-fastcalc=0.5018, perl-math-complex=1.62, perl-memoize=1.16, perl-mime-base64=3.16_01, perl-module-corelist=5.20250118_40, perl-module-load=0.36, perl-module-load-conditional=0.74, perl-module-loaded=0.08, perl-module-metadata=1.000038, perl-net-ping=2.76, perl-params-check=0.38, perl-parent=0.241, perl-pathtools=3.91, perl-perl-ostype=1.010, perl-perlfaq=5.20240218, perl-perlio-via-quotedprint=0.10, perl-pod-checker=1.77, perl-pod-escapes=1.07, perl-pod-perldoc=3.2801, perl-pod-simple=3.45, perl-pod-usage=2.03, perl-podlators=5.010, perl-safe=2.46, perl-scalar-list-utils=1.63, perl-search-dict=1.07, perl-selfloader=1.27, perl-socket=2.038, perl-storable=3.32, perl-sys-syslog=0.36, perl-term-ansicolor=5.01, perl-term-cap=1.18, perl-term-complete=1.403, perl-term-readline=1.17, perl-term-table=0.018, perl-test=1.31, perl-test-harness=3.48, perl-test-simple=1.302199, perl-test2-suite=0.000162, perl-text-abbrev=1.02, perl-text-balanced=2.06, perl-text-parsewords=3.31, perl-text-tabs=2024.001, perl-thread-queue=3.14, perl-thread-semaphore=2.13, perl-threads=2.40, perl-threads-shared=1.69, perl-tie-file=1.09, perl-tie-refhash=1.40, perl-time-hires=1.9777, perl-time-local=1.35, perl-time-piece=1.3401_01, perl-unicode-collate=1.31, perl-unicode-normalize=1.32, perl-version=0.9930, perl-xsloader=0.32
```