### PR TITLE
Feature: Add light macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,16 @@ some frequently-used query patterns are available as built-in macros for conveni
   qp where size=100MB:
   ```
 
+* `light` - matches packages 1MB and smaller
+  ```
+  qp w light
+  ```
+
+  is equivalent to:
+  ```
+  qp where size=1MB:
+  ```
+
 these macros can be combined with other queries as usual:
 
 ```

--- a/internal/quipple/preprocess/macro_engine.go
+++ b/internal/quipple/preprocess/macro_engine.go
@@ -50,6 +50,8 @@ func expandWhereMacro(token string) ([]string, bool) {
 		expanded = []string{"no:required-by", "and", "reason=dependency", "and", "no:optional-for"}
 	case "heavy":
 		expanded = []string{"size=100MB:"}
+	case "light":
+		expanded = []string{"size=:1MB"}
 	default:
 		return nil, false
 	}


### PR DESCRIPTION
`qp w light` is equivalent to `qp where size=:1MB`.

Example:
```
qp w light
UPDATED     NAME                           REASON      SIZE
2025-05-26  python-setuptools-scm          dependency  374.83 KB
2025-05-26  time                           explicit    79.63 KB
2025-05-26  ttf-nerd-fonts-symbols-common  dependency  53.47 KB
2025-05-26  timg                           explicit    265.99 KB
2025-05-26  litecli                        explicit    506.37 KB
2025-05-26  downgrade                      explicit    79.75 KB
2025-05-27  libldap                        dependency  750.15 KB
2025-05-28  dnssec-anchors                 dependency  809 B
2025-05-30  aws-c-io                       dependency  580.64 KB
2025-05-30  aws-c-mqtt                     dependency  824.96 KB
2025-05-30  aws-c-s3                       dependency  407.67 KB
2025-05-30  aws-c-cal                      dependency  179.91 KB
2025-05-30  python-s3transfer              dependency  946.41 KB
2025-05-30  libxkbcommon-x11               dependency  219.62 KB
2025-05-30  python-installer               explicit    178.87 KB
2025-05-30  libxss                         explicit    78.31 KB
2025-05-30  libnghttp3                     dependency  296.41 KB
2025-05-30  systemd-sysvcompat             dependency  2.65 KB
2025-05-30  llhttp                         dependency  102.13 KB
2025-06-01  luajit                         dependency  869.42 KB
```