### PR TITLE
Refactor: Use "formula" instead of "bottle" as pkgtype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ src-bundle
 *.local
 *.bak
 
+notes.md
+
 /vendor/
 
 *.prof

--- a/internal/origins/drivers/brew/parser.go
+++ b/internal/origins/drivers/brew/parser.go
@@ -67,25 +67,13 @@ func parseInstallReceipt(path string, version string) (*pkgdata.PkgInfo, error) 
 		Reason:           inferInstallReason(receipt),
 		Version:          version,
 		Arch:             receipt.Arch,
-		PkgType:          getPkgType(receipt),
+		PkgType:          "formula",
 		Depends:          parseDepends(receipt),
 	}
 
 	inferBuildDate(pkg, receipt)
 
 	return pkg, nil
-}
-
-func getPkgType(receipt installReceipt) string {
-	if receipt.BuiltAsBottle && receipt.PouredFromBottle {
-		return "bottle"
-	}
-
-	if receipt.BuiltAsBottle {
-		return "local_bottle"
-	}
-
-	return "source"
 }
 
 func inferBuildDate(pkg *pkgdata.PkgInfo, receipt installReceipt) {

--- a/internal/pkgdata/cache.go
+++ b/internal/pkgdata/cache.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	cacheVersion    = 19 // bump when updating structure of PkgInfo/Relation/pkginfo.proto OR when dependency resolution is updated
+	cacheVersion    = 20 // bump when updating structure of PkgInfo/Relation/pkginfo.proto OR when dependency resolution is updated
 	xdgCacheHomeEnv = "XDG_CACHE_HOME"
 	homeEnv         = "HOME"
 	qpCacheDir      = "query-packages"


### PR DESCRIPTION
As we move towards adding Cask support, the two main types of packages will be "formula" and "cask" going forward.