### PR TITLE
Feature: Add brew origin

### DIFF
--- a/cmd/qp/main.go
+++ b/cmd/qp/main.go
@@ -32,7 +32,7 @@ func mainWithConfig(configProvider config.ConfigProvider) error {
 
 	isInteractive := isInteractive(cfg.DisableProgress)
 
-	cacheBasePath, err := pkgdata.GetCacheBasePath()
+	cacheBasePath, err := pkgdata.GetCachePath()
 	if err != nil {
 		out.WriteLine(fmt.Sprintf("WARNING: failed to set up cache dir: %v", err))
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module qp
 go 1.24.1
 
 require (
+	github.com/goccy/go-json v0.10.5
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/term v0.28.0
 	google.golang.org/protobuf v1.36.6

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
+github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/internal/origins/drivers/brew/constants.go
+++ b/internal/origins/drivers/brew/constants.go
@@ -1,7 +1,7 @@
 package brew
 
 const (
-	formulaCachePath = ".cache/Homebrew/api/formula.jws.json"
+	formulaCachePath = "/Homebrew/api/formula.jws.json"
 	receiptName      = "INSTALL_RECEIPT.json"
 
 	armMacPrefix       = "/opt/homebrew"

--- a/internal/origins/drivers/brew/constants.go
+++ b/internal/origins/drivers/brew/constants.go
@@ -1,0 +1,14 @@
+package brew
+
+const (
+	formulaCachePath = ".cache/Homebrew/api/formula.jws.json"
+	receiptName      = "INSTALL_RECEIPT.json"
+
+	armMacPrefix       = "/opt/homebrew"
+	x86MacPrefix       = "/usr/local"
+	x86MacDetectPrefix = "/usr/local/Homebrew"
+	linuxPrefix        = "/home/linuxbrew/.linuxbrew"
+
+	cellarSubPath = "Cellar"
+	binSubPath    = "bin"
+)

--- a/internal/origins/drivers/brew/driver.go
+++ b/internal/origins/drivers/brew/driver.go
@@ -1,0 +1,51 @@
+package brew
+
+import (
+	"os"
+	"path/filepath"
+	"qp/internal/pkgdata"
+)
+
+type BrewDriver struct {
+	prefix string
+}
+
+func (d *BrewDriver) Name() string {
+	return "brew"
+}
+
+func (d *BrewDriver) Detect() bool {
+	prefix, err := getPrefix()
+	d.prefix = prefix
+
+	return err == nil
+}
+
+func (d *BrewDriver) Load() ([]*pkgdata.PkgInfo, error) {
+	return fetchPackages(d.Name(), d.prefix)
+}
+
+func (d *BrewDriver) ResolveDeps(pkgs []*pkgdata.PkgInfo) ([]*pkgdata.PkgInfo, error) {
+	return pkgdata.ResolveDependencyGraph(pkgs, nil)
+}
+
+func (d *BrewDriver) LoadCache(path string, modTime int64) ([]*pkgdata.PkgInfo, error) {
+	return pkgdata.LoadProtoCache(path, modTime)
+}
+
+func (d *BrewDriver) SaveCache(
+	path string,
+	pkgs []*pkgdata.PkgInfo,
+	modTime int64,
+) error {
+	return pkgdata.SaveProtoCache(pkgs, path, modTime)
+}
+
+func (d *BrewDriver) SourceModified() (int64, error) {
+	info, err := os.Stat(filepath.Join(d.prefix, cellarSubPath))
+	if err != nil {
+		return 0, err
+	}
+
+	return info.ModTime().Unix(), nil
+}

--- a/internal/origins/drivers/brew/driver.go
+++ b/internal/origins/drivers/brew/driver.go
@@ -66,5 +66,15 @@ func (d *BrewDriver) SourceModified() (int64, error) {
 		}
 	}
 
+	cellarInfo, err := os.Stat(cellarPath)
+	if err != nil {
+		return 0, fmt.Errorf("failed to stat Cellar: %w", err)
+	}
+
+	modTime := cellarInfo.ModTime().Unix()
+	if modTime > latest {
+		latest = modTime
+	}
+
 	return latest, nil
 }

--- a/internal/origins/drivers/brew/fetch.go
+++ b/internal/origins/drivers/brew/fetch.go
@@ -158,12 +158,7 @@ func resolveLinkedVersion(pkgName string, cellarRoot string, binRoot string) (st
 }
 
 func loadFormulaMetadataSubset(wanted map[string]struct{}) (map[string]*FormulaMetadata, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get home directory: %w", err)
-	}
-
-	fullPath := filepath.Join(homeDir, formulaCachePath)
+	fullPath := filepath.Join(pkgdata.GetBaseCachePath(), formulaCachePath)
 	data, err := os.ReadFile(fullPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read formula cache: %w", err)

--- a/internal/origins/drivers/brew/fetch.go
+++ b/internal/origins/drivers/brew/fetch.go
@@ -1,0 +1,157 @@
+package brew
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"qp/internal/pkgdata"
+	"strings"
+)
+
+func fetchPackages(origin string, prefix string) ([]*pkgdata.PkgInfo, error) {
+	formulaMeta, err := loadFormulaMetadata()
+	if err != nil {
+		return nil, err
+	}
+
+	binRoot := filepath.Join(prefix, binSubPath)
+	cellarRoot := filepath.Join(prefix, cellarSubPath)
+	installedNames, err := getInstalledPkgNames(cellarRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	var pkgs []*pkgdata.PkgInfo
+	for _, name := range installedNames {
+		version, err := getLinkedVersion(name, cellarRoot, binRoot)
+		if err != nil {
+			return nil, err
+		}
+
+		receiptPath := filepath.Join(cellarRoot, name, version, "INSTALL_RECEIPT.json")
+		pkg, err := parseInstallReceipt(receiptPath)
+		if err != nil {
+			return nil, err
+		}
+
+		if meta, ok := formulaMeta[name]; ok {
+			mergeFormulaMetadata(pkg, meta)
+		}
+
+		versionPath := filepath.Join(prefix, cellarSubPath, pkg.Name, pkg.Version)
+		size, err := getInstallSize(versionPath)
+		if err == nil {
+			pkg.Size = size
+		}
+
+		pkg.Origin = origin
+		pkgs = append(pkgs, pkg)
+	}
+
+	return pkgs, nil
+}
+
+func getInstalledPkgNames(cellarRoot string) ([]string, error) {
+	entries, err := os.ReadDir(cellarRoot)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Cellar directory: %w", err)
+	}
+
+	var names []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			names = append(names, entry.Name())
+		}
+	}
+
+	return names, nil
+}
+
+func getLinkedVersion(pkgName string, cellarRoot string, binRoot string) (string, error) {
+	pkgPath := filepath.Join(cellarRoot, pkgName)
+
+	entries, err := os.ReadDir(pkgPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read Cellar/%s: %w", pkgName, err)
+	}
+
+	// only check symlinks if there are multiple versions
+	if len(entries) == 1 {
+		return entries[0].Name(), nil
+	}
+
+	binPath := filepath.Join(binRoot, pkgName)
+	target, err := os.Readlink(binPath)
+	if err != nil {
+		return "", fmt.Errorf("no symlink found in /bin for %s", pkgName)
+	}
+
+	absPath, err := filepath.Abs(filepath.Join(filepath.Dir(binPath), target))
+	if err != nil {
+		return "", err
+	}
+
+	parts := strings.Split(filepath.Clean(absPath), string(os.PathSeparator))
+	if len(parts) < 3 {
+		return "", fmt.Errorf("unexpected symlink path: %s", absPath)
+	}
+
+	return parts[len(parts)-3], nil
+}
+
+func loadFormulaMetadata() (map[string]*FormulaMetadata, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	fullPath := filepath.Join(homeDir, formulaCachePath)
+	data, err := os.ReadFile(fullPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read formula cache: %w", err)
+	}
+
+	var container struct {
+		Payload string `json:"payload"`
+	}
+
+	if err := json.Unmarshal(data, &container); err != nil {
+		return nil, fmt.Errorf("failed to parse formula jws: %w", err)
+	}
+
+	var formulae []*FormulaMetadata
+	if err := json.Unmarshal([]byte(container.Payload), &formulae); err != nil {
+		return nil, fmt.Errorf("failed to parse formula payload: %w", err)
+	}
+
+	result := make(map[string]*FormulaMetadata)
+	for _, formula := range formulae {
+		result[formula.Name] = formula
+	}
+
+	return result, nil
+}
+
+func getInstallSize(dir string) (int64, error) {
+	var total int64
+
+	err := filepath.WalkDir(dir, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !d.IsDir() {
+			info, err := d.Info()
+			if err != nil {
+				return err
+			}
+			total += info.Size()
+		}
+
+		return nil
+	})
+
+	return total, err
+}

