### PR TITLE
Feature: Manage storage permissions

### DIFF
--- a/internal/storage/cache.go
+++ b/internal/storage/cache.go
@@ -14,7 +14,7 @@ import (
 
 func SaveCacheModTime(cacheRoot string, modTime int64) error {
 	modPath := cacheRoot + dotModTime
-	return os.WriteFile(modPath, []byte(strconv.FormatInt(modTime, 10)), 0644)
+	return FileManager.WriteFile(modPath, []byte(strconv.FormatInt(modTime, 10)), 0644)
 }
 
 func LoadCacheModTime(cacheRoot string) (int64, error) {
@@ -65,5 +65,5 @@ func SaveProtoCache(cacheRoot string, pkgs []*pkgdata.PkgInfo) error {
 		return fmt.Errorf("failed to marshal cache: %v", cachedPkgs)
 	}
 
-	return os.WriteFile(cachePath, byteData, 0644)
+	return FileManager.WriteFile(cachePath, byteData, 0644)
 }

--- a/internal/storage/file_manager.go
+++ b/internal/storage/file_manager.go
@@ -1,0 +1,82 @@
+package storage
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+)
+
+var FileManager *fileManager
+
+type fileManager struct {
+	targetUser *user.User
+	uid        int
+	gid        int
+}
+
+func init() {
+	var targetUser *user.User
+	var gid int
+	var uid int
+
+	if sudoUser := os.Getenv(sudoUserEnv); sudoUser != "" {
+		var err error
+		if targetUser, err = user.Lookup(sudoUser); err == nil {
+			uid, _ = strconv.Atoi(targetUser.Uid)
+			gid, _ = strconv.Atoi(targetUser.Gid)
+		}
+	}
+
+	FileManager = &fileManager{
+		targetUser: targetUser,
+		uid:        uid,
+		gid:        gid,
+	}
+}
+
+func (fm *fileManager) WriteFile(path string, data []byte, mode os.FileMode) error {
+	if err := os.WriteFile(path, data, mode); err != nil {
+		return err
+	}
+
+	if fm.targetUser != nil {
+		return fm.Chown(path)
+	}
+
+	return nil
+}
+
+func (fm *fileManager) Remove(path string) error {
+	return os.Remove(path)
+}
+
+func (fm *fileManager) MkdirAll(dir string, mode os.FileMode) error {
+	var parentDir string
+	var needsParentChown bool
+	if fm.targetUser != nil {
+		parentDir = filepath.Dir(dir)
+		_, err := os.Stat(parentDir)
+		needsParentChown = err != nil
+	}
+
+	if err := os.MkdirAll(dir, mode); err != nil {
+		return err
+	}
+
+	if fm.targetUser != nil {
+		if needsParentChown {
+			if err := fm.Chown(parentDir); err != nil {
+				return err
+			}
+		}
+
+		return fm.Chown(dir)
+	}
+
+	return nil
+}
+
+func (fm *fileManager) Chown(dir string) error {
+	return os.Chown(dir, fm.uid, fm.gid)
+}

--- a/internal/storage/lock.go
+++ b/internal/storage/lock.go
@@ -14,10 +14,10 @@ func IsLockFileExists(cacheRoot string) bool {
 func CreateLockFile(cacheRoot string) error {
 	lockPath := cacheRoot + dotLock
 	pid := os.Getpid()
-	return os.WriteFile(lockPath, []byte(strconv.Itoa(pid)), 0644)
+	return FileManager.WriteFile(lockPath, []byte(strconv.Itoa(pid)), 0644)
 }
 
 func RemoveLockFile(cacheRoot string) error {
 	lockPath := cacheRoot + dotLock
-	return os.Remove(lockPath)
+	return FileManager.Remove(lockPath)
 }

--- a/internal/storage/paths.go
+++ b/internal/storage/paths.go
@@ -15,7 +15,7 @@ func GetCachePath() (string, error) {
 	}
 
 	cachePath := filepath.Join(userCacheDir, qpCacheDir)
-	if err := os.MkdirAll(cachePath, 0755); err != nil {
+	if err := FileManager.MkdirAll(cachePath, 0755); err != nil {
 		return "", fmt.Errorf("failed to create cache directory: %w", err)
 	}
 


### PR DESCRIPTION
We now ensure that all files and directories created by qp are owned by the user, even if they run qp with `sudo`. All file operations should go through FileManager from here on out to ensure that users don't accidentally create files they can't access.