### PR TITLE
Fix: Timezone format

### DIFF
--- a/internal/consts/dates.go
+++ b/internal/consts/dates.go
@@ -2,5 +2,5 @@ package consts
 
 const (
 	DateOnlyFormat = "2006-01-02"
-	DateTimeFormat = "2006-01-02 03:04:05 PM UTC"
+	DateTimeFormat = "2006-01-02 03:04:05 PM MST"
 )


### PR DESCRIPTION
Apparently UTC is not the valid format. As it turns out, running tests on a remote machine in UTC will yield false positives.