### PR TITLE
Feature: Prefixes with limit macros (e.g. `limit end:all`)

### DIFF
--- a/internal/pipeline/filtering/matchers.go
+++ b/internal/pipeline/filtering/matchers.go
@@ -39,24 +39,24 @@ var DateMatchers = RangeMatcher{
 
 var SizeMatchers = RangeMatcher{
 	true: {
-		consts.MatchFuzzy: func(start, _ int64) RangeFilter {
+		consts.MatchFuzzy: func(start int64, _ int64) RangeFilter {
 			return func(value int64) bool {
 				return pkgdata.FuzzySize(value, start)
 			}
 		},
-		consts.MatchStrict: func(start, _ int64) RangeFilter {
+		consts.MatchStrict: func(start int64, _ int64) RangeFilter {
 			return func(value int64) bool {
 				return pkgdata.StrictSize(value, start)
 			}
 		},
 	},
 	false: {
-		consts.MatchFuzzy: func(start, end int64) RangeFilter {
+		consts.MatchFuzzy: func(start int64, end int64) RangeFilter {
 			return func(value int64) bool {
 				return pkgdata.FuzzySizeRange(value, start, end)
 			}
 		},
-		consts.MatchStrict: func(start, end int64) RangeFilter {
+		consts.MatchStrict: func(start int64, end int64) RangeFilter {
 			return func(value int64) bool {
 				return pkgdata.StrictSizeRange(value, start, end)
 			}

--- a/internal/pipeline/filtering/size.go
+++ b/internal/pipeline/filtering/size.go
@@ -39,9 +39,9 @@ func parseSizeFilter(sizeFilterInput string) (RangeSelector, error) {
 	}
 
 	return RangeSelector{
-		start,
-		end,
-		isExact,
+		Start:   start,
+		End:     end,
+		IsExact: isExact,
 	}, nil
 }
 

--- a/internal/preprocess/macro_engine.go
+++ b/internal/preprocess/macro_engine.go
@@ -56,9 +56,15 @@ func expandWhereMacro(token string) ([]string, bool) {
 }
 
 func expandLimitMacro(token string) ([]string, bool) {
+	var prefix string
+	if strings.ContainsRune(token, ':') {
+		parts := strings.SplitAfter(token, ":")
+		prefix, token = parts[0], parts[1]
+	}
+
 	switch token {
 	case "all":
-		return []string{"0"}, true
+		return []string{prefix + "0"}, true
 	default:
 		return nil, false
 	}


### PR DESCRIPTION
Users can now use prefixes with limit macros. 

Example:
```
> qp o size:desc l end:all
DATE        NAME                           REASON      SIZE
2025-03-31  linux-firmware                 dependency  709.65 MB
2025-03-31  linux-aarch64                  explicit    298.75 MB
2025-03-26  go                             explicit    233.51 MB
2025-04-02  rust                           dependency  221.98 MB
2025-03-31  gcc                            dependency  167.40 MB
2025-03-31  gcc-libs                       dependency  145.20 MB
2025-02-11  llvm-libs                      dependency  132.93 MB
2025-03-31  python-scipy                   dependency  115.74 MB
[continuation omitted for brevity]
```