### PR TITLE
Feature: Faster cache validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,57 +271,6 @@ jobs:
             gpg --batch --yes --armor --detach-sign "$file"
           done
 
-      - name: Upload signatures to query-packages-signatures release
-        run: |
-          gh release create "${{ env.TAG_NAME }}" \
-            --repo Zweih/query-packages-signatures \
-            --title "Signatures for qp ${{ env.TAG_NAME }}" \
-            --notes "Detached signatures for qp release ${{ env.TAG_NAME }}" \
-            ./release/qp-*.asc
-        env:
-          GH_TOKEN: ${{ secrets.QP_SIGNATURES_TOKEN }}
-
-      - name: Update Homebrew Tap Formula
-        run: |
-          git clone https://${HOMEBREW_QP_TOKEN}@github.com/Zweih/homebrew-qp.git
-          cd homebrew-qp
-
-          BRANCH_NAME="update-qp-${TAG_NAME#v}"
-          git checkout -b "$BRANCH_NAME"
-
-          FORMULA="Formula/qp.rb"
-          VERSION="${TAG_NAME#v}"
-
-          CHECKSUM_FILE="../release/SHA256SUMS.txt"
-          SHA256_AMD64=$(grep "qp-${TAG_NAME}-brew-darwin_amd64.tar.gz" "$CHECKSUM_FILE" | cut -d ' ' -f1)
-          SHA256_ARM64=$(grep "qp-${TAG_NAME}-brew-darwin_arm64.tar.gz" "$CHECKSUM_FILE" | cut -d ' ' -f1)
-          SHA256_LINUX_X86_64=$(grep "qp-${TAG_NAME}-brew-x86_64.tar.gz" "$CHECKSUM_FILE" | cut -d ' ' -f1)
-          SHA256_LINUX_AARCH64=$(grep "qp-${TAG_NAME}-brew-aarch64.tar.gz" "$CHECKSUM_FILE" | cut -d ' ' -f1)
-
-          sed -i "s/^  version \".*\"/  version \"${VERSION}\"/" "$FORMULA"
-          sed -i "s/^  sha256_amd64 = \".*\"/  sha256_amd64 = \"${SHA256_AMD64}\"/" "$FORMULA"
-          sed -i "s/^  sha256_arm64 = \".*\"/  sha256_arm64 = \"${SHA256_ARM64}\"/" "$FORMULA"
-          sed -i "s/^  sha256_linux_x86_64 = \".*\"/  sha256_linux_x86_64 = \"${SHA256_LINUX_X86_64}\"/" "$FORMULA"
-          sed -i "s/^  sha256_linux_aarch64 = \".*\"/  sha256_linux_aarch64 = \"${SHA256_LINUX_AARCH64}\"/" "$FORMULA"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          git add $FORMULA
-          git commit -m "Update qp formula to v${VERSION}"
-          git push origin "$BRANCH_NAME"
-
-          gh pr create \
-            --title "Update qp formula to v${VERSION}" \
-            --body "Automated update of qp formula to version ${VERSION}" \
-            --head "$BRANCH_NAME" \
-            --base master
-          cd ..
-        env:
-          TAG_NAME: ${{ env.TAG_NAME }}
-          HOMEBREW_QP_TOKEN: ${{ secrets.HOMEBREW_QP_TOKEN }}
-          GH_TOKEN: ${{ secrets.HOMEBREW_QP_TOKEN }}
-
       - name: Update PKGBUILDs for qp-bin and qp-src
         run: |
           source ./packaging_targets.sh
@@ -377,7 +326,7 @@ jobs:
           chmod +x ./filter_release_ipks.sh
           ./filter_release_ipks.sh
 
-      - name: Publish Release
+      - name: Upload Artifacts to qp Release
         run: |
           cd ./release
           gh release upload "${{ env.TAG_NAME }}" qp-*.tar.gz qp-*.deb qp-*.ipk --clobber
@@ -410,11 +359,63 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.QP_EXTRA_PACKAGES_TOKEN }}
 
