### PR TITLE
Feature: Add key-value output (`kv`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ qp [command] [args] [options]
   - `select default` | `s default` will act as a list of all default fields
   - use `select default,version` to list default fields + version
   - use `select all,version` to list default fields + version
-  - [see fields available for selection](#available-selectors)
+  - [see fields available for selection](#available-fields)
 - `where <query>` | `w <query>`: apply one or more queries to refine package results.
   - supported query types:
     - **string match** -> `field=value` (fuzzy) or `field==value` (strict)
@@ -230,7 +230,6 @@ qp [command] [args] [options]
   - learn more about querying [here](#querying-with-where)
 - `order <field>:<direction>` | `o <field>:<direction>`: sort results ascending or descending
   - default sort is `date:asc`:
-  - [see fields avaialble for sorting](#available-sorts)
 - `limit <number>` | `l <number>`: limit the amount of packages to display (default: 20)
   - `limit all` | `l all`: display all packages
   - `limit end:<number>`: display last `n` packages

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ learn about installation [here](#installation)
 | ✓ | opkg origin (openwrt support) | ✓ | brew origin (homebrew support)|
 | ✓ | bottles in brew | - | casks in brew |
 | - | replaced-by resolution | - | multi-license support |
-| – | short-args for queries | – | key/value output |
+| – | short-args for queries | ✓ | key/value output |
 
 ## installation
 
@@ -240,7 +240,7 @@ qp [command] [args] [options]
 
 - `--no-headers`: omit column headers in table output (useful for scripting)
 - `--full-timestamp`: display the full timestamp (date and time) of package install/build instead of just the date
-- `--output`: output format, `table` or `json` (default:`table`)
+- `--output`: format output as `table`, `kv` (key-value), `json` (default:`table`)
 - `--no-progress`: force no progress bar outside of non-interactive environments
 - `--no-cache`: disable cache loading/saving and force fresh package data loading
 - `--regen-cache`: disable cache loading, force fresh package data loading, and save fresh cache

--- a/README.md
+++ b/README.md
@@ -214,8 +214,8 @@ qp [command] [args] [options]
 ### commands
 
 - `select <list>` | `s <list>`: comma-separated list of fields to display
-  - `select all | s all` will act as a list of all available fields
-  - `select default | s default` will act as a list of all default fields
+  - `select all` | `s all` will act as a list of all available fields
+  - `select default` | `s default` will act as a list of all default fields
   - use `select default,version` to list default fields + version
   - use `select all,version` to list default fields + version
   - [see fields available for selection](#available-selectors)
@@ -232,7 +232,7 @@ qp [command] [args] [options]
   - default sort is `date:asc`:
   - [see fields avaialble for sorting](#available-sorts)
 - `limit <number>` | `l <number>`: limit the amount of packages to display (default: 20)
-  - `limit all | l all`: display all packages
+  - `limit all` | `l all`: display all packages
   - `limit end:<number>`: display last `n` packages
   - `limit mid:<number>`: display middle `n` packages
 

--- a/cmd/qp/main.go
+++ b/cmd/qp/main.go
@@ -138,6 +138,8 @@ func renderOutput(pkgs []*pkgdata.PkgInfo, cfg *config.Config) error {
 	switch cfg.OutputFormat {
 	case consts.OutputTable:
 		out.RenderTable(pkgs, cfg.Fields, cfg.ShowFullTimestamp, cfg.HasNoHeaders)
+	case consts.OutputKeyValue:
+		out.RenderKeyValue(pkgs, cfg.Fields)
 	case consts.OutputJSON:
 		out.RenderJSON(pkgs, cfg.Fields)
 	default:

--- a/cmd/qp/main_test.go
+++ b/cmd/qp/main_test.go
@@ -21,10 +21,10 @@ func (m *MockConfigProvider) GetConfig() (*config.Config, error) {
 // TODO: more testing, this is just validating if the depenendency injection works for testing
 func TestMainWithConfig(t *testing.T) {
 	mockCfg := config.Config{
-		Limit:      5,
-		SortOption: syntax.SortOption{Field: consts.FieldSize, Asc: false},
-		OutputJSON: true,
-		Fields:     []consts.FieldType{consts.FieldName, consts.FieldSize},
+		Limit:        5,
+		SortOption:   syntax.SortOption{Field: consts.FieldSize, Asc: false},
+		OutputFormat: consts.OutputJSON,
+		Fields:       []consts.FieldType{consts.FieldName, consts.FieldSize},
 	}
 
 	var buf bytes.Buffer
@@ -44,7 +44,7 @@ func TestMainWithConfig(t *testing.T) {
 	}
 
 	expectedSubstring := "{"
-	if mockCfg.OutputJSON && !strings.Contains(output, expectedSubstring) {
+	if mockCfg.OutputFormat == consts.OutputJSON && !strings.Contains(output, expectedSubstring) {
 		t.Errorf("Expected JSON output but did not find JSON structure")
 	}
 }

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -128,7 +128,7 @@ func markHiddenFlags() {
 
 func registerCommonFlags(cfg *Config) {
 	pflag.BoolVar(&cfg.HasNoHeaders, "no-headers", false, "Hide headers")
-	pflag.StringVar(&cfg.OutputFormat, "output", "table", "Output format: \"table\" or \"json\"")
+	pflag.StringVar(&cfg.OutputFormat, "output", "table", "Output format: \"table\", \"json\", or \"kv\" (key-value)")
 	pflag.BoolVarP(&cfg.ShowHelp, "help", "h", false, "Show help")
 	pflag.BoolVar(&cfg.ShowVersion, "version", false, "Show version")
 	pflag.BoolVar(&cfg.ShowFullTimestamp, "full-timestamp", false, "Show full timestamp")

--- a/internal/display/output_manager.go
+++ b/internal/display/output_manager.go
@@ -63,6 +63,10 @@ func RenderJSON(pkgPtrs []*pkgdata.PkgInfo, fields []consts.FieldType) {
 	manager.renderJSON(pkgPtrs, fields)
 }
 
+func RenderKeyValue(pkgs []*pkgdata.PkgInfo, fields []consts.FieldType) {
+	manager.renderKeyValue(pkgs, fields)
+}
+
 func (o *OutputManager) write(msg string) {
 	o.mu.Lock()
 	defer o.mu.Unlock()

--- a/internal/display/render_kv.go
+++ b/internal/display/render_kv.go
@@ -1,0 +1,98 @@
+package display
+
+import (
+	"bytes"
+	"fmt"
+	"qp/internal/consts"
+	"qp/internal/pkgdata"
+	"strings"
+)
+
+type kvEntry struct {
+	Key   string
+	Value string
+}
+
+func (o *OutputManager) renderKeyValue(pkgs []*pkgdata.PkgInfo, fields []consts.FieldType) {
+	o.clearProgress()
+
+	dateFormat := consts.DateTimeFormat
+	ctx := tableContext{DateFormat: dateFormat}
+
+	var buffer bytes.Buffer
+
+	for i, pkg := range pkgs {
+		entries := make([]kvEntry, len(fields))
+		maxKeyLen := 0
+
+		for _, field := range fields {
+			value := getTableValue(pkg, field, ctx)
+			if value == "" {
+				continue
+			}
+
+			key := columnHeaders[field]
+			if len(key) > maxKeyLen {
+				maxKeyLen = len(key)
+			}
+
+			entries = append(entries, kvEntry{key, value})
+		}
+
+		for _, entry := range entries {
+			lines := wrapKeyValue(entry.Key, entry.Value, maxKeyLen, o.terminalWidth)
+			for _, line := range lines {
+				buffer.WriteString(line + "\n")
+			}
+		}
+
+		if i+1 < len(pkgs) {
+			buffer.WriteString("\n")
+		}
+	}
+
+	o.write(buffer.String())
+}
+
+func wrapKeyValue(key, value string, keyWidth, termWidth int) []string {
+	prefix := fmt.Sprintf("%-*s : ", keyWidth, key)
+	indent := strings.Repeat(" ", len(prefix))
+
+	maxValueWidth := termWidth - len(prefix)
+	if maxValueWidth <= 0 {
+		maxValueWidth = 10
+	}
+
+	words := strings.Fields(value)
+	var lines []string
+	var currentLine strings.Builder
+
+	for _, word := range words {
+		if currentLine.Len()+len(word)+1 > maxValueWidth {
+			lines = append(lines, currentLine.String())
+			currentLine.Reset()
+		}
+
+		if currentLine.Len() > 0 {
+			currentLine.WriteByte(' ')
+		}
+
+		currentLine.WriteString(word)
+	}
+
+	if currentLine.Len() > 0 {
+		lines = append(lines, currentLine.String())
+	}
+
+	output := make([]string, len(lines))
+	for i, line := range lines {
+		if i == 0 {
+			output[i] = prefix + line
+			continue
+		}
+
+		output[i] = indent + line
+	}
+
+	return output
+}


### PR DESCRIPTION
Users can now output packages in a key-value output style similar to `pacman -Qi`.

Example:
```
> qp s all w name=zoxide
DATE        : 2025-05-16 16:02:07
SIZE        : 1.09 MB
NAME        : zoxide
REASON      : explicit
VERSION     : 0.9.7
ORIGIN      : brew
ARCH        : x86_64
LICENSE     : MIT
DESCRIPTION : Shell extension to navigate your filesystem faster
URL         : https://github.com/ajeetdsouza/zoxide
PKGTYPE     : formula
```