### PR TITLE
Feature: Add `--cache-only` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ learn about installation [here](#installation)
 | ✓ | pipx origin (python global packages) | - | formulae from taps (brew) |
 | - | casks from taps (brew) | - | dependencies for casks |
 | - | rpm packaging | - | zypper (openSUSE support) |
+| ✓ | cache-only option | - | package manager hooks |
 
 ## installation
 
@@ -282,6 +283,7 @@ qp [command] [args] [options]
 - `--no-progress`: force no progress bar outside of non-interactive environments
 - `--no-cache`: disable cache loading/saving and force fresh package data loading
 - `--regen-cache`: disable cache loading, force fresh package data loading, and save fresh cache
+- `--cache-only`: update cache only and nothing else. specify origin ('pacman', 'brew', 'deb', etc.) or all.
 - `-h` | `--help`: print help info
 
 ### available fields

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,12 +11,13 @@ type Config struct {
 	Limit             int
 	ShowHelp          bool
 	ShowVersion       bool
-	OutputFormat      string
 	HasNoHeaders      bool
 	ShowFullTimestamp bool
 	DisableProgress   bool
 	NoCache           bool
 	RegenCache        bool
+	CacheOnly         string
+	OutputFormat      string
 	LimitMode         syntax.LimitMode
 	SortOption        syntax.SortOption
 	Fields            []consts.FieldType

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -35,6 +35,11 @@ func ParseFlags(args []string) (Config, error) {
 		return Config{}, fmt.Errorf("error parsing flags: %v", err)
 	}
 
+	// exit asap, we don't need user syntax
+	if flagCfg.CacheOnly != "" {
+		return flagCfg, nil
+	}
+
 	remainingArgs := pflag.Args()
 	newSyntaxParser := func() (syntax.ParsedInput, error) {
 		return syntax.ParseSyntax(remainingArgs)
@@ -135,6 +140,7 @@ func registerCommonFlags(cfg *Config) {
 	pflag.BoolVar(&cfg.DisableProgress, "no-progress", false, "Disable progress bar")
 	pflag.BoolVar(&cfg.NoCache, "no-cache", false, "Disable cache")
 	pflag.BoolVar(&cfg.RegenCache, "regen-cache", false, "Force fresh cache")
+	pflag.StringVar(&cfg.CacheOnly, "cache-only", "", "Update cache only and nothing else. Specify origin ('pacman', 'brew', 'deb') or 'all'.")
 }
 
 func registerLegacyFlags(

--- a/qp.1
+++ b/qp.1
@@ -75,6 +75,9 @@ Skip using cache, force fresh data load.
 .B \-\-regen-cache
 Reload package data and regenerate cache.
 .TP
+.B \-\-cache-only
+Update cache only and nothing else. Specify origin ('pacman', 'brew', 'deb') or 'all'.
+.TP
 .B \-h, \-\-help
 Show help message.
 


### PR DESCRIPTION
By using `--cache-only`, qp will only update (or build) the cache and nothing else. No querying, sorting, limiting, or output. This is to make way for package manager hooks.