### PR TITLE
Feature: Improve cache load times

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,39 @@ more distros and non-linux platforms are planned!
 
 ## features
 
-- list installed packages by numerous fields
-- query by those fields
-  - learn more about querying [here](#querying-with-where)
-- sort by those fields
-- output as:
-  - table
-  - JSON
-
+* list installed packages across supported systems
+* compatible with macOS, arch, debian, openwrt, and over 60 distros
+* * supports multiple ecosystems:
+  * pacman, dpkg/apt, opkg, brew (formulae, bottles, casks)
+* query packages using an expressive query language
+  * supports full boolean logic (`and`, `or`, `not`, grouping)
+  * supports fuzzy and strict matching
+  * supports range queries for `size`, `date`, and `build-date`
+  * supports presence/absence checks (`has:`, `no:`)
+  * learn more about querying [here](#querying-with-where)
+* sort results by any field
+* output formats:
+  * table (default)
+  * key/value
+  * JSON
+* query by:
+  * name, version, origin, architecture, license
+  * size on disk
+  * install or build date
+  * package base or groups
+  * dependencies, optional dependencies, reverse dependencies
+  * package provisions, conflicts, replacements
+  * installation reason (explicit or dependency)
+  * package validation method (e.g., sha256, pgp)
+  * packager, URL, description
+  * package type (debug, split, etc.)
+* complex queries via grouping (`q ... p`) and built-in macros
+  * includes `orphan` and `superorphan` filters
+* customizable field selection for output
+* cache system for fast repeated queries
+* lightweight, fast, concurrent architecture
+* CLI designed for both scripting and interactive use
+* extensive roadmap with frequent improvements and optimizations
 
 learn about usage [here](#usage)
 

--- a/api/driver/interface.go
+++ b/api/driver/interface.go
@@ -7,7 +7,8 @@ type Driver interface {
 	Detect() bool
 	Load() ([]*pkgdata.PkgInfo, error)
 	ResolveDeps(pkgs []*pkgdata.PkgInfo) ([]*pkgdata.PkgInfo, error)
-	LoadCache(path string, modTime int64) ([]*pkgdata.PkgInfo, error)
-	SaveCache(path string, pkgs []*pkgdata.PkgInfo, modTime int64) error
+	LoadCache(cacheRoot string) ([]*pkgdata.PkgInfo, error)
+	SaveCache(cacheRoot string, pkgs []*pkgdata.PkgInfo) error
 	SourceModified() (int64, error)
+	IsCacheStale(cacheModTime int64) (bool, error)
 }

--- a/internal/origins/drivers/deb/driver.go
+++ b/internal/origins/drivers/deb/driver.go
@@ -59,12 +59,12 @@ func (d *DebDriver) ResolveDeps(pkgs []*pkgdata.PkgInfo) ([]*pkgdata.PkgInfo, er
 	return resolvedPkgs, nil
 }
 
-func (d *DebDriver) LoadCache(path string, modTime int64) ([]*pkgdata.PkgInfo, error) {
-	return pkgdata.LoadProtoCache(path, modTime)
+func (d *DebDriver) LoadCache(path string) ([]*pkgdata.PkgInfo, error) {
+	return pkgdata.LoadProtoCache(path)
 }
 
-func (d *DebDriver) SaveCache(path string, pkgs []*pkgdata.PkgInfo, modTime int64) error {
-	return pkgdata.SaveProtoCache(pkgs, path, modTime)
+func (d *DebDriver) SaveCache(cacheRoot string, pkgs []*pkgdata.PkgInfo) error {
+	return pkgdata.SaveProtoCache(cacheRoot, pkgs)
 }
 
 func (d *DebDriver) SourceModified() (int64, error) {
@@ -74,4 +74,13 @@ func (d *DebDriver) SourceModified() (int64, error) {
 	}
 
 	return dirInfo.ModTime().Unix(), nil
+}
+
+func (d *DebDriver) IsCacheStale(cacheModTime int64) (bool, error) {
+	dirInfo, err := os.Stat(dpkgPath)
+	if err != nil {
+		return false, fmt.Errorf("failed to read %s DB mod time: %v", d.Name(), err)
+	}
+
+	return dirInfo.ModTime().Unix() > cacheModTime, nil
 }

--- a/internal/origins/drivers/opkg/driver.go
+++ b/internal/origins/drivers/opkg/driver.go
@@ -26,12 +26,12 @@ func (d *OpkgDriver) ResolveDeps(pkgs []*pkgdata.PkgInfo) ([]*pkgdata.PkgInfo, e
 	return pkgdata.ResolveDependencyGraph(pkgs, nil)
 }
 
-func (d *OpkgDriver) LoadCache(path string, modTime int64) ([]*pkgdata.PkgInfo, error) {
-	return pkgdata.LoadProtoCache(path, modTime)
+func (d *OpkgDriver) LoadCache(path string) ([]*pkgdata.PkgInfo, error) {
+	return pkgdata.LoadProtoCache(path)
 }
 
-func (d *OpkgDriver) SaveCache(path string, pkgs []*pkgdata.PkgInfo, modTime int64) error {
-	return pkgdata.SaveProtoCache(pkgs, path, modTime)
+func (d *OpkgDriver) SaveCache(cacheRoot string, pkgs []*pkgdata.PkgInfo) error {
+	return pkgdata.SaveProtoCache(cacheRoot, pkgs)
 }
 
 func (d *OpkgDriver) SourceModified() (int64, error) {
@@ -41,4 +41,13 @@ func (d *OpkgDriver) SourceModified() (int64, error) {
 	}
 
 	return dirInfo.ModTime().Unix(), nil
+}
+
+func (d *OpkgDriver) IsCacheStale(cacheModTime int64) (bool, error) {
+	dirInfo, err := os.Stat(opkgStatusPath)
+	if err != nil {
+		return false, fmt.Errorf("failed to read %s DB mod time: %v", d.Name(), err)
+	}
+
+	return dirInfo.ModTime().Unix() > cacheModTime, nil
 }

--- a/internal/origins/drivers/pacman/driver.go
+++ b/internal/origins/drivers/pacman/driver.go
@@ -26,16 +26,12 @@ func (d *PacmanDriver) ResolveDeps(pkgs []*pkgdata.PkgInfo) ([]*pkgdata.PkgInfo,
 	return pkgdata.ResolveDependencyGraph(pkgs, nil)
 }
 
-func (d *PacmanDriver) LoadCache(path string, modTime int64) ([]*pkgdata.PkgInfo, error) {
-	return pkgdata.LoadProtoCache(path, modTime)
+func (d *PacmanDriver) LoadCache(path string) ([]*pkgdata.PkgInfo, error) {
+	return pkgdata.LoadProtoCache(path)
 }
 
-func (d *PacmanDriver) SaveCache(
-	path string,
-	pkgs []*pkgdata.PkgInfo,
-	modTime int64,
-) error {
-	return pkgdata.SaveProtoCache(pkgs, path, modTime)
+func (d *PacmanDriver) SaveCache(cacheRoot string, pkgs []*pkgdata.PkgInfo) error {
+	return pkgdata.SaveProtoCache(cacheRoot, pkgs)
 }
 
 func (d *PacmanDriver) SourceModified() (int64, error) {
@@ -45,4 +41,13 @@ func (d *PacmanDriver) SourceModified() (int64, error) {
 	}
 
 	return dirInfo.ModTime().Unix(), nil
+}
+
+func (d *PacmanDriver) IsCacheStale(cacheModTime int64) (bool, error) {
+	dirInfo, err := os.Stat(PacmanDbPath)
+	if err != nil {
+		return false, fmt.Errorf("failed to read %s DB mod time: %v", d.Name(), err)
+	}
+
+	return dirInfo.ModTime().Unix() > cacheModTime, nil
 }

--- a/internal/origins/shared/source_modtime.go
+++ b/internal/origins/shared/source_modtime.go
@@ -1,4 +1,4 @@
-package brew
+package shared
 
 import (
 	"fmt"
@@ -6,11 +6,10 @@ import (
 	"path/filepath"
 )
 
-func getModTime(prefix string, subPath string) (int64, error) {
-	path := filepath.Join(prefix, subPath)
+func GetModTime(path string) (int64, error) {
 	entries, err := os.ReadDir(path)
 	if err != nil {
-		return 0, fmt.Errorf("failed to read Cellar: %w", err)
+		return 0, fmt.Errorf("failed to read %s: %w", path, err)
 	}
 
 	var latest int64
@@ -30,12 +29,12 @@ func getModTime(prefix string, subPath string) (int64, error) {
 		}
 	}
 
-	cellarInfo, err := os.Stat(path)
+	parentInfo, err := os.Stat(path)
 	if err != nil {
-		return 0, fmt.Errorf("failed to stat Cellar: %w", err)
+		return 0, fmt.Errorf("failed to stat %s: %w", path, err)
 	}
 
-	modTime := cellarInfo.ModTime().Unix()
+	modTime := parentInfo.ModTime().Unix()
 	if modTime > latest {
 		latest = modTime
 	}

--- a/internal/pipeline/phase/pipeline.go
+++ b/internal/pipeline/phase/pipeline.go
@@ -2,13 +2,10 @@ package phase
 
 import (
 	"fmt"
-	"path/filepath"
 	"qp/api/driver"
 	"qp/internal/config"
-	out "qp/internal/display"
 	"qp/internal/pkgdata"
 	"sync"
-	"time"
 )
 
 type Pipeline struct {
@@ -27,18 +24,18 @@ func NewPipeline(
 	isInteractive bool,
 	baseCachePath string,
 ) *Pipeline {
-	modTime, err := origin.SourceModified()
-	if err != nil {
-		out.WriteLine(fmt.Sprintf("WARNING: failed to get mod time for origin %s: %v", origin.Name(), err))
-		modTime = time.Now().Unix()
-	}
+	// modTime, err := origin.SourceModified()
+	// if err != nil {
+	// 	out.WriteLine(fmt.Sprintf("WARNING: failed to get mod time for origin %s: %v", origin.Name(), err))
+	// 	modTime = time.Now().Unix()
+	// }
 
 	return &Pipeline{
 		Origin:        origin,
 		Config:        cfg,
 		IsInteractive: isInteractive,
-		CachePath:     filepath.Join(baseCachePath, origin.Name()+".cache"),
-		ModTime:       modTime,
+		CachePath:     baseCachePath,
+		// ModTime:       modTime,
 	}
 }
 


### PR DESCRIPTION
Modtime is now loaded from a separate one line file instead of checking the whole protobuf. We also load it before stat'ing all the relevant directories for metadata, allowing us to early return when staleness is detected.