### PR TITLE
Feature: Speed up JSON output

### DIFF
--- a/internal/display/render_json.go
+++ b/internal/display/render_json.go
@@ -2,10 +2,11 @@ package display
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"qp/internal/consts"
 	"qp/internal/pkgdata"
+
+	json "github.com/goccy/go-json"
 )
 
 type PkgInfoJSON struct {


### PR DESCRIPTION
Output now uses goccy. This has the added benefit of shrinking the size of the binary, though this is mainly due to the enormous size of brew metadata that using the standard go decoder is unacceptable.