### PR TITLE
Feature: Add groups sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ learn about installation [here](#installation)
 | ✓ | depends query | ✓ | all-fields option |
 | ✓ | required-by query | ✓ | no cache option |
 | ✓ | optional full timestamp | ✓ | package description field |
-| ✓  | groups query | – | streaming pipeline |
+| ✓ | groups query | – | streaming pipeline |
 | – | short-args for queries | – | key/value output |
 | ✓ | package base query | ✓ | required-by sort |
 | ✓ | optdepends sort | ✓ | depends sort |
@@ -122,7 +122,7 @@ learn about installation [here](#installation)
 | ✓ | architecture query | ✓ | groups field |
 | ✓	| conflicts query | ✓ | package description sort |
 | ✓	| regenerate cache option | ✓ | validation query |
-| ✓ | url sort | - | groups sort |
+| ✓ | url sort | ✓ | groups sort |
 | ✓ | packager field | ✓ | optional dependency field |
 | ✓ | sort by size on disk | ✓ | conflicts sort |
 | ✓ | optional-for sort | ✓ | provides sort |
@@ -390,6 +390,7 @@ qp w q has:depends or has:required-by p and not reason=explicit
 - `pkgtype`
 - `pkgbase`
 - `packager`
+- `groups`
 - `conflicts`
 - `depends`
 - `optdepends`

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -43,6 +43,11 @@ func GetComparator(field consts.FieldType, asc bool) (PkgComparator, error) {
 			return strings.ToLower(p.GetString(field))
 		}, asc), nil
 
+	case consts.FieldGroups:
+		return makeComparator(func(p *PkgInfo) int {
+			return len(p.GetStrArr(field))
+		}, asc), nil
+
 	case consts.FieldConflicts, consts.FieldReplaces,
 		consts.FieldDepends, consts.FieldOptDepends,
 		consts.FieldRequiredBy, consts.FieldOptionalFor,

--- a/qp.1
+++ b/qp.1
@@ -44,7 +44,7 @@ Existence check — \fBhas:field\fR or \fBno:field\fR
 
 .TP
 .B order <field>:<direction>, o <..>
-Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBsize\fR, \fBname\fR, \fBreason\fR, \fBversion\fR, \fBorigin\fR, \fBarch\fR, \fBlicense\fR, \fBdescription\fR, \fBurl\fR, \fBpkgbase\fR, \fBpkgtype\fR, \fBvalidation\fR, \fBpackager\fR, \fBconflicts\fR, \fBreplaces\fR, \fBdepends\fR,\fBoptdepends\fR, \fBrequired-by\fR, \fBoptional-for\fR, \fBprovides\fR
+Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBsize\fR, \fBname\fR, \fBreason\fR, \fBversion\fR, \fBorigin\fR, \fBarch\fR, \fBlicense\fR, \fBdescription\fR, \fBurl\fR, \fBpkgbase\fR, \fBpkgtype\fR, \fBvalidation\fR, \fBpackager\fR, \fBgroups\fR, \fBconflicts\fR, \fBreplaces\fR, \fBdepends\fR,\fBoptdepends\fR, \fBrequired-by\fR, \fBoptional-for\fR, \fBprovides\fR
 
 .TP
 .B limit <number>, l <number>


### PR DESCRIPTION
Users can now sort by the length of groups with `qp order groups`, `qp order groups:asc`, or `qp order groups:desc`.

```
> qp s name,groups o groups
NAME                    GROUPS
xxhash                  -
xvidcore                -
yay-bin                 -
xz                      -
archlinuxarm-keyring    base-devel
fcitx5                  fcitx5-im
python-poetry-core      python-build-backend
python-setuptools       python-build-backend
pacman-mirrorlist       base
vulkan-icd-loader       vulkan-devel
vulkan-headers          vulkan-devel
ttf-nerd-fonts-symbols  nerd-fonts
tree-sitter-vimdoc      tree-sitter-grammars
tree-sitter-vim         tree-sitter-grammars
tree-sitter-query       tree-sitter-grammars
tree-sitter-markdown    tree-sitter-grammars
tree-sitter-c           tree-sitter-grammars
tree-sitter-lua         tree-sitter-grammars
spirv-tools             vulkan-devel
xorg-xprop              xorg-apps, xorg
```

Closes #309 