### PR TITLE
Feature: Add orphan macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,27 @@ for example:
   - `name=gtk` matches `gtk3`, `libgtk`, etc. (fuzzy)
   - `name==gtk` only matches a package named exactly `gtk`
 
+#### built-in macros
+
+some frequently-used query patterns are available as built-in macros for convenience.
+
+* `orphan` - matches orphaned packages (dependencies no longer required by anything):
+  ```
+  qp where orphan
+  ```
+
+  this is equivalent to:
+  ```
+  qp where no:required-by and reason=dependency
+  ```
+
+these macros can be combined with other queries as usual:
+
+```
+qp w orphan and size=100KB:
+qp w orphan and not name=gtk
+```
+
 #### query examples
 
 ```
@@ -322,7 +343,7 @@ qp w not arch=x86_64
 qp w q has:depends or has:required-by p and not reason=explicit
 ```
 
-#### query types
+#### field types
 
 | field type | description |
 |------------|-------------|

--- a/qp.1
+++ b/qp.1
@@ -121,6 +121,17 @@ Use to combine or negate queries:
 \fBq\fR ... \fBp\fR - group conditions (equivalent to parentheses)
 .RE
 
+.SH BUILT-IN MACROS
+Some common query patterns are available as macros.
+
+.TP
+.B orphan
+Matches orphaned packages - installed as dependencies but no longer required by any package.
+
+Equivalent to:
+.BR "qp where no:required-by and reason=dependency"
+
+
 .TP
 Group and combine logic:
 .B qp where q name=vim or name=nvim p and not has:conflicts


### PR DESCRIPTION
This feature was implemented a while back undocumented. It's time to start expanding and introducing macros to users.

`orphan` is equivalent to `no:required-by and reason=dependency`.

Example:
```
> qp w orphan
DATE        NAME                         REASON      SIZE
2025-02-11  libxss                       dependency  78.31 KB
2025-02-11  adobe-source-code-pro-fonts  dependency  1.86 MB
2025-02-11  ninja                        dependency  533.03 KB
2025-02-11  ibus                         dependency  113.92 MB
2025-02-11  libdecor                     dependency  165.36 KB
2025-02-11  fcitx5                       dependency  19.38 MB
2025-02-12  po4a                         dependency  3.60 MB
2025-03-01  python-installer             dependency  178.87 KB
2025-03-01  python-build                 dependency  202.26 KB
2025-03-31  cmake                        dependency  94.44 MB
2025-03-31  imagemagick                  dependency  28.33 MB
2025-03-31  pipewire                     dependency  4.54 MB
2025-03-31  python-setuptools-scm        dependency  377.91 KB
2025-03-31  vulkan-broadcom              dependency  7.82 MB
2025-03-31  wayland-protocols            dependency  906.43 KB
2025-03-31  vulkan-headers               dependency  30.54 MB
2025-03-31  zoxide                       dependency  1.05 MB
2025-04-02  rust                         dependency  221.98 MB
2025-04-02  mandown                      dependency  1.13 MB
2025-04-07  python-poetry-core           dependency  1.40 MB
```