### PR TITLE
Feature: Add superorphan macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ learn about installation [here](#installation)
 | ✓ | abstract syntax tree | ✓ | directed acyclical graph for filtering |
 | - | user-defined macros | ✓ | parentetical (grouping) logic |
 | ✓ | limit from end | ✓ | limit from middle |
-| - | built-in macros | – | streaming pipeline |
+| ✓ | built-in macros | – | streaming pipeline |
 | - | query explaination | - | user configuration file |
 | ✓ | deb origin (apt/dpkg support) | ✓ | deb packaging |
 | ✓ | opkg origin (openwrt support) | - | brew origin (homebrew support)|
@@ -319,16 +319,26 @@ some frequently-used query patterns are available as built-in macros for conveni
   qp where orphan
   ```
 
-  this is equivalent to:
+  is equivalent to:
   ```
   qp where no:required-by and reason=dependency
+  ```
+
+* `superorphan` - matches "super" orphaned packages (dependencies no longer required by anything AND optional for nothing)
+  ```
+  qp w superorphan
+  ```
+
+  is equivalent to:
+  ```
+  qp where no:required-by and reason=dependency and no:optional-for
   ```
 
 these macros can be combined with other queries as usual:
 
 ```
 qp w orphan and size=100KB:
-qp w orphan and not name=gtk
+qp w superorphan and not name=gtk
 ```
 
 #### query examples

--- a/internal/config/help.go
+++ b/internal/config/help.go
@@ -82,6 +82,10 @@ Short Command Examples:
   qp w reason=explicit and size=50MB:
   qp w q size=10MB:1GB or size==20MB p and not has:depends
 
+Build-in Macros:
+  - 'qp w orphan' is equivalent to 'qp where no:required-by and reason=dependency'
+  - 'qp w superorphan' is equivalent to 'qp where no:required-by and reason=dependency and no:optional-for'
+
 Tips:
   - Queries can include comma-separated values, these act a shorthand for 'or' logic:
       arch=aarch64,any

--- a/qp.1
+++ b/qp.1
@@ -121,20 +121,26 @@ Use to combine or negate queries:
 \fBq\fR ... \fBp\fR - group conditions (equivalent to parentheses)
 .RE
 
-.SH BUILT-IN MACROS
+.TP
+Group and combine logic:
+.B qp where q name=vim or name=nvim p and not has:conflicts
+
+.SH Built-in Macros
 Some common query patterns are available as macros.
 
 .TP
 .B orphan
 Matches orphaned packages - installed as dependencies but no longer required by any package.
 
-Equivalent to:
+"qp where orphan" is equivalent to:
 .BR "qp where no:required-by and reason=dependency"
 
-
 .TP
-Group and combine logic:
-.B qp where q name=vim or name=nvim p and not has:conflicts
+.B superorphan
+Matches super-orphaned packages - installed as dependencies but are required by nothing AND optional for nothing.
+
+"qp where superorphan" is equivalent to:
+.BR "qp where no:required-by and reason=dependency and no:optional-for"
 
 .SH SUPPORTED QUERY FIELDS
 .TP


### PR DESCRIPTION
`superorphan` is equivalent to `no:required-by and reason=dependency and no:optional-for`.

Example:
```
> qp w superorphan
DATE        NAME                         REASON      SIZE
2024-12-18  ca-certificates              dependency  0 B
2024-12-18  dbus-units                   dependency  0 B
2024-12-18  argon2                       dependency  165.79 KB
2024-12-18  ldns                         dependency  3.14 MB
2025-01-15  p7zip                        dependency  11.24 MB
2025-01-25  bridge-utils                 dependency  40.73 KB
2025-02-11  libxss                       dependency  78.31 KB
2025-02-11  adobe-source-code-pro-fonts  dependency  1.86 MB
2025-02-11  ibus                         dependency  113.92 MB
2025-02-11  fcitx5                       dependency  19.38 MB
2025-02-12  po4a                         dependency  3.60 MB
2025-03-01  python-installer             dependency  178.87 KB
2025-03-01  python-build                 dependency  202.26 KB
2025-03-31  cmake                        dependency  94.44 MB
2025-03-31  python-setuptools-scm        dependency  377.91 KB
2025-03-31  vulkan-headers               dependency  30.54 MB
2025-03-31  wayland-protocols            dependency  906.43 KB
2025-04-02  mandown                      dependency  1.13 MB
2025-04-07  python-poetry-core           dependency  1.40 MB
```