--- a/internal/origins/drivers/brew/fetch.go
+++ b/internal/origins/drivers/brew/fetch.go
@@ -87,6 +87,7 @@ func fetchPackages(
 			if meta, ok := formulaMeta[pkg.Name]; ok {
 				mergeFormulaMetadata(pkg, meta)
 			}
+
 			pkg.Origin = origin
 			return pkg, nil
 		},
@@ -109,11 +110,13 @@ func getInstalledPkgs(cellarRoot, binRoot string) ([]installedPkg, error) {
 		if !entry.IsDir() {
 			continue
 		}
+
 		name := entry.Name()
 		version, err := resolveLinkedVersion(name, cellarRoot, binRoot)
 		if err != nil {
 			continue
 		}
+
 		pkgs = append(pkgs, installedPkg{
 			Name:        name,
 			Version:     version,
@@ -172,15 +175,15 @@ func loadFormulaMetadataSubset(wanted map[string]struct{}) (map[string]*FormulaM
 		return nil, fmt.Errorf("failed to parse formula jws: %w", err)
 	}
 
-	var formulas []*FormulaMetadata
-	if err := json.Unmarshal([]byte(container.Payload), &formulas); err != nil {
+	var formulae []*FormulaMetadata
+	if err := json.Unmarshal([]byte(container.Payload), &formulae); err != nil {
 		return nil, fmt.Errorf("failed to parse formula payload: %w", err)
 	}
 
 	result := make(map[string]*FormulaMetadata, len(wanted))
-	for _, f := range formulas {
-		if _, ok := wanted[f.Name]; ok {
-			result[f.Name] = f
+	for _, formula := range formulae {
+		if _, ok := wanted[formula.Name]; ok {
+			result[formula.Name] = formula
 		}
 	}
 
@@ -190,16 +193,17 @@ func loadFormulaMetadataSubset(wanted map[string]struct{}) (map[string]*FormulaM
 func getInstallSize(dir string) (int64, error) {
 	var total int64
 
-	err := filepath.WalkDir(dir, func(_ string, d fs.DirEntry, err error) error {
+	err := filepath.WalkDir(dir, func(_ string, dir fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
-		if !d.IsDir() {
-			info, err := d.Info()
+		if !dir.IsDir() {
+			info, err := dir.Info()
 			if err != nil {
 				return err
 			}
+
 			total += info.Size()
 		}
 

--- a/internal/origins/drivers/brew/fetch.go
+++ b/internal/origins/drivers/brew/fetch.go
@@ -56,7 +56,7 @@ func fetchPackages(
 	stage1Out, stage1Err := worker.RunWorkers(
 		inputChan,
 		func(iPkg installedPkg) (*pkgdata.PkgInfo, error) {
-			return parseInstallReceipt(iPkg.ReceiptPath)
+			return parseInstallReceipt(iPkg.ReceiptPath, iPkg.Version)
 		},
 		0,
 		len(installedPkgs),
@@ -172,6 +172,7 @@ func loadFormulaMetadataSubset(wanted map[string]struct{}) (map[string]*FormulaM
 	var container struct {
 		Payload string `json:"payload"`
 	}
+
 	if err := json.Unmarshal(data, &container); err != nil {
 		return nil, fmt.Errorf("failed to parse formula jws: %w", err)
 	}

--- a/internal/origins/drivers/brew/parser.go
+++ b/internal/origins/drivers/brew/parser.go
@@ -65,6 +65,7 @@ func parseInstallReceipt(path string, version string) (*pkgdata.PkgInfo, error) 
 		InstallTimestamp: receipt.Time,
 		Name:             pkgName,
 		Reason:           inferInstallReason(receipt),
+		Version:          version,
 		Arch:             receipt.Arch,
 		PkgType:          getPkgType(receipt),
 		Depends:          parseDepends(receipt),

--- a/internal/origins/drivers/brew/parser.go
+++ b/internal/origins/drivers/brew/parser.go
@@ -23,12 +23,6 @@ type installReceipt struct {
 		PkgVersion       string `json:"pkg_version"`
 		DeclaredDirectly bool   `json:"declared_directly"`
 	} `json:"runtime_dependencies"`
-
-	Source struct {
-		Versions struct {
-			Stable string `json:"stable"`
-		} `json:"versions"`
-	} `json:"source"`
 }
 
 type FormulaMetadata struct {
@@ -51,7 +45,7 @@ func mergeFormulaMetadata(pkg *pkgdata.PkgInfo, formula *FormulaMetadata) {
 	pkg.OptDepends = parseOptDepends(formula.OptionalDependencies, formula.RecommendedDependencies)
 }
 
-func parseInstallReceipt(path string) (*pkgdata.PkgInfo, error) {
+func parseInstallReceipt(path string, version string) (*pkgdata.PkgInfo, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read receipt JSON: %v", err)
@@ -70,7 +64,6 @@ func parseInstallReceipt(path string) (*pkgdata.PkgInfo, error) {
 	pkg := &pkgdata.PkgInfo{
 		InstallTimestamp: receipt.Time,
 		Name:             pkgName,
-		Version:          receipt.Source.Versions.Stable,
 		Reason:           inferInstallReason(receipt),
 		Arch:             receipt.Arch,
 		PkgType:          getPkgType(receipt),

--- a/internal/origins/drivers/brew/parser.go
+++ b/internal/origins/drivers/brew/parser.go
@@ -1,23 +1,22 @@
 package brew
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"qp/internal/consts"
 	"qp/internal/pkgdata"
 	"strings"
+
+	json "github.com/goccy/go-json"
 )
 
 type installReceipt struct {
-	Time                  int64  `json:"time"`
-	Compiler              string `json:"compiler"`
-	InstalledOnRequest    bool   `json:"installed_on_request"`
-	InstalledAsDependency bool   `json:"installed_as_dependency"`
-	BuiltAsBottle         bool   `json:"built_as_bottle"`
-	PouredFromBottle      bool   `json:"poured_from_bottle"`
-	Arch                  string `json:"arch"`
+	Time               int64  `json:"time"`
+	InstalledOnRequest bool   `json:"installed_on_request"`
+	BuiltAsBottle      bool   `json:"built_as_bottle"`
+	PouredFromBottle   bool   `json:"poured_from_bottle"`
+	Arch               string `json:"arch"`
 
 	RuntimeDependencies []struct {
 		FullName         string `json:"full_name"`
@@ -29,27 +28,14 @@ type installReceipt struct {
 		Versions struct {
 			Stable string `json:"stable"`
 		} `json:"versions"`
-		Path string `json:"path"`
-		Tap  string `json:"tap"`
 	} `json:"source"`
 }
 
 type FormulaMetadata struct {
-	Name      string `json:"name"`
-	Desc      string `json:"desc"`
-	License   string `json:"license"`
-	Homepage  string `json:"homepage"`
-	LinkedKeg string `json:"linked_keg"`
-	Versions  struct {
-		Stable string `json:"stable"`
-	} `json:"versions"`
-	Bottle struct {
-		Stable struct {
-			Files map[string]struct {
-				SHA256 string `json:"sha256"`
-			} `json:"files"`
-		} `json:"stable"`
-	} `json:"bottle"`
+	Name                    string   `json:"name"`
+	Desc                    string   `json:"desc"`
+	License                 string   `json:"license"`
+	Homepage                string   `json:"homepage"`
 	OptionalDependencies    []string `json:"optional_dependencies"`
 	RecommendedDependencies []string `json:"recommended_dependencies"`
 }
@@ -118,10 +104,8 @@ func inferInstallReason(receipt installReceipt) string {
 	switch {
 	case receipt.InstalledOnRequest:
 		return consts.ReasonExplicit
-	case receipt.InstalledAsDependency:
-		return consts.ReasonDependency
 	default:
-		return "unknown" // TODO: perhaps this should be blank
+		return consts.ReasonDependency // TODO: perhaps this should be blank
 	}
 }
 

--- a/internal/origins/drivers/brew/paths.go
+++ b/internal/origins/drivers/brew/paths.go
@@ -1,0 +1,30 @@
+package brew
+
+import (
+	"fmt"
+	"os"
+)
+
+func getPrefix() (string, error) {
+	possiblePrefixes := []string{
+		armMacPrefix,
+		x86MacDetectPrefix,
+		linuxPrefix,
+	}
+
+	for _, path := range possiblePrefixes {
+		if _, err := os.Stat(path); err == nil {
+			return normalizeMac(path), nil
+		}
+	}
+
+	return "", fmt.Errorf("no valid Homebrew prefix found")
+}
+
+func normalizeMac(detectedPrefix string) string {
+	if detectedPrefix == x86MacDetectPrefix {
+		return x86MacPrefix
+	}
+
+	return detectedPrefix
+}

--- a/internal/origins/registry.go
+++ b/internal/origins/registry.go
@@ -2,6 +2,7 @@ package origins
 
 import (
 	"qp/api/driver"
+	"qp/internal/origins/drivers/brew"
 	"qp/internal/origins/drivers/deb"
 	"qp/internal/origins/drivers/opkg"
 	"qp/internal/origins/drivers/pacman"
@@ -10,6 +11,7 @@ import (
 var registeredDrivers = []driver.Driver{
 	&opkg.OpkgDriver{},
 	&deb.DebDriver{},
+	&brew.BrewDriver{},
 	&pacman.PacmanDriver{},
 }
 

--- a/internal/pipeline/phase/pipeline.go
+++ b/internal/pipeline/phase/pipeline.go
@@ -29,7 +29,7 @@ func NewPipeline(
 ) *Pipeline {
 	modTime, err := origin.SourceModified()
 	if err != nil {
-		out.WriteLine(fmt.Sprintf("WARNING: failed to get mod time for origin %s", origin.Name()))
+		out.WriteLine(fmt.Sprintf("WARNING: failed to get mod time for origin %s: %v", origin.Name(), err))
 		modTime = time.Now().Unix()
 	}
 

--- a/internal/pkgdata/cache.go
+++ b/internal/pkgdata/cache.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	pb "qp/internal/protobuf"
+	"runtime"
 
 	"google.golang.org/protobuf/proto"
 )
@@ -17,18 +18,26 @@ const (
 	qpCacheDir      = "query-packages"
 )
 
-func GetCacheBasePath() (string, error) {
-	userCacheDir := os.Getenv(xdgCacheHomeEnv)
-	if userCacheDir == "" {
-		userCacheDir = filepath.Join(os.Getenv(homeEnv), ".cache")
-	}
-
-	cachePath := filepath.Join(userCacheDir, qpCacheDir)
+func GetCachePath() (string, error) {
+	cachePath := filepath.Join(GetBaseCachePath(), qpCacheDir)
 	if err := os.MkdirAll(cachePath, 0755); err != nil {
 		return "", fmt.Errorf("failed to create cache directory: %w", err)
 	}
 
 	return cachePath, nil
+}
+
+func GetBaseCachePath() string {
+	if runtime.GOOS == "darwin" {
+		return filepath.Join(os.Getenv(homeEnv), "Library/Caches")
+	}
+
+	userCacheDir := os.Getenv(xdgCacheHomeEnv)
+	if userCacheDir == "" {
+		userCacheDir = filepath.Join(os.Getenv(homeEnv), ".cache")
+	}
+
+	return userCacheDir
 }
 
 func SaveProtoCache(pkgs []*PkgInfo, cachePath string, lastModified int64) error {

--- a/internal/pkgdata/cache.go
+++ b/internal/pkgdata/cache.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	cacheVersion    = 18 // bump when updating structure of PkgInfo/Relation/pkginfo.proto OR when dependency resolution is updated
+	cacheVersion    = 19 // bump when updating structure of PkgInfo/Relation/pkginfo.proto OR when dependency resolution is updated
 	xdgCacheHomeEnv = "XDG_CACHE_HOME"
 	homeEnv         = "HOME"
 	qpCacheDir      = "query-packages"


### PR DESCRIPTION
We now have support for brew (Homebrew) in `qp`. Right now only formulae and bottles are supported, but cask support is coming soon. Once cask support is complete, MacOS compilation will follow. 

```
qp s default,origin 
DATE        NAME       REASON      SIZE       ORIGIN
2025-05-15  fastfetch  explicit    2.74 MB    brew
2025-05-15  go         explicit    247.32 MB  brew
2025-05-16  fswatch    explicit    1.18 MB    brew
2025-05-16  oniguruma  dependency  1.45 MB    brew
2025-05-16  jq         explicit    1.36 MB    brew
```