### PR TITLE
Feature: Improve cache discovery

### DIFF
--- a/internal/pipeline/phase/pipeline.go
+++ b/internal/pipeline/phase/pipeline.go
@@ -58,7 +58,7 @@ func (p *Pipeline) Run() ([]*pkgdata.PkgInfo, error) {
 	for _, ph := range phases {
 		pkgs, err = ph.Run(p.Config, pkgs, p.IsInteractive)
 		if err != nil {
-			return nil, fmt.Errorf("[%s:%s] %w", p.Origin.Name(), ph.name, err)
+			return nil, fmt.Errorf("[%s] %w", ph.name, err)
 		}
 	}
 

--- a/internal/pipeline/phase/steps.go
+++ b/internal/pipeline/phase/steps.go
@@ -41,8 +41,7 @@ func (p *Pipeline) fetchStep(
 	pkgs, err := p.Origin.Load()
 	if err != nil {
 		err = fmt.Errorf(
-			"failed to fetch packages for origin: %v",
-			p.Origin.Name(), err,
+			"failed to fetch packages: %v", err,
 		)
 		return nil, err
 	}
@@ -61,7 +60,7 @@ func (p *Pipeline) resolveStep(
 
 	pkgs, err := p.Origin.ResolveDeps(pkgs)
 	if err != nil {
-		return nil, fmt.Errorf("dependency resolution failed for origin %s: %w", p.Origin.Name(), err)
+		return nil, fmt.Errorf("dependency resolution failed: %w", err)
 	}
 
 	return pkgs, nil
@@ -79,7 +78,7 @@ func (p *Pipeline) saveCacheStep(
 	cachePath := filepath.Join(p.CachePath)
 	err := p.Origin.SaveCache(cachePath, pkgs, p.ModTime)
 	if err != nil {
-		out.WriteLine(fmt.Sprintf("Warning: failed to save cache for origin %s: %v", p.Origin.Name(), err))
+		out.WriteLine(fmt.Sprintf("Warning: failed to save cache:", err))
 	}
 
 	return pkgs, nil

--- a/internal/pkgdata/cache.go
+++ b/internal/pkgdata/cache.go
@@ -39,7 +39,7 @@ func GetBaseCachePath() string {
 
 	userCacheDir := os.Getenv(xdgCacheHomeEnv)
 	if userCacheDir == "" {
-		userCacheDir = filepath.Join(homeEnv, ".cache")
+		userCacheDir = filepath.Join(home, ".cache")
 	}
 
 	return userCacheDir

--- a/internal/pkgdata/cache.go
+++ b/internal/pkgdata/cache.go
@@ -28,13 +28,18 @@ func GetCachePath() (string, error) {
 }
 
 func GetBaseCachePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = os.Getenv(homeEnv)
+	}
+
 	if runtime.GOOS == "darwin" {
-		return filepath.Join(os.Getenv(homeEnv), "Library/Caches")
+		return filepath.Join(home, "Library/Caches")
 	}
 
 	userCacheDir := os.Getenv(xdgCacheHomeEnv)
 	if userCacheDir == "" {
-		userCacheDir = filepath.Join(os.Getenv(homeEnv), ".cache")
+		userCacheDir = filepath.Join(homeEnv, ".cache")
 	}
 
 	return userCacheDir


### PR DESCRIPTION
We grab the OS's home directory first, then fallback to $HOME. If the environment variable is set for a custom cache location, `qp` respects that.