-      - name: Delete Draft Release if Job Failed
+      - name: Update Homebrew Tap Formula
+        run: |
+          git clone https://${HOMEBREW_QP_TOKEN}@github.com/Zweih/homebrew-qp.git
+          cd homebrew-qp
+
+          BRANCH_NAME="update-qp-${TAG_NAME#v}"
+          git checkout -b "$BRANCH_NAME"
+
+          FORMULA="Formula/qp.rb"
+          VERSION="${TAG_NAME#v}"
+
+          CHECKSUM_FILE="../release/SHA256SUMS.txt"
+          SHA256_AMD64=$(grep "qp-${TAG_NAME}-brew-darwin_amd64.tar.gz" "$CHECKSUM_FILE" | cut -d ' ' -f1)
+          SHA256_ARM64=$(grep "qp-${TAG_NAME}-brew-darwin_arm64.tar.gz" "$CHECKSUM_FILE" | cut -d ' ' -f1)
+          SHA256_LINUX_X86_64=$(grep "qp-${TAG_NAME}-brew-x86_64.tar.gz" "$CHECKSUM_FILE" | cut -d ' ' -f1)
+          SHA256_LINUX_AARCH64=$(grep "qp-${TAG_NAME}-brew-aarch64.tar.gz" "$CHECKSUM_FILE" | cut -d ' ' -f1)
+
+          sed -i "s/^  version \".*\"/  version \"${VERSION}\"/" "$FORMULA"
+          sed -i "s/^  sha256_amd64 = \".*\"/  sha256_amd64 = \"${SHA256_AMD64}\"/" "$FORMULA"
+          sed -i "s/^  sha256_arm64 = \".*\"/  sha256_arm64 = \"${SHA256_ARM64}\"/" "$FORMULA"
+          sed -i "s/^  sha256_linux_x86_64 = \".*\"/  sha256_linux_x86_64 = \"${SHA256_LINUX_X86_64}\"/" "$FORMULA"
+          sed -i "s/^  sha256_linux_aarch64 = \".*\"/  sha256_linux_aarch64 = \"${SHA256_LINUX_AARCH64}\"/" "$FORMULA"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add $FORMULA
+          git commit -m "Update qp formula to v${VERSION}"
+          git push origin "$BRANCH_NAME"
+
+          gh pr create \
+            --title "Update qp formula to v${VERSION}" \
+            --body "Automated update of qp formula to version ${VERSION}" \
+            --head "$BRANCH_NAME" \
+            --base master
+ 
+          cd ..
+        env:
+          TAG_NAME: ${{ env.TAG_NAME }}
+          HOMEBREW_QP_TOKEN: ${{ secrets.HOMEBREW_QP_TOKEN }}
+          GH_TOKEN: ${{ secrets.HOMEBREW_QP_TOKEN }}
+      
+      - name: Upload signatures to query-packages-signatures release
+        run: |
+          gh release create "${{ env.TAG_NAME }}" \
+            --repo Zweih/query-packages-signatures \
+            --draft \
+            --title "Signatures for qp ${{ env.TAG_NAME }}" \
+            --notes "Detached signatures for qp release ${{ env.TAG_NAME }}" \
+            ./release/qp-*.asc
+        env:
+          GH_TOKEN: ${{ secrets.QP_SIGNATURES_TOKEN }}
+
+      - name: Delete qp Draft Release if Job Failed
         if: ${{ (failure() || cancelled()) && env.created == 'true' }}
         run: |
-          echo "Workflow failed. Deleting draft release ${TAG_NAME}..."
+          echo "Workflow failed. Deleting draft releases for ${TAG_NAME}..."
           gh release delete "${TAG_NAME}" --yes || echo "No release found or already deleted."
         env:
           GH_TOKEN: ${{ github.token }}
-

--- a/api/driver/interface.go
+++ b/api/driver/interface.go
@@ -9,6 +9,5 @@ type Driver interface {
 	ResolveDeps(pkgs []*pkgdata.PkgInfo) ([]*pkgdata.PkgInfo, error)
 	LoadCache(cacheRoot string) ([]*pkgdata.PkgInfo, error)
 	SaveCache(cacheRoot string, pkgs []*pkgdata.PkgInfo) error
-	SourceModified() (int64, error)
-	IsCacheStale(cacheModTime int64) (bool, error)
+	IsCacheStale(cacheMtime int64) (bool, error)
 }

--- a/internal/origins/drivers/deb/driver.go
+++ b/internal/origins/drivers/deb/driver.go
@@ -1,9 +1,9 @@
 package deb
 
 import (
-	"fmt"
 	"os"
 	"qp/internal/consts"
+	"qp/internal/origins/shared"
 	"qp/internal/pkgdata"
 )
 
