### PR TITLE
Feature: Add `--output` flag (deprecate `--json`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,6 @@ for the latest (unstable) version from git w/ the AUR, use `qp-git`*.
 
 ***note**: this is not recommended for most users
 
-the cache is located under `/query-packages` at `$HOME/.cache/` or wherever you have `$XDG_HOME_CACHE` set to.
-
 ### debian-based systems (e.g. ubuntu, mint, pop!_os)
 
 to install the latest `.deb` release for your system architecture:
@@ -199,6 +197,14 @@ installation via `apt` is coming soon™!
    sudo install -m644 qp.1 /usr/share/man/man1/qp.1
    ```
 
+### cache
+
+#### linux:
+the cache is located under `/query-packages` at `$HOME/.cache/` or wherever you have `$XDG_HOME_CACHE` set to.
+
+#### macOS:
+the cache is located under `/query-packages` at `$HOME/Library/Caches/`
+
 ## usage
 
 ```bash
@@ -234,7 +240,7 @@ qp [command] [args] [options]
 
 - `--no-headers`: omit column headers in table output (useful for scripting)
 - `--full-timestamp`: display the full timestamp (date and time) of package install/build instead of just the date
-- `--json`: output results in JSON format (overrides table output and `--full-timestamp`)
+- `--output`: output format, `table` or `json` (default:`table`)
 - `--no-progress`: force no progress bar outside of non-interactive environments
 - `--no-cache`: disable cache loading/saving and force fresh package data loading
 - `--regen-cache`: disable cache loading, force fresh package data loading, and save fresh cache
@@ -406,11 +412,11 @@ qp w q has:depends or has:required-by p and not reason=explicit
 
 ### JSON output
 
-the `--json` flag outputs the package data as structured JSON instead of a table. this can be useful for scripts or automation.
+`--output json` outputs the package data as structured JSON instead of a table. this can be useful for scripts or automation.
 
 example:
 ```
-qp select all where name=gtk3 --json
+qp select all where name=gtk3 --output json
 ```
 
 `gtk3` is one of the few packages that actually has all the fields populated.
@@ -627,22 +633,22 @@ output format:
 
 17. output package data in JSON format
    ```
-   qp --json
+   qp --output json
    ```
 
 18. save all explicitly installed packages to a JSON file
    ```
-   qp where reason=explicit --json > explicit-packages.json
+   qp where reason=explicit --output json > explicit-packages.json
    ```
 
 19. output all packages sorted by size (descending) in JSON
    ```
-   qp order size:desc limit all --json
+   qp order size:desc limit all --output json
    ```
 
 20. output JSON with specific fields
    ```
-   qp select name,version,size --json
+   qp select name,version,size --output json
    ```
 
 21. show all available package details for all packages
@@ -652,7 +658,7 @@ output format:
 
 22. output all packages with all fields in JSON format
    ```
-   qp select all limit all --json
+   qp select all limit all --output json
    ```
 
 23. show package names and sizes without headers for scripting

--- a/README.md
+++ b/README.md
@@ -55,23 +55,9 @@ more distros and non-linux platforms are planned!
 ## features
 
 - list installed packages by numerous fields
-  - see all available fields for selection [here](#available-fields-for-selection)
-- query by:
-  - field existence
-  - explicitly installed packages
-  - packages installed as dependencies, required by specified packages, depend upon specified packages, provide specified packages, conflict with specific packages
-  - packages that contain specific licenses
-  - installation/build date or date range
-  - packages built with specified architectures
-  - package size or size range
-  - package names, descriptions, and packagers
+- query by those fields
   - learn more about querying [here](#querying-with-where)
-- sort by: 
-  - installation date and build date
-  - package name
-  - license
-  - size on disk
-  - package base, package type, and packager
+- sort by those fields
 - output as:
   - table
   - JSON
@@ -153,7 +139,8 @@ learn about installation [here](#installation)
 | ✓ | built-in macros | – | streaming pipeline |
 | - | query explaination | - | user configuration file |
 | ✓ | deb origin (apt/dpkg support) | ✓ | deb packaging |
-| ✓ | opkg origin (openwrt support) | - | brew origin (homebrew support)|
+| ✓ | opkg origin (openwrt support) | ✓ | brew origin (homebrew support)|
+| ✓ | bottles in brew | - | casks in brew |
 | - | replaced-by resolution | - | multi-license support |
 | – | short-args for queries | – | key/value output |
 
@@ -252,6 +239,33 @@ qp [command] [args] [options]
 - `--no-cache`: disable cache loading/saving and force fresh package data loading
 - `--regen-cache`: disable cache loading, force fresh package data loading, and save fresh cache
 - `-h` | `--help`: print help info
+
+### available fields
+
+- `date` - installation date of the package
+- `build-date` - date the package was built
+- `size` - package size on disk
+- `name` - package name
+- `reason` - installation reason (explicit/dependency)
+- `version` - installed package version
+- `origin` - the package ecosystem or source the package belongs to (e.g., pacman); reflects which package manager or backend maintains it
+- `arch` - architecture the package was built for (e.g., x86_64, aarch64, any)
+- `license` - package software license
+- `description` - package description
+- `url` - the URL of the official site of the software being packaged
+- `validation` - package integrity validation method (e.g., sha256, pgp)
+- `pkgtype` - package type (pkg, split, debug, src)
+    - ***note**: older packages may have no pkgtype if built before pacman introduced XDATA
+- `pkgbase` - name of the base package used to group split packages; for non-split packages, it is the same as the package name. 
+- `packager` - person/entity who built the package (if available)
+- `groups` - list of package groups or categories (e.g., base, gnome, xfce4)
+- `conflicts` - list of packages that conflict, or cause problems, with the package
+- `replaces` - list of packages that are replaced by the package
+- `depends` - list of dependencies
+- `optdepends` - list of optional dependencies
+- `required-by` - list of packages required by the package and are dependent
+- `optional-for` - list of packages that optionally depend on the package (optionally dependent)
+- `provides` - list of alternative package names or shared libraries provided by package
 
 ### querying with `where`
 
@@ -353,6 +367,7 @@ qp w not arch=x86_64
 qp w q has:depends or has:required-by p and not reason=explicit
 ```
 
+
 #### field types
 
 | field type | description |
@@ -361,7 +376,7 @@ qp w q has:depends or has:required-by p and not reason=explicit
 | range | matches numerical or time-based fields across a range. <br> supports full ranges (start:end), open-ended ranges (start: / :end), or exact values |
 | relation | matches fields that contain relationships to other packages (e.g., dependencies, conflicts, provides) <br> can take a comma-separated list |
 
-#### available queries
+#### fields and their types
 
 | field name | field type |
 |------------|------------|
@@ -388,58 +403,6 @@ qp w q has:depends or has:required-by p and not reason=explicit
 | required-by | relation |
 | optional-for | relation |
 | provides | relation |
-
-### available selectors
-
-- `date` - installation date of the package
-- `build-date` - date the package was built
-- `size` - package size on disk
-- `name` - package name
-- `reason` - installation reason (explicit/dependency)
-- `version` - installed package version
-- `origin` - the package ecosystem or source the package belongs to (e.g., pacman); reflects which package manager or backend maintains it
-- `arch` - architecture the package was built for (e.g., x86_64, aarch64, any)
-- `license` - package software license
-- `description` - package description
-- `url` - the URL of the official site of the software being packaged
-- `validation` - package integrity validation method (e.g., sha256, pgp)
-- `pkgtype` - package type (pkg, split, debug, src)
-    - ***note**: older packages may have no pkgtype if built before pacman introduced XDATA
-- `pkgbase` - name of the base package used to group split packages; for non-split packages, it is the same as the package name. 
-- `packager` - person/entity who built the package (if available)
-- `groups` - package groups or categories (e.g., base, gnome, xfce4)
-- `conflicts` - list of packages that conflict, or cause problems, with the package
-- `replaces` - list of packages that are replaced by the package
-- `depends` - list of dependencies
-- `optdepends` - list of optional dependencies
-- `required-by` - list of packages required by the package and are dependent
-- `optional-for` - list of packages that optionally depend on the package (optionally dependent)
-- `provides` - list of alternative package names or shared libraries provided by package
-
-### available sorts
-
-- `date`
-- `build-date`
-- `size`
-- `name`
-- `reason`
-- `version`
-- `origin`
-- `arch`
-- `license`
-- `description`
-- `url`
-- `validation`
-- `pkgtype`
-- `pkgbase`
-- `packager`
-- `groups`
-- `conflicts`
-- `depends`
-- `optdepends`
-- `required-by`
-- `optional-for`
-- `provides`
 
 ### JSON output
 

--- a/cmd/qp/main.go
+++ b/cmd/qp/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"qp/internal/config"
+	"qp/internal/consts"
 	out "qp/internal/display"
 	"qp/internal/origins"
 	"qp/internal/pipeline/phase"
@@ -85,7 +87,10 @@ func mainWithConfig(configProvider config.ConfigProvider) error {
 	}
 
 	allPkgs = trimPackagesLen(allPkgs, cfg)
-	renderOutput(allPkgs, cfg)
+	err = renderOutput(allPkgs, cfg)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -129,13 +134,17 @@ func trimPackagesLen(
 	}
 }
 
-func renderOutput(pkgs []*pkgdata.PkgInfo, cfg *config.Config) {
-	if cfg.OutputJSON {
+func renderOutput(pkgs []*pkgdata.PkgInfo, cfg *config.Config) error {
+	switch cfg.OutputFormat {
+	case consts.OutputTable:
+		out.RenderTable(pkgs, cfg.Fields, cfg.ShowFullTimestamp, cfg.HasNoHeaders)
+	case consts.OutputJSON:
 		out.RenderJSON(pkgs, cfg.Fields)
-		return
+	default:
+		return errors.New("invalid output format")
 	}
 
-	out.RenderTable(pkgs, cfg.Fields, cfg.ShowFullTimestamp, cfg.HasNoHeaders)
+	return nil
 }
 
 func isInteractive(disableProgress bool) bool {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,7 +11,7 @@ type Config struct {
 	Limit             int
 	ShowHelp          bool
 	ShowVersion       bool
-	OutputJSON        bool
+	OutputFormat      string
 	HasNoHeaders      bool
 	ShowFullTimestamp bool
 	DisableProgress   bool

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -128,7 +128,7 @@ func markHiddenFlags() {
 
 func registerCommonFlags(cfg *Config) {
 	pflag.BoolVar(&cfg.HasNoHeaders, "no-headers", false, "Hide headers")
-	pflag.BoolVar(&cfg.OutputJSON, "json", false, "Output in JSON format")
+	pflag.StringVar(&cfg.OutputFormat, "output", "table", "Output format: \"table\" or \"json\"")
 	pflag.BoolVarP(&cfg.ShowHelp, "help", "h", false, "Show help")
 	pflag.BoolVar(&cfg.ShowVersion, "version", false, "Show version")
 	pflag.BoolVar(&cfg.ShowFullTimestamp, "full-timestamp", false, "Show full timestamp")
@@ -172,4 +172,12 @@ func registerLegacyFlags(
 	pflag.StringVar(sizeFilter, "size", "", "")
 	pflag.StringVar(nameFilter, "name", "", "")
 	pflag.StringVar(requiredByFilter, "required-by", "", "")
+
+	var legacyJSON bool
+	pflag.BoolVar(&legacyJSON, "json", false, "")
+	_ = pflag.CommandLine.MarkHidden("json")
+	_ = pflag.CommandLine.MarkDeprecated("json", "use --output json instead")
+	if legacyJSON {
+		cfg.OutputFormat = consts.OutputJSON
+	}
 }

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -176,7 +176,7 @@ func registerLegacyFlags(
 	var legacyJSON bool
 	pflag.BoolVar(&legacyJSON, "json", false, "")
 	_ = pflag.CommandLine.MarkHidden("json")
-	_ = pflag.CommandLine.MarkDeprecated("json", "use --output json instead")
+	_ = pflag.CommandLine.MarkDeprecated("json", "use \"--output json\" instead")
 	if legacyJSON {
 		cfg.OutputFormat = consts.OutputJSON
 	}

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -176,7 +176,7 @@ func registerLegacyFlags(
 	var legacyJSON bool
 	pflag.BoolVar(&legacyJSON, "json", false, "")
 	_ = pflag.CommandLine.MarkHidden("json")
-	_ = pflag.CommandLine.MarkDeprecated("json", "use \"--output json\" instead")
+	_ = pflag.CommandLine.MarkDeprecated("json", "use \"--output json\" instead.")
 	if legacyJSON {
 		cfg.OutputFormat = consts.OutputJSON
 	}

--- a/internal/consts/output.go
+++ b/internal/consts/output.go
@@ -1,0 +1,7 @@
+package consts
+
+const (
+	OutputJSON     = "json"
+	OutputTable    = "table"
+	OutputKeyValue = "kv"
+)

--- a/internal/display/formatting.go
+++ b/internal/display/formatting.go
@@ -11,7 +11,7 @@ import (
 
 func formatRelations(relations []pkgdata.Relation) string {
 	if len(relations) == 0 {
-		return "-"
+		return ""
 	}
 
 	return strings.Join(flattenRelations(relations), ", ")


### PR DESCRIPTION
As we plan to add more output types, `--json` is too prominent in main flags.

It has been replaced with `--output json`. `--json` is an alias for `--output json` for now but it will be fully deprecated in the future. 