### PR TITLE
Feature: Add optional-for sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ qp w q has:depends or has:required-by p and not reason=explicit
 - `depends`
 - `optdepends`
 - `required-by`
+- `optional-for`
 - `provides`
 
 ### JSON output

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -45,7 +45,8 @@ func GetComparator(field consts.FieldType, asc bool) (PkgComparator, error) {
 
 	case consts.FieldConflicts,
 		consts.FieldDepends, consts.FieldOptDepends,
-		consts.FieldRequiredBy, consts.FieldProvides:
+		consts.FieldRequiredBy, consts.FieldOptionalFor,
+		consts.FieldProvides:
 		return makeComparator(func(p *PkgInfo) int {
 			return len(GetRelationsByDepth(p.GetRelations(field), 1))
 		}, asc), nil

--- a/qp.1
+++ b/qp.1
@@ -44,7 +44,7 @@ Existence check — \fBhas:field\fR or \fBno:field\fR
 
 .TP
 .B order <field>:<direction>, o <..>
-Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBsize\fR, \fBname\fR, \fBreason\fR, \fBversion\fR, \fBorigin\fR, \fBarch\fR, \fBlicense\fR, \fBdescription\fR, \fBurl\fR, \fBpkgbase\fR, \fBpkgtype\fR, \fBvalidation\fR, \fBpackager\fR, \fBconflicts\fR, \fBdepends\fR,\fBoptdepends\fR, \fBrequired-by\fR, \fBprovides\fR 
+Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBsize\fR, \fBname\fR, \fBreason\fR, \fBversion\fR, \fBorigin\fR, \fBarch\fR, \fBlicense\fR, \fBdescription\fR, \fBurl\fR, \fBpkgbase\fR, \fBpkgtype\fR, \fBvalidation\fR, \fBpackager\fR, \fBconflicts\fR, \fBdepends\fR,\fBoptdepends\fR, \fBrequired-by\fR, \fBoptional-for\fR, \fBprovides\fR
 
 .TP
 .B limit <number>, l <number>


### PR DESCRIPTION
Users can now sort by the length of optional-for with `qp order optional-for`, `qp order optional-for:asc`, or `qp order optional-for:desc`.

```
> qp s name,optional-for o optional-for
NAME               OPTIONAL FOR
xz                 mkinitcpio (Use lzma or xz compression for the initramfs image), python (for lzma)
vulkan-broadcom    sdl3 (vulkan renderer), vulkan-icd-loader (packaged vulkan driver)
vim                fzf (plugin), pacman-contrib (default merge program for pacdiff)
python-gobject     avahi (avahi-bookmarks, avahi-discover), libibus (for Python integration), python-matplotlib (for GTK{3,4}{Agg,Cairo} backend)
python-scipy       hyperfine (run data analysis scripts), python-fonttools (for finding wrong contour/component order between different masters), python-pandas (miscellaneous statistical functions)
python-setuptools  python (for building Python packages using tooling that is usually bundled with Python), python-cffi ("limited api" version checking in cffi.setuptools_ext), python-wheel (for legacy bdist_wheel subcommand)
python-lxml        python-fonttools (faster backend for XML files reading/writing), python-networkx (for GraphML XML format), python-pandas (read_xml, to_xml and read_html function (and/or python-html5lib))
curl               fio (for gfio - fio GUI frontend), pciutils (for update-pciids), systemd (systemd-journal-upload, machinectl pull-tar and pull-raw)
alsa-lib           libsndfile (for sndfile-play), sdl3 (ALSA audio driver), v4l-utils (for qv4l2)
gtk3               avahi (avahi-discover, avahi-discover-standalone, bshell, bssh, bvnc), libdecor (gtk3 support), pinentry (GTK backend)
git                gettext (for autopoint infrastructure updates), github-cli (To interact with repositories), ruby-build (install ruby from git)
imagemagick        fastfetch (Image output using sixel or kitty graphics protocol), python-matplotlib (for saving animated gifs), yazi (for previewing fonts)
libpulse           fastfetch (Sound detection), mpg123 (for pulse audio support), sdl3 (PulseAudio audio driver)
libjxl             gdk-pixbuf2 (Load .jxl), graphicsmagick (jpeg-xl module), imagemagick (JPEG XL support)
sudo               downgrade (for installation via sudo), pacman-contrib (privilege elevation for several scripts), yay-bin (privilege elevation)
python-matplotlib  hyperfine (run data analysis scripts), python-contourpy (matplotlib renderer), python-fonttools (for visualizing DesignSpaceDocument and resulting VariationModel), python-pandas (plotting)
bash               audit (for augenrules), ncurses (for ncursesw6-config), openssh (for ssh-copy-id and findssl.sh), pcre2 (for pcre2-config), tzdata (for tzselect), vim-runtime (support for some tools and macros)
tree-sitter        tree-sitter-c (core library), tree-sitter-lua (core library), tree-sitter-markdown (core library), tree-sitter-query (core library), tree-sitter-vim (core library), tree-sitter-vimdoc (core library)
perl               glibc (for mtrace), gperftools (pprof and pprof-symbolize commands), lm_sensors (for sensor detection and configuration convert), mpg123 (for conplay), openssl, pacman-contrib (for pacsearch), vim (Perl language support)
python             fastfetch (Needed for zsh and fish completions), git (git svn & git p4), gstreamer (gst-plugins-doc-cache-generator), gtest (gmock generator), gupnp (gupnp-binding-tool), iproute2 (for routel), libevent (event_rpcgen.py), libxml2 (Python bindings), libxslt (Python bindings), util-linux-libs (python bindings to libmount), vim (Python language support), vim-runtime (demoserver example tool), vulkan-headers (Registry tools)
```

Closes #305 