@@ -67,20 +67,6 @@ func (d *DebDriver) SaveCache(cacheRoot string, pkgs []*pkgdata.PkgInfo) error {
 	return pkgdata.SaveProtoCache(cacheRoot, pkgs)
 }
 
-func (d *DebDriver) SourceModified() (int64, error) {
-	dirInfo, err := os.Stat(dpkgPath)
-	if err != nil {
-		return 0, fmt.Errorf("failed to read %s DB mod time: %v", d.Name(), err)
-	}
-
-	return dirInfo.ModTime().Unix(), nil
-}
-
-func (d *DebDriver) IsCacheStale(cacheModTime int64) (bool, error) {
-	dirInfo, err := os.Stat(dpkgPath)
-	if err != nil {
-		return false, fmt.Errorf("failed to read %s DB mod time: %v", d.Name(), err)
-	}
-
-	return dirInfo.ModTime().Unix() > cacheModTime, nil
+func (d *DebDriver) IsCacheStale(cacheMtime int64) (bool, error) {
+	return shared.IsDirStale(d.Name(), dpkgPath, cacheMtime)
 }

--- a/internal/origins/drivers/opkg/driver.go
+++ b/internal/origins/drivers/opkg/driver.go
@@ -1,9 +1,9 @@
 package opkg
 
 import (
-	"fmt"
 	"os"
 	"qp/internal/consts"
+	"qp/internal/origins/shared"
 	"qp/internal/pkgdata"
 )
 
@@ -34,20 +34,6 @@ func (d *OpkgDriver) SaveCache(cacheRoot string, pkgs []*pkgdata.PkgInfo) error 
 	return pkgdata.SaveProtoCache(cacheRoot, pkgs)
 }
 
-func (d *OpkgDriver) SourceModified() (int64, error) {
-	dirInfo, err := os.Stat(opkgStatusPath)
-	if err != nil {
-		return 0, fmt.Errorf("failed to read %s DB mod time: %v", d.Name(), err)
-	}
-
-	return dirInfo.ModTime().Unix(), nil
-}
-
-func (d *OpkgDriver) IsCacheStale(cacheModTime int64) (bool, error) {
-	dirInfo, err := os.Stat(opkgStatusPath)
-	if err != nil {
-		return false, fmt.Errorf("failed to read %s DB mod time: %v", d.Name(), err)
-	}
-
-	return dirInfo.ModTime().Unix() > cacheModTime, nil
+func (d *OpkgDriver) IsCacheStale(cacheMtime int64) (bool, error) {
+	return shared.IsDirStale(d.Name(), opkgStatusPath, cacheMtime)
 }

--- a/internal/origins/drivers/pacman/constants.go
+++ b/internal/origins/drivers/pacman/constants.go
@@ -24,5 +24,5 @@ const (
 
 	subfieldPkgType = "pkgtype"
 
-	PacmanDbPath = "/var/lib/pacman/local"
+	pacmanDbPath = "/var/lib/pacman/local"
 )

--- a/internal/origins/drivers/pacman/driver.go
+++ b/internal/origins/drivers/pacman/driver.go
@@ -1,9 +1,9 @@
 package pacman
 
 import (
-	"fmt"
 	"os"
 	"qp/internal/consts"
+	"qp/internal/origins/shared"
 	"qp/internal/pkgdata"
 )
 
@@ -14,7 +14,7 @@ func (d *PacmanDriver) Name() string {
 }
 
 func (d *PacmanDriver) Detect() bool {
-	_, err := os.Stat(PacmanDbPath)
+	_, err := os.Stat(pacmanDbPath)
 	return err == nil
 }
 
@@ -34,20 +34,6 @@ func (d *PacmanDriver) SaveCache(cacheRoot string, pkgs []*pkgdata.PkgInfo) erro
 	return pkgdata.SaveProtoCache(cacheRoot, pkgs)
 }
 
