### PR TITLE
Feature: Add timezone + 12hr timestamp

### DIFF
--- a/internal/consts/dates.go
+++ b/internal/consts/dates.go
@@ -1,7 +1,6 @@
 package consts
 
 const (
-	DateOnlyFormat       = "2006-01-02"
-	DateTimeFormat       = "2006-01-02 15:04:05"
-	DefaultTerminalWidth = 80
+	DateOnlyFormat = "2006-01-02"
+	DateTimeFormat = "2006-01-02 03:04:05 PM UTC"
 )

--- a/internal/display/output_manager.go
+++ b/internal/display/output_manager.go
@@ -11,6 +11,8 @@ import (
 	"golang.org/x/term"
 )
 
+const DefaultTerminalWidth = 80
+
 type OutputManager struct {
 	mu            sync.Mutex
 	lastMsgLength int
@@ -28,7 +30,7 @@ func newOutputManager() *OutputManager {
 func getTerminalWidth() int {
 	width, _, err := term.GetSize(int(os.Stdout.Fd()))
 	if err != nil {
-		return consts.DefaultTerminalWidth // default width if unable to detect
+		return DefaultTerminalWidth // default width if unable to detect
 	}
 
 	return width


### PR DESCRIPTION
A simple format change. I noticed that leaving out the timezone confused me when using qp on remote kubernetes clusters. When we add a config we may add an option for 12hr/24hr clock.