### PR TITLE
Feature: Add brew install history

### DIFF
--- a/internal/origins/drivers/brew/cask_parser.go
+++ b/internal/origins/drivers/brew/cask_parser.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"qp/internal/consts"
+	"qp/internal/origins/shared"
 	"qp/internal/pkgdata"
 
 	json "github.com/goccy/go-json"
@@ -59,6 +60,11 @@ func parseCaskReceipt(name string, path string) (*pkgdata.PkgInfo, error) {
 		Depends:         append(formulaRels, caskRels...),
 		Reason:          reason,
 		PkgType:         typeCask,
+	}
+
+	creationTime, isReliable, err := shared.GetCreationTime(path)
+	if err == nil && isReliable {
+		pkg.InstallTimestamp = creationTime
 	}
 
 	return pkg, nil

--- a/internal/origins/drivers/brew/formula_parser.go
+++ b/internal/origins/drivers/brew/formula_parser.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"qp/internal/consts"
+	"qp/internal/origins/shared"
 	"qp/internal/pkgdata"
 
 	json "github.com/goccy/go-json"
@@ -61,6 +62,11 @@ func parseFormulaReceipt(iPkg *installedPkg) (*pkgdata.PkgInfo, error) {
 
 	if iPkg.IsTap {
 		inferTapMetadata(pkg, iPkg.VersionPath)
+	}
+
+	creationTime, isReliable, err := shared.GetCreationTime(filepath.Dir(iPkg.VersionPath))
+	if err == nil && isReliable {
+		pkg.InstallTimestamp = creationTime
 	}
 
 	inferBuildDate(pkg, receipt)

--- a/internal/origins/drivers/pacman/fetch.go
+++ b/internal/origins/drivers/pacman/fetch.go
@@ -122,7 +122,7 @@ func getSystemInstallTime() (int64, error) {
 
 	for _, path := range systemPaths {
 		if fileInfo, err := os.Stat(path); err == nil {
-			if birthTime, reliable, err := shared.GetBirthTime(path); err == nil && reliable {
+			if birthTime, _, err := shared.GetCreationTime(path); err == nil {
 				if birthTime < oldestTime {
 					oldestTime = birthTime
 					foundAny = true

--- a/internal/origins/drivers/pipx/fetch.go
+++ b/internal/origins/drivers/pipx/fetch.go
@@ -68,8 +68,8 @@ func fetchPackages(venvRoot string, origin string) ([]*pkgdata.PkgInfo, error) {
 			pkg.Origin = origin
 			pkg.Reason = consts.ReasonExplicit
 
-			creationTime, _, err := shared.GetBirthTime(dirPath)
-			if err == nil {
+			creationTime, reliable, err := shared.GetCreationTime(dirPath)
+			if err == nil && reliable {
 				pkg.InstallTimestamp = creationTime
 			}
 

--- a/internal/origins/shared/birth_bsd.go
+++ b/internal/origins/shared/birth_bsd.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build freebsd
 
 package shared
 
@@ -8,13 +8,13 @@ import (
 	"time"
 )
 
-func GetBirthTime(path string) (int64, bool, error) {
+func getBirthTime(path string) (int64, bool, error) {
 	fileInfo, err := os.Stat(path)
 	if err != nil {
 		return 0, false, err
 	}
 
 	stat := fileInfo.Sys().(*syscall.Stat_t)
-	birthTime := time.Unix(stat.Birthtimespec.Sec, stat.Birthtimespec.Nsec)
+	birthTime := time.Unix(int64(stat.Birthtimespec.Sec), int64(stat.Birthtimespec.Nsec))
 	return birthTime.Unix(), true, nil
 }

--- a/internal/origins/shared/birth_darwin.go
+++ b/internal/origins/shared/birth_darwin.go
@@ -1,4 +1,4 @@
-//go:build freebsd
+//go:build darwin
 
 package shared
 
@@ -8,13 +8,13 @@ import (
 	"time"
 )
 
-func GetBirthTime(path string) (int64, bool, error) {
+func getBirthTime(path string) (int64, bool, error) {
 	fileInfo, err := os.Stat(path)
 	if err != nil {
 		return 0, false, err
 	}
 
 	stat := fileInfo.Sys().(*syscall.Stat_t)
-	birthTime := time.Unix(int64(stat.Birthtimespec.Sec), int64(stat.Birthtimespec.Nsec))
+	birthTime := time.Unix(stat.Birthtimespec.Sec, stat.Birthtimespec.Nsec)
 	return birthTime.Unix(), true, nil
 }

--- a/internal/origins/shared/birth_linux.go
+++ b/internal/origins/shared/birth_linux.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func GetBirthTime(path string) (int64, bool, error) {
+func getBirthTime(path string) (int64, bool, error) {
 	var stat unix.Statx_t
 
 	err := unix.Statx(unix.AT_FDCWD, path, 0, unix.STATX_BTIME, &stat)

--- a/internal/origins/shared/birth_linux.go
+++ b/internal/origins/shared/birth_linux.go
@@ -12,13 +12,13 @@ import (
 func getBirthTime(path string) (int64, bool, error) {
 	var stat unix.Statx_t
 
+	if stat.Mask&unix.STATX_BTIME == 0 {
+		return 0, false, fmt.Errorf("birth time not available")
+	}
+
 	err := unix.Statx(unix.AT_FDCWD, path, 0, unix.STATX_BTIME, &stat)
 	if err != nil {
 		return 0, false, err
-	}
-
-	if stat.Mask&unix.STATX_BTIME == 0 {
-		return 0, false, fmt.Errorf("birth time not available")
 	}
 
 	birthTime := time.Unix(stat.Btime.Sec, int64(stat.Btime.Nsec))

--- a/internal/origins/shared/creation_time.go
+++ b/internal/origins/shared/creation_time.go
@@ -1,0 +1,16 @@
+package shared
+
+import "os"
+
+func GetCreationTime(path string) (int64, bool, error) {
+	if birthTime, reliable, err := getBirthTime(path); err == nil {
+		return birthTime, reliable, nil
+	}
+
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return 0, false, err
+	}
+
+	return fileInfo.ModTime().Unix(), false, nil
+}

--- a/internal/pkgdata/cache.go
+++ b/internal/pkgdata/cache.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	cacheVersion    = 23 // bump when updating structure of PkgInfo/Relation/pkginfo.proto OR when dependency resolution is updated
+	cacheVersion    = 24 // bump when updating structure of PkgInfo/Relation/pkginfo.proto OR when dependency resolution is updated
 	historyVersion  = 2
 	xdgCacheHomeEnv = "XDG_CACHE_HOME"
 	homeEnv         = "HOME"


### PR DESCRIPTION
Homebrew now has history, joining pacman and pipx. However, this is not supported in docker containers that have an overlay filesystem, as well as ext filesystems prior to ext4 or ext4 filesystems with Linux kernel versions below 4.11.