### PR TITLE
Feature: Use concurrent workers for opkg

### DIFF
--- a/internal/origins/drivers/opkg/parser.go
+++ b/internal/origins/drivers/opkg/parser.go
@@ -8,15 +8,16 @@ import (
 	"path/filepath"
 	"qp/internal/consts"
 	"qp/internal/origins/formats/debstyle"
+	"qp/internal/origins/worker"
 	"qp/internal/pkgdata"
 	"strconv"
 )
 
 func parseStatusFile(data []byte, origin string) ([]*pkgdata.PkgInfo, error) {
-	var collectedErrors []error
-	pkgs := []*pkgdata.PkgInfo{}
+	blocks := bytes.Split(data, []byte("\n\n"))
+	inputChan := make(chan map[string]string, len(blocks))
 
-	for block := range bytes.SplitSeq(data, []byte("\n\n")) {
+	for _, block := range blocks {
 		if len(block) < 1 {
 			continue
 		}
@@ -26,19 +27,21 @@ func parseStatusFile(data []byte, origin string) ([]*pkgdata.PkgInfo, error) {
 			continue
 		}
 
-		pkg, err := parseStatusBlock(fields, origin)
-		if err != nil {
-			collectedErrors = append(collectedErrors, err)
-		}
-
-		pkgs = append(pkgs, pkg)
+		inputChan <- fields
 	}
+	close(inputChan)
 
-	if len(collectedErrors) > 0 {
-		return pkgs, errors.Join(collectedErrors...)
-	}
+	resultChan, errorChan := worker.RunWorkers(
+		inputChan,
+		func(fields map[string]string) (*pkgdata.PkgInfo, error) {
+			pkg, err := parseStatusBlock(fields, origin)
+			return pkg, err
+		},
+		0,
+		len(blocks),
+	)
 
-	return pkgs, nil
+	return worker.CollectOutput(resultChan, errorChan)
 }
 
 func parseStatusBlock(fields map[string]string, origin string) (*pkgdata.PkgInfo, error) {


### PR DESCRIPTION
The `opkg` driver now uses the concurrent worker patter. The `deb` driver will use a similar pattern, so they'll most likely be abstracted.