### PR TITLE
Feature: Depth querying

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ learn about installation [here](#installation)
 |--------|---------|--------|---------|
 | ✓ | reverse optional dependencies field (optional-for) | - | optdepends installation indicator |
 | - | separate field for optdepends reason | ✓ | fuzzy/strict querying |
-| ✓ | existence querying | - | depth querying |
+| ✓ | existence querying | ✓ | depth querying |
 | ✓ | command-based syntax | ✓ | full boolean logic |
 | ✓ | abstract syntax tree | ✓ | directed acyclical graph for filtering |
 | - | user-defined macros | ✓ | parentetical (grouping) logic |
@@ -272,7 +272,7 @@ qp [command] [args] [options]
   - use `and`, `or`, `not`, `q ... p` to build complex filters
   - learn more about querying [here](#querying-with-where)
 - `order <field>:<direction>` | `o <field>:<direction>`: sort results ascending or descending
-  - default sort is `date:asc`:
+  - default sort is `date:asc`
 - `limit <number>` | `l <number>`: limit the amount of packages to display (default: 20)
   - `limit all` | `l all`: display all packages
   - `limit end:<number>`: display last `n` packages
@@ -388,6 +388,49 @@ each `where` query supports one of the following:
 for example:
   - `name=gtk` matches `gtk3`, `libgtk`, etc. (fuzzy)
   - `name==gtk` only matches a package named exactly `gtk`
+
+#### depth querying
+
+for relation fields, you can specify the depth level to query using the `@` syntax:
+
+```bash
+qp w depends=glibc@2    # packages that depend on glibc at depth 2
+qp w required-by=gtk3@1 # packages directly required by gtk3 (depth 1)
+qp w provides=libssl@3  # packages that provide libssl at depth 3
+```
+
+**depth levels:**
+- no `@` specified: depth 1 (direct relations only)
+- `@1`: direct relations only (same as default)
+- `@2`: second-level relations (relations of relations)
+- `@3`, `@4`, etc.: deeper levels in the dependency tree
+
+**special behavior for optional dependencies:**
+- `optdepends` and `optional-for` return the optional relationships at the depth 1
+- after depth 1, the dependency resolution includes hard dependencies from those optional packages in the final results. this is intentional.
+
+**examples:**
+```bash
+# show packages with direct dependencies on python (depth 1 implied)
+qp w depends=python
+
+# show packages with direct dependencies on python (explicit depth 1)
+qp w depends=python@1
+
+# show packages that indirectly depend on openssl at depth 2
+qp w depends=openssl@2
+
+# show direct optional dependencies of vlc
+qp w optdepends=vlc@1
+
+# show optional dependencies of vlc at depth 2
+qp w optdepends=vlc@2
+
+# show packages that directly optionally depend on ffmpeg
+qp w optional-for=ffmpeg@1
+```
+
+**note:** depth querying works with all relation fields: `depends`, `optdepends`, `required-by`, `optional-for`, `provides`, `conflicts`, and `replaces`.
 
 #### built-in macros
 

--- a/internal/config/help.go
+++ b/internal/config/help.go
@@ -20,14 +20,13 @@ Commands:
                                 - Supports: field=value, field==value
                                 - Range: date=2024-01-01:2024-01-10
                                 - Existence: has:depends, no:conflicts
-                                - You can use multiple where clauses
+                                - Depth: depends=package@2, required-by=pkg@3
 
   order <field>:<dir> | o <..>  Sort by field in asc/desc order
-                                - Fields: date, build-date, name, size, license, pkgbase
 
   limit <num> | l <num>         Limit number of results (default: 20)
                                 - Use 'limit all' to show everything
-                                - Use end:<num> / mid:<num> modifier to display from
+                                - Use end:<num> / mid:<num> prefix to display from
                                     different parts of the output
 Options:
 `
@@ -50,6 +49,13 @@ Query Types:
       has:field         -> field must exist or be non-empty
       no:field          -> field must not exist or be empty
 
+  - Depth querying (relation fields):
+      field=value@1     -> direct relations (default)
+      field=value@2     -> second-level relations
+      field=value@3     -> third-level relations, etc.
+        Note: optdepends and optional-for include hard dependencies
+              after depth 1
+
   - Logical operators
       and   -> both must match
       or    -> either can match
@@ -65,6 +71,7 @@ Query Types:
     qp w name=gtk or name=qt
     qp w not name==vim
     qp w reason=explicit and size=50MB:
+    qp w depends=python@2
     qp w q name=vim or name=emacs p and not has:depends
 
 Match Behavior:
@@ -82,7 +89,7 @@ Short Command Examples:
   qp w reason=explicit and size=50MB:
   qp w q size=10MB:1GB or size==20MB p and not has:depends
 
-Build-in Macros:
+Built-in Macros:
   - 'qp w orphan' is equivalent to 'qp where no:required-by and reason=dependency'
   - 'qp w superorphan' is equivalent to 'qp where no:required-by and reason=dependency and no:optional-for'
 
@@ -98,15 +105,15 @@ Tips:
       qp --no-headers select name,size
 
   - JSON output:
-      qp select name,version,size --output=json
+      qp select name,version,size --output json
 
   - Key-Value output (ideal for selecting all fields):
-     qp s all --output=kv
+     qp s all --output kv
 
   - Quote arguments with spaces or special characters:
       qp where description="for tree-sitter"
 
-  - To group conditions, use q and p (like brackets):
+  - To group conditions, use q and p as grouping parentheses:
     qp where q name=curl or name=openssl and no:depends
       -> matches packages named curl or openssl but only if they have no dependencies
 
@@ -117,7 +124,7 @@ Default Behavior:
 Use 'man qp' to see all available fields
     for select, where, and order.
 
-See full docs for:
+See full docs at https://github.com/Zweih/qp for:
   - Available fields
   - Query examples
   - JSON schema

--- a/qp.1
+++ b/qp.1
@@ -1,21 +1,23 @@
 .\" Man page for qp
 .TH qp 1 "@DATE@" "qp @VERSION@" "User Commands"
 .SH NAME
-qp \- query packages. A CLI utility for querying installed packages.
+qp \- query packages. A CLI utility for querying installed packages across multiple package ecosystems.
 
 .SH SYNOPSIS
 .B qp [command] [args] [options]
 
 .SH DESCRIPTION
 .B qp
-is a fast, flexible, and standalone CLI utility for querying installed packages on Arch Linux and Arch-based distributions. It supports advanced querying, sorting, and formatting features including:
+is a fast, flexible, and standalone CLI utility for querying installed packages across multiple package ecosystems and operating systems. It supports Arch Linux (pacman), Debian/Ubuntu (apt/dpkg), Homebrew (brew), OpenWrt (opkg), and application ecosystems like pipx. Features include:
 
-- Existence checks
-- Field filtering
+- Cross-platform package discovery
+- Advanced querying with boolean logic
+- Field filtering and existence checks
 - Date and size range queries
+- Dependency graph traversal with depth control
 - Reverse dependencies and provisions
 - Conflicts, optional dependencies, and groups
-- Sorting and output as table or JSON
+- Sorting by any field and multiple output formats
 
 .SH COMMANDS
 .TP
@@ -40,27 +42,29 @@ String match — \fIfield=value\fR (fuzzy), \fIfield==value\fR (strict)
 Range match — \fIfield=start:end\fR or \fIfield==start:end\fR (works with \fBdate\fR, \fBsize\fR)
 .IP \[bu] 
 Existence check — \fBhas:field\fR or \fBno:field\fR
+.IP \[bu]
+Depth querying — \fIfield=value@depth\fR (for relation fields)
 .RE
 
 .TP
 .B order <field>:<direction>, o <..>
-Sort results. Fields: \fBdate\fR, \fBbuild-date\fR, \fBsize\fR, \fBname\fR, \fBreason\fR, \fBversion\fR, \fBorigin\fR, \fBarch\fR, \fBlicense\fR, \fBdescription\fR, \fBurl\fR, \fBpkgbase\fR, \fBpkgtype\fR, \fBvalidation\fR, \fBpackager\fR, \fBgroups\fR, \fBconflicts\fR, \fBreplaces\fR, \fBdepends\fR,\fBoptdepends\fR, \fBrequired-by\fR, \fBoptional-for\fR, \fBprovides\fR
+Sort results by any available field in ascending (\fBasc\fR) or descending (\fBdesc\fR) order.
 
 .TP
 .B limit <number>, l <number>
 Limit number of displayed results. Use \fBlimit all\fR to show all.
-Numbers can be prefixed with end:<number> or mid:<number> to display X amount from a specific part of the output.
+Numbers can be prefixed with \fBend:\fR or \fBmid:\fR to display from specific parts of the output.
 
 .SH OPTIONS
 .TP
 .B \-\-no-headers
 Omit column headers (useful in scripts).
 .TP
-.B \-\-json
-Output results in JSON format.
+.B \-\-output <format>
+Output format: \fBtable\fR (default), \fBjson\fR, or \fBkv\fR (key-value).
 .TP
 .B \-\-full-timestamp
-Show full date+time for install/build.
+Show full date+time for install/build timestamps.
 .TP
 .B \-\-no-progress
 Disable progress bar.
@@ -95,6 +99,20 @@ Supports full (e.g., 1GB:5GB), open-ended (e.g., 1GB:, :5GB), or exact values.
 \fBno:field\fR — must be empty or missing
 
 .TP
+.B Depth Querying
+\fIfield=value@depth\fR — query relation fields at specific depths
+.RS
+.IP \[bu]
+\fB@1\fR or no \fB@\fR — direct relations (default)
+.IP \[bu]
+\fB@2\fR — second-level relations
+.IP \[bu]
+\fB@3\fR, \fB@4\fR, etc. — deeper levels
+.IP \[bu]
+Note: \fBoptdepends\fR and \fBoptional-for\fR include hard dependencies in results after depth 1
+.RE
+
+.TP
 .B Match Behavior Summary:
 .TS
 box, tab(:);
@@ -111,13 +129,13 @@ Size:±0.3% tolerance:exact byte size
 .B Logical Operators
 Use to combine or negate queries:
 .RS
-.IP \[bu] 
+.IP \[bu]
 \fBand\fR - require all conditions to match
-.IP \[bu] 
+.IP \[bu]
 \fBor\fR - match if any condition matches
-.IP \[bu] 
+.IP \[bu]
 \fBnot\fR - invert a single condition
-.IP \[bu] 
+.IP \[bu]
 \fBq\fR ... \fBp\fR - group conditions (equivalent to parentheses)
 .RE
 
@@ -142,6 +160,26 @@ Matches super-orphaned packages - installed as dependencies but are required by 
 "qp where superorphan" is equivalent to:
 .BR "qp where no:required-by and reason=dependency and no:optional-for"
 
+.SH SUPPORTED PACKAGE ECOSYSTEMS
+.B qp
+automatically detects and queries packages from:
+
+.TP
+.B pacman
+Arch Linux and derivatives (Manjaro, EndeavourOS, etc.)
+.TP
+.B deb
+Debian, Ubuntu, and derivatives (Mint, Pop!_OS, etc.) via apt/dpkg
+.TP
+.B brew
+Homebrew on macOS and Linux (formulae and casks)
+.TP
+.B opkg
+OpenWrt and embedded systems using ipkg packages
+.TP
+.B pipx
+Python applications installed in isolated environments
+
 .SH SUPPORTED QUERY FIELDS
 .TP
 .B Range:
@@ -154,7 +192,7 @@ name, reason, version, origin, arch, license, pkgbase, description, url, groups,
 conflicts, replaces, depends, optdepends, required-by, optional-for, provides
 
 .SH AVAILABLE FIELDS
-Available for use with \fBselect\fR, \fBselect all\fR, etc:
+Available for use with \fBselect\fR, \fBorder\fR, and \fBwhere\fR:
 
 date, build-date, size, name, reason, version, origin, arch, license, 
 description, url, validation, pkgbase, pkgtype, packager, groups, conflicts,
@@ -165,21 +203,29 @@ List 10 smallest explicitly installed packages:
 .br
 \fBqp w reason=explicit o size:asc l 10\fR
 
-Query packages larger than 500MB:
+Query packages larger than 500MB from Homebrew:
 .br
-\fBqp w size=500MB:\fR
+\fBqp w size=500MB: and origin=brew\fR
 
-Search packages that depend on \fBgtk3\fR:
+Search packages that depend on \fBgtk3\fR at depth 2:
 .br
-\fBqp w required-by=gtk3\fR
+\fBqp w depends=gtk3@2\fR
 
 Get all fields for \fBgtk3\fR in JSON:
 .br
-\fBqp s all w name==gtk3 --json\fR
+\fBqp s all w name==gtk3 --output json\fR
 
 Group and filter multiple conditions:
 .br
 \fBqp w q name=zoxide or name=yazi p and optdepends=fzf\fR
+
+Show packages that directly require \fBpython\fR:
+.br
+\fBqp w required-by=python@1\fR
+
+Find orphaned packages larger than 100MB:
+.br
+\fBqp w orphan and size=100MB:\fR
 
 .SH TIPS
 - Pipe long outputs:
@@ -190,13 +236,16 @@ Group and filter multiple conditions:
 .br
 - Omit headers for scripts:
   \fBqp --no-headers s name,size\fR
+.br
+- Query across package ecosystems:
+  \fBqp w origin=brew,pacman\fR
 
 .SH FILES
 Cache is stored in:
 .br
-\fB$XDG_CACHE_HOME/query-packages\fR or \fB~/.cache/query-packages\fR
+Linux: \fB$XDG_CACHE_HOME/query-packages\fR or \fB~/.cache/query-packages\fR
 .br
-If \fBXDG_CACHE_HOME\fR is not set, fallback is \fB~/.cache/query-packages\fR
+macOS: \fB~/Library/Caches/query-packages\fR
 
 .SH AUTHOR
 Written by Fernando Nunez <me@fernandonunez.io>
@@ -211,6 +260,7 @@ Report issues at:
 
 .SH SEE ALSO
 .BR pacman(8),
-.BR yay(1),
-.BR paru(1)
-
+.BR apt(8),
+.BR brew(1),
+.BR opkg(1),
+.BR pipx(1)


### PR DESCRIPTION
Enables querying dependencies and other relations at specific depths (depends=glibc@2, required-by=gtk3@1) with special handling for optional dependencies that include hard dependency chains in results after depth 1.

Example 1:
```
> qp w depends=glibc@2                   
DATE        NAME               REASON      SIZE
2025-05-16  lib32-pam          dependency  770.83 KB
2025-05-20  libdecor           dependency  165.77 KB
2025-05-20  lib32-libgcrypt    dependency  1.04 MB
2025-05-20  v4l-utils          dependency  11.55 MB
2025-05-20  linux-lts          explicit    138.19 MB
2025-05-20  nodejs             dependency  66.41 MB
2025-05-20  linux-lts-headers  explicit    138.17 MB
2025-05-20  thunar             explicit    9.31 MB
2025-05-20  ftgl               dependency  2.28 MB
2025-05-20  sdl2_image         dependency  207.39 KB
2025-05-20  boost-libs         dependency  8.84 MB
2025-05-20  gource             explicit    1.75 MB
2025-05-22  brave-bin          explicit    394.86 MB
2025-05-23  chromium           dependency  339.04 MB
2025-05-23  mypaint-brushes1   dependency  2.32 MB
2025-05-23  lensfun            dependency  4.29 MB
2025-05-23  gd                 dependency  666.18 KB
2025-05-23  gts                dependency  678.78 KB
2025-05-23  graphviz           explicit    10.54 MB
```

Example 2:
```
qp w depends=glibc@2                   
DATE        NAME               REASON      SIZE
2025-05-16  lib32-pam          dependency  770.83 KB
2025-05-20  libdecor           dependency  165.77 KB
2025-05-20  discord            explicit    259.30 MB
2025-05-20  lib32-libgcrypt    dependency  1.04 MB
2025-05-20  v4l-utils          dependency  11.55 MB
2025-05-20  linux-lts          explicit    138.19 MB
2025-05-20  nodejs             dependency  66.41 MB
2025-05-20  linux-lts-headers  explicit    138.17 MB
2025-05-20  thunar             explicit    9.31 MB
2025-05-20  ftgl               dependency  2.28 MB
2025-05-20  sdl2_image         dependency  207.39 KB
2025-05-20  boost-libs         dependency  8.84 MB
2025-05-20  gource             explicit    1.75 MB
2025-05-22  brave-bin          explicit    394.86 MB
2025-05-23  chromium           dependency  339.04 MB
2025-05-23  mypaint-brushes1   dependency  2.32 MB
2025-05-23  lensfun            dependency  4.29 MB
2025-05-23  gd                 dependency  666.18 KB
2025-05-23  gts                dependency  678.78 KB
2025-05-23  graphviz           explicit    10.54 MB
```

Closes #201 