### PR TITLE
Feature: Add rpm history

### DIFF
--- a/internal/origins/drivers/rpm/constants.go
+++ b/internal/origins/drivers/rpm/constants.go
@@ -22,10 +22,10 @@ const (
 	dnfReasonUser       = 2
 	dnfReasonWeakDep    = 4
 
-	dnfActionInstall  = 1
-	dnfActionUpgrade  = 2
-	dnfActionRemove   = 3
-	dnfActionObsolete = 4
+	dnfActionInstall  = 1 // new package installation
+	dnfActionUpgrade  = 6 // installing new version of existing package
+	dnfActionUpgraded = 7 // removing old version during upgrade
+	dnfActionRemove   = 8
 
 	yumReasonUser = "user"
 	yumReasonDep  = "dep"

--- a/internal/origins/drivers/rpm/discover.go
+++ b/internal/origins/drivers/rpm/discover.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"qp/internal/consts"
 	out "qp/internal/display"
 )
 
@@ -44,8 +45,12 @@ func findHistoryDb() string {
 
 	for _, pattern := range candidates {
 		matches, err := filepath.Glob(pattern)
+
 		if err == nil && len(matches) > 0 {
-			return matches[len(matches)-1]
+			dbPath := matches[len(matches)-1]
+			if isValidHistoryDb(dbPath) {
+				return dbPath
+			}
 		}
 	}
 
@@ -64,4 +69,13 @@ func checkSqlite() error {
 	}
 
 	return nil
+}
+
+func isValidHistoryDb(path string) bool {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+
+	return stat.Size() > consts.KB
 }

--- a/internal/origins/drivers/rpm/fetch.go
+++ b/internal/origins/drivers/rpm/fetch.go
@@ -34,28 +34,33 @@ func fetchPackages(origin string, path string) ([]*pkgdata.PkgInfo, error) {
 		}
 
 		reason := consts.ReasonExplicit
+
+		// TODO: perhaps for yum, a file should be saved for history
+		installTimestamp := int64(rpmPkg.InstallTime)
 		if historyReason, exists := reasonMap[rpmPkg.Name]; exists {
-			reason = historyReason
+			reason = historyReason.Reason
+			installTimestamp = historyReason.Timestamp
 		}
 
 		pkg := &pkgdata.PkgInfo{
-			UpdateTimestamp: int64(rpmPkg.InstallTime),
-			BuildTimestamp:  int64(rpmPkg.BuildTime),
-			Name:            rpmPkg.Name,
-			Version:         parseVersion(rpmPkg.Epoch, rpmPkg.Version),
-			Arch:            rpmPkg.Arch,
-			Size:            int64(rpmPkg.Size),
-			License:         rpmPkg.License,
-			Origin:          origin,
-			Description:     rpmPkg.Summary,
-			Packager:        rpmPkg.Packager,
-			Url:             rpmPkg.URL,
-			Groups:          []string{group},
-			Reason:          reason,
-			Conflicts:       parseRelationList(rpmPkg.Conflicts),
-			Replaces:        parseRelationList(rpmPkg.Obsoletes),
-			Depends:         parseRelationList(rpmPkg.Requires),
-			Provides:        parseRelationList(rpmPkg.Provides),
+			InstallTimestamp: installTimestamp,
+			UpdateTimestamp:  int64(rpmPkg.InstallTime),
+			BuildTimestamp:   int64(rpmPkg.BuildTime),
+			Name:             rpmPkg.Name,
+			Version:          parseVersion(rpmPkg.Epoch, rpmPkg.Version),
+			Arch:             rpmPkg.Arch,
+			Size:             int64(rpmPkg.Size),
+			License:          rpmPkg.License,
+			Origin:           origin,
+			Description:      rpmPkg.Summary,
+			Packager:         rpmPkg.Packager,
+			Url:              rpmPkg.URL,
+			Groups:           []string{group},
+			Reason:           reason,
+			Conflicts:        parseRelationList(rpmPkg.Conflicts),
+			Replaces:         parseRelationList(rpmPkg.Obsoletes),
+			Depends:          parseRelationList(rpmPkg.Requires),
+			Provides:         parseRelationList(rpmPkg.Provides),
 		}
 
 		pkgs = append(pkgs, pkg)

--- a/internal/origins/drivers/rpm/history.go
+++ b/internal/origins/drivers/rpm/history.go
@@ -9,33 +9,42 @@ import (
 	"strings"
 )
 
