### PR TITLE
Feature: Add replaces sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ learn about installation [here](#installation)
 | ✓  | groups query | – | streaming pipeline |
 | – | short-args for queries | – | key/value output |
 | ✓ | package base query | ✓ | required-by sort |
-| ✓ | optdepends sort | – | depends sort |
+| ✓ | optdepends sort | ✓ | depends sort |
 | ✓ | build-date field | ✓ | build-date query |
 | ✓ | build-date sort | ✓ | pkgtype field |
 | ✓ | url query | ✓ | pkgtype sort |
@@ -125,10 +125,10 @@ learn about installation [here](#installation)
 | ✓ | url sort | - | groups sort |
 | ✓ | packager field | ✓ | optional dependency field |
 | ✓ | sort by size on disk | ✓ | conflicts sort |
-| - | optional-for sort | - | provides sort |
+| ✓ | optional-for sort | ✓ | provides sort |
 | ✓ | validation field | ✓ | validation sort |
 | ✓ | packager sort | ✓ | architecture sort |
-| ✓ | reason sort | ✓ |version sort |
+| ✓ | reason sort | ✓ | version sort |
 | ✓ | reverse optional dependencies field (optional for) | - | optdepends installation indicator |
 | ✓ | optional-for query | - | separate field for optdepends reason |
 | ✓ | fuzzy/strict querying | ✓ | existence querying |
@@ -140,7 +140,7 @@ learn about installation [here](#installation)
 | ✓ | abstract syntax tree | ✓ | directed acyclical graph for filtering |
 | - | user-defined macros | ✓ | parentetical (grouping) logic |
 | ✓ | limit from end | ✓ | limit from middle |
-| - | replaces sort | - | built-in macros |
+| ✓ | replaces sort | - | built-in macros |
 | - | query explaination | - | user configuration file |
 | ✓ | deb origin (apt/dpkg support) | ✓ | deb packaging |
 | - | replaced-by resolution | - | multi-license support | 

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -43,7 +43,7 @@ func GetComparator(field consts.FieldType, asc bool) (PkgComparator, error) {
 			return strings.ToLower(p.GetString(field))
 		}, asc), nil
 
-	case consts.FieldConflicts,
+	case consts.FieldConflicts, consts.FieldReplaces,
 		consts.FieldDepends, consts.FieldOptDepends,
 		consts.FieldRequiredBy, consts.FieldOptionalFor,
 		consts.FieldProvides:

--- a/qp.1
+++ b/qp.1
@@ -44,7 +44,7 @@ Existence check — \fBhas:field\fR or \fBno:field\fR
 
 .TP
 .B order <field>:<direction>, o <..>
-Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBsize\fR, \fBname\fR, \fBreason\fR, \fBversion\fR, \fBorigin\fR, \fBarch\fR, \fBlicense\fR, \fBdescription\fR, \fBurl\fR, \fBpkgbase\fR, \fBpkgtype\fR, \fBvalidation\fR, \fBpackager\fR, \fBconflicts\fR, \fBdepends\fR,\fBoptdepends\fR, \fBrequired-by\fR, \fBoptional-for\fR, \fBprovides\fR
+Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBsize\fR, \fBname\fR, \fBreason\fR, \fBversion\fR, \fBorigin\fR, \fBarch\fR, \fBlicense\fR, \fBdescription\fR, \fBurl\fR, \fBpkgbase\fR, \fBpkgtype\fR, \fBvalidation\fR, \fBpackager\fR, \fBconflicts\fR, \fBreplaces\fR, \fBdepends\fR,\fBoptdepends\fR, \fBrequired-by\fR, \fBoptional-for\fR, \fBprovides\fR
 
 .TP
 .B limit <number>, l <number>


### PR DESCRIPTION
Users can now sort by the length of replaces with `qp order replaces`, `qp order replaces:asc`, or `qp order replaces:desc`.


```
> qp s name,replaces o replaces
NAME                    REPLACES
vim                     vim-minimal
v4l-utils               libv4l
tinysparql              tracker3<=3.7.3-2
systemd-libs            libsystemd
util-linux-libs         libutil-linux
sqlite                  sqlite3
libdrm                  libdrm-new, libdrm-nouveau
openssl                 openssl-doc, openssl-perl
at-spi2-core            at-spi2-atk<=2.38.0-2, atk<=2.38.0-2
python                  python-externally-managed, python3
procps-ng               procps, sysvinit-tools
util-linux              hardlink, rfkill
ttf-nerd-fonts-symbols  ttf-nerd-fonts-symbols-1000-em, ttf-nerd-fonts-symbols-2048-em
mesa                    libva-mesa-driver<1:24.2.7-1, mesa-libgl<17.0.1-2, mesa-vdpau<1:24.2.7-1
ncurses                 alacritty-terminfo, rio-terminfo, wezterm-terminfo
qp                      yaylog, yaylog-bin, yaylog-git
x264                    libx264, libx264-10bit, libx264-all
systemd                 nss-myhostname, systemd-tools, udev
grub                    grub-bios, grub-common, grub-efi-aarch64, grub-emu
rust                    cargo, cargo-tree, rust-docs<1:1.56.1-3, rustfmt
```

Closes #307 