-func (d *PacmanDriver) SourceModified() (int64, error) {
-	dirInfo, err := os.Stat(PacmanDbPath)
-	if err != nil {
-		return 0, fmt.Errorf("failed to read pacman DB mod time: %v", err)
-	}
-
-	return dirInfo.ModTime().Unix(), nil
-}
-
-func (d *PacmanDriver) IsCacheStale(cacheModTime int64) (bool, error) {
-	dirInfo, err := os.Stat(PacmanDbPath)
-	if err != nil {
-		return false, fmt.Errorf("failed to read %s DB mod time: %v", d.Name(), err)
-	}
-
-	return dirInfo.ModTime().Unix() > cacheModTime, nil
+func (d *PacmanDriver) IsCacheStale(cacheMtime int64) (bool, error) {
+	return shared.IsDirStale(d.Name(), pacmanDbPath, cacheMtime)
 }

--- a/internal/origins/drivers/pacman/fetch.go
+++ b/internal/origins/drivers/pacman/fetch.go
@@ -10,7 +10,7 @@ import (
 )
 
 func fetchPackages(origin string) ([]*pkgdata.PkgInfo, error) {
-	pkgPaths, err := os.ReadDir(PacmanDbPath)
+	pkgPaths, err := os.ReadDir(pacmanDbPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read pacman database: %v", err)
 	}
@@ -21,7 +21,7 @@ func fetchPackages(origin string) ([]*pkgdata.PkgInfo, error) {
 	go func() {
 		for _, packagePath := range pkgPaths {
 			if packagePath.IsDir() {
-				descPath := filepath.Join(PacmanDbPath, packagePath.Name(), "desc")
+				descPath := filepath.Join(pacmanDbPath, packagePath.Name(), "desc")
 				descPathChan <- descPath
 			}
 		}

--- a/internal/origins/shared/source_modtime.go
+++ b/internal/origins/shared/source_modtime.go
@@ -6,38 +6,80 @@ import (
 	"path/filepath"
 )
 
-func GetModTime(path string) (int64, error) {
-	entries, err := os.ReadDir(path)
+type Node struct {
+	Depth int
+	Path  string
+	Entry os.DirEntry
+}
+
+func BfsStale(path string, cacheMtime int64, maxDepth int) (bool, error) {
+	parentInfo, err := os.Stat(path)
 	if err != nil {
-		return 0, fmt.Errorf("failed to read %s: %w", path, err)
+		return false, fmt.Errorf("failed to stat %s: %w", path, err)
 	}
 
-	var latest int64
+	if parentInfo.ModTime().Unix() > cacheMtime {
+		return true, nil
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false, fmt.Errorf("failed to read %s: %w", path, err)
+	}
+
+	bfsQueue := make([]Node, 0, len(entries))
 	for _, entry := range entries {
-		if !entry.IsDir() {
+		bfsQueue = append(bfsQueue, Node{
+			Depth: 1,
+			Path:  filepath.Join(path, entry.Name()),
+			Entry: entry,
+		})
+	}
+
+	for 0 < len(bfsQueue) {
+		node := bfsQueue[0]
+		bfsQueue = bfsQueue[1:]
+
+		if node.Depth > maxDepth {
+			return false, nil
+		}
+
+		if !node.Entry.IsDir() {
 			continue
 		}
 
-		info, err := os.Stat(filepath.Join(path, entry.Name()))
+		info, err := os.Stat(node.Path)
 		if err != nil {
 			continue
 		}
 
 		modTime := info.ModTime().Unix()
-		if modTime > latest {
-			latest = modTime
+		if modTime > cacheMtime {
+			return true, nil
+		}
+
+		subEntries, err := os.ReadDir(node.Path)
+		if err != nil {
+			return false, fmt.Errorf("failed to read %s: %w", node.Path, err)
+		}
+
+		for _, subEntry := range subEntries {
+			bfsQueue = append(bfsQueue, Node{
+				Depth: node.Depth + 1,
+				Path:  filepath.Join(node.Path, subEntry.Name()),
+				Entry: subEntry,
+			})
 		}
 	}
 
-	parentInfo, err := os.Stat(path)
+	return false, nil
+}
+
+func IsDirStale(origin string, path string, cacheMtime int64) (bool, error) {
+	dirInfo, err := os.Stat(path)
 	if err != nil {
-		return 0, fmt.Errorf("failed to stat %s: %w", path, err)
+		return false, fmt.Errorf("failed to read %s DB modified time: %v", origin, err)
 	}
 
-	modTime := parentInfo.ModTime().Unix()
-	if modTime > latest {
-		latest = modTime
-	}
-
-	return latest, nil
+	return dirInfo.ModTime().Unix() > cacheMtime, nil
 }


### PR DESCRIPTION
We know use a breadth-first search to stat directory modtimes that invalidate the cache. It's limited to the specified depth to prevent BFSing every single nested dependency as well as early returning.