-const permissionError = "failed to open history database (may need root permissions): %w\n rpm install reasons will incorrectly display as 'explicit'"
+type InstallInfo struct {
+	Reason    string
+	Timestamp int64
+}
 
-func loadInstallReasons() (map[string]string, error) {
+const permissionError = "failed to open history database (may need sudo): %w\n rpm install reasons will incorrectly display as 'explicit'"
+
+func loadInstallReasons() (map[string]InstallInfo, error) {
 	historyPath := findHistoryDb()
 	if historyPath == "" {
-		return map[string]string{}, nil
+		return map[string]InstallInfo{}, nil
 	}
 
 	return parseRpmHistory(historyPath)
 }
 
-func parseRpmHistory(historyPath string) (map[string]string, error) {
+func parseRpmHistory(historyPath string) (map[string]InstallInfo, error) {
 	if _, err := os.Stat(historyPath); err != nil {
-		return map[string]string{}, fmt.Errorf("history database not found: %w", err)
+		return map[string]InstallInfo{}, fmt.Errorf("history database not found: %w", err)
 	}
 
 	dnfQuery := fmt.Sprintf(`
     SELECT
-      r.name, ti.reason 
+      r.name, ti.reason, t.dt_begin 
     FROM
       trans_item ti 
     JOIN
       item i ON ti.item_id = i.id 
     JOIN
-      rpm r ON i.id = r.item_id 
+      rpm r ON i.id = r.item_id
+    JOIN
+      trans t ON ti.trans_id = t.id
     WHERE
-      i.item_type = 0 AND ti.action = %d;
+      i.item_type = 0 AND ti.action = %d
+    ORDER BY
+      t.dt_begin DESC;
   `, dnfActionInstall)
 
 	cmd := exec.Command("sqlite3", historyPath, dnfQuery)
@@ -53,35 +62,40 @@ func parseRpmHistory(historyPath string) (map[string]string, error) {
         WHEN tdp.state IN ('%s', '%s') THEN %d
         WHEN tdp.state = '%s' THEN %d
         ELSE 0
-      END as reason
+      END as reason,
+      t.timestamp
     FROM
       pkgtups p
     JOIN
       trans_data_pkgs tdp ON p.pkgtupid = tdp.pkgtupid
+    JOIN
+      trans_beg t ON tdp.tid = t.tid
     LEFT JOIN
       pkg_yumdb py ON p.pkgtupid = py.pkgtupid AND py.yumdb_key = 'reason'
     WHERE
       tdp.state IN ('%s', '%s', '%s')
-    GROUP BY
-      p.name;
+    ORDER BY
+      timestamp DESC;
   `,
 		yumReasonUser, dnfReasonUser,
 		yumReasonDep, dnfReasonDependency,
 		yumStateInstall, yumStateTrueInstall, dnfReasonUser,
 		yumStateDepInstall, dnfReasonDependency,
-		yumStateInstall, yumStateTrueInstall, yumStateDepInstall)
+		yumStateInstall, yumStateTrueInstall, yumStateDepInstall,
+	)
 
 	cmd = exec.Command("sqlite3", historyPath, yumQuery)
 	output, err = cmd.CombinedOutput()
 	if err != nil {
-		return map[string]string{}, fmt.Errorf(permissionError, err)
+		return map[string]InstallInfo{}, fmt.Errorf(permissionError, err)
 	}
 
 	return parseHistoryOutput(string(output))
 }
 
-func parseHistoryOutput(output string) (map[string]string, error) {
-	reasonMap := make(map[string]string)
+func parseHistoryOutput(output string) (map[string]InstallInfo, error) {
+	infoMap := make(map[string]InstallInfo)
+	seenPackages := make(map[string]bool)
 
 	lines := strings.Split(strings.TrimSpace(output), "\n")
 	for _, line := range lines {
@@ -95,6 +109,12 @@ func parseHistoryOutput(output string) (map[string]string, error) {
 		}
 
 		name := strings.TrimSpace(parts[0])
+
+		if seenPackages[name] {
+			continue
+		}
+		seenPackages[name] = true
+
 		reasonCode := strings.TrimSpace(parts[1])
 		reasonInt, err := strconv.Atoi(reasonCode)
 		if err != nil {
@@ -109,10 +129,23 @@ func parseHistoryOutput(output string) (map[string]string, error) {
 			pkgReason = consts.ReasonExplicit
 		}
 
-		if pkgReason != "" {
-			reasonMap[name] = pkgReason
+		if pkgReason == "" {
+			continue
 		}
+
+		info := InstallInfo{
+			Reason: pkgReason,
+		}
+
+		if len(parts) >= 3 {
+			timestampStr := strings.TrimSpace(parts[2])
+			if timestamp, err := strconv.ParseInt(timestampStr, 10, 64); err == nil {
+				info.Timestamp = timestamp
+			}
+		}
+
+		infoMap[name] = info
 	}
 
-	return reasonMap, nil
+	return infoMap, nil
 }

--- a/internal/origins/drivers/rpm/history.go
+++ b/internal/origins/drivers/rpm/history.go
@@ -31,21 +31,21 @@ func parseRpmHistory(historyPath string) (map[string]InstallInfo, error) {
 	}
 
 	dnfQuery := fmt.Sprintf(`
-    SELECT
-      r.name, ti.reason, t.dt_begin 
-    FROM
-      trans_item ti 
-    JOIN
-      item i ON ti.item_id = i.id 
-    JOIN
-      rpm r ON i.id = r.item_id
-    JOIN
-      trans t ON ti.trans_id = t.id
-    WHERE
-      i.item_type = 0 AND ti.action = %d
-    ORDER BY
-      t.dt_begin DESC;
-  `, dnfActionInstall)
+      SELECT
+        r.name, ti.reason, t.dt_begin
+      FROM
+        trans_item ti
+      JOIN
+        item i ON ti.item_id = i.id
+      JOIN
+        rpm r ON i.id = r.item_id
+      JOIN
+        trans t ON ti.trans_id = t.id
+      WHERE
+        i.item_type = 0 AND ti.action = %d
+      ORDER BY
+        t.dt_begin DESC;
+    `, dnfActionInstall)
 
 	cmd := exec.Command("sqlite3", historyPath, dnfQuery)
 	output, err := cmd.CombinedOutput()
@@ -54,29 +54,29 @@ func parseRpmHistory(historyPath string) (map[string]InstallInfo, error) {
 	}
 
 	yumQuery := fmt.Sprintf(`
-    SELECT 
-      p.name, 
-      CASE
-        WHEN py.yumdb_val = '%s' THEN %d
-        WHEN py.yumdb_val = '%s' THEN %d
-        WHEN tdp.state IN ('%s', '%s') THEN %d
-        WHEN tdp.state = '%s' THEN %d
-        ELSE 0
-      END as reason,
-      t.timestamp
-    FROM
-      pkgtups p
-    JOIN
-      trans_data_pkgs tdp ON p.pkgtupid = tdp.pkgtupid
-    JOIN
-      trans_beg t ON tdp.tid = t.tid
-    LEFT JOIN
-      pkg_yumdb py ON p.pkgtupid = py.pkgtupid AND py.yumdb_key = 'reason'
-    WHERE
-      tdp.state IN ('%s', '%s', '%s')
-    ORDER BY
-      timestamp DESC;
-  `,
+      SELECT 
+        p.name,
+        CASE
+          WHEN py.yumdb_val = '%s' THEN %d
+          WHEN py.yumdb_val = '%s' THEN %d
+          WHEN tdp.state IN ('%s', '%s') THEN %d
+          WHEN tdp.state = '%s' THEN %d
+         ELSE 0
+       END as reason,
+        t.timestamp
+      FROM
+        pkgtups p
+      JOIN
+        trans_data_pkgs tdp ON p.pkgtupid = tdp.pkgtupid
+      JOIN
+        trans_beg t ON tdp.tid = t.tid
+      LEFT JOIN
+        pkg_yumdb py ON p.pkgtupid = py.pkgtupid AND py.yumdb_key = 'reason'
+      WHERE
+        tdp.state IN ('%s', '%s', '%s')
+      ORDER BY
+        timestamp DESC;
+    `,
 		yumReasonUser, dnfReasonUser,
 		yumReasonDep, dnfReasonDependency,
 		yumStateInstall, yumStateTrueInstall, dnfReasonUser,

--- a/protobuf/history.proto
+++ b/protobuf/history.proto
@@ -7,8 +7,8 @@ package pkginfo;
 option go_package = "internal/protobuf;protobuf";
 
 message InstallHistory {
+  reserved 3;
   int32 version = 1;
   int64 latest_log_timestamp = 4;
   map<string, int64> install_timestamps = 2;
-  map<string, int64> seen_timestamps = 3;
 }


### PR DESCRIPTION
The rpm origin now has history. Perhaps we should set the system creation date as the install date for packages not found in the logs.