### PR TITLE
Feature: Origin deduplication

### DIFF
--- a/cmd/qp/main.go
+++ b/cmd/qp/main.go
@@ -12,6 +12,7 @@ import (
 	"qp/internal/origins"
 	"qp/internal/pipeline/phase"
 	"qp/internal/pkgdata"
+	"qp/internal/quipple/compiler"
 	"qp/internal/quipple/syntax"
 	"qp/internal/storage"
 	"sync"
@@ -81,6 +82,15 @@ func mainWithConfig(configProvider config.ConfigProvider) error {
 	var allPkgs []*pkgdata.PkgInfo
 	for pkgs := range results {
 		allPkgs = append(allPkgs, pkgs...)
+	}
+
+	allPkgs = pkgdata.Deduplicate(allPkgs)
+
+	if cfg.QueryExpr != nil {
+		allPkgs, err = compiler.RunDAG(cfg.QueryExpr, allPkgs)
+		if err != nil {
+			return fmt.Errorf("filtering failed: %w", err)
+		}
 	}
 
 	if len(allPkgs) == 0 {

--- a/internal/pipeline/phase/pipeline.go
+++ b/internal/pipeline/phase/pipeline.go
@@ -35,6 +35,7 @@ func NewPipeline(
 	}
 }
 
+// TODO: we can merge the logic of these two and just swap in arrays
 func (p *Pipeline) Run() ([]*pkgdata.PkgInfo, error) {
 	var wg sync.WaitGroup
 	phases := []PipelinePhase{
@@ -42,7 +43,6 @@ func (p *Pipeline) Run() ([]*pkgdata.PkgInfo, error) {
 		NewPhase("Fetch packages", p.fetchStep, &wg),
 		NewPhase("Resolve dependencies", p.resolveStep, &wg),
 		NewPhase("Save cache", p.saveCacheStep, &wg),
-		NewPhase("Filter", p.filterStep, &wg),
 	}
 
 	pkgs := []*PkgInfo{}

--- a/internal/pipeline/phase/steps.go
+++ b/internal/pipeline/phase/steps.go
@@ -6,7 +6,6 @@ import (
 	out "qp/internal/display"
 	"qp/internal/pipeline/meta"
 	"qp/internal/pkgdata"
-	"qp/internal/quipple/compiler"
 	"qp/internal/storage"
 	"time"
 )
@@ -104,18 +103,6 @@ func (p *Pipeline) saveCacheStep(
 	if err != nil {
 		out.WriteLine(fmt.Sprintf("Warning: failed to save cache modtime: %v", err))
 		return pkgs, nil
-	}
-
-	return pkgs, nil
-}
-
-func (p *Pipeline) filterStep(
-	cfg *config.Config,
-	pkgs []*pkgdata.PkgInfo,
-	reportProgress meta.ProgressReporter,
-) ([]*pkgdata.PkgInfo, error) {
-	if cfg.QueryExpr != nil {
-		return compiler.RunDAG(cfg.QueryExpr, pkgs)
 	}
 
 	return pkgs, nil

--- a/internal/pkgdata/deduplication.go
+++ b/internal/pkgdata/deduplication.go
@@ -1,0 +1,128 @@
+package pkgdata
+
+import (
+	"qp/internal/consts"
+	"strings"
+)
+
+var originPriorityOrder = []string{
+	consts.OriginPacman,
+	consts.OriginDeb,
+	consts.OriginRpm,
+	consts.OriginOpkg,
+	consts.OriginBrew,
+	consts.OriginPipx,
+	consts.OriginNpm,
+}
+
+const (
+	node         = "node-"
+	nodejs       = "nodejs-"
+	python       = "python-"
+	python3      = "python3-"
+	pythonNoDash = "python"
+)
+
+func Deduplicate(pkgs []*PkgInfo) []*PkgInfo {
+	nameGroups := make(map[string][]*PkgInfo)
+
+	for _, pkg := range pkgs {
+		normalizedName := normalizeName(pkg.Name, pkg.Origin)
+		nameGroups[normalizedName] = append(nameGroups[normalizedName], pkg)
+	}
+
+	var result []*PkgInfo
+
+	for _, group := range nameGroups {
+		if len(group) == 1 {
+			result = append(result, group[0])
+			continue
+		}
+
+		bestPkg := bestPriority(group)
+		result = append(result, bestPkg)
+	}
+
+	return result
+}
+
+func normalizeName(name, origin string) string {
+	switch origin {
+	case consts.OriginPacman:
+		return normalizeArch(name)
+	case consts.OriginDeb:
+		return normalizeDeb(name)
+	case consts.OriginRpm:
+		return normalizeRpm(name)
+	default:
+		return strings.ToLower(name)
+	}
+}
+
+func normalizeArch(name string) string {
+	if strings.HasPrefix(name, python) {
+		return strings.TrimPrefix(name, python)
+	}
+
+	if strings.HasPrefix(name, nodejs) {
+		return strings.TrimPrefix(name, nodejs)
+	}
+
+	return strings.ToLower(name)
+}
+
+func normalizeDeb(name string) string {
+	if strings.HasPrefix(name, python3) {
+		return strings.TrimPrefix(name, python3)
+	}
+
+	if strings.HasPrefix(name, node) {
+		return strings.TrimPrefix(name, node)
+	}
+
+	return strings.ToLower(name)
+}
+
+func normalizeRpm(name string) string {
+	if strings.HasPrefix(name, python3) {
+		return strings.TrimPrefix(name, python3)
+	}
+
+	// versioned python (python39-xyx), we can't guarantee what version fedora will support next
+	if strings.HasPrefix(name, pythonNoDash) && strings.Contains(name, "-") {
+		parts := strings.SplitN(name, "-", 2)
+		if len(parts) == 2 && strings.HasPrefix(parts[0], pythonNoDash) {
+			return parts[1]
+		}
+	}
+
+	if strings.HasPrefix(name, nodejs) {
+		return strings.TrimPrefix(name, nodejs)
+	}
+
+	return strings.ToLower(name)
+}
+
+func bestPriority(pkgs []*PkgInfo) *PkgInfo {
+	if len(pkgs) == 1 {
+		return pkgs[0]
+	}
+
+	priorityMap := make(map[string]int)
+	for i, origin := range originPriorityOrder {
+		priorityMap[origin] = i
+	}
+
+	bestPkg := pkgs[0]
+	bestPriority := priorityMap[bestPkg.Origin]
+
+	for _, pkg := range pkgs[1:] {
+		priority := priorityMap[pkg.Origin]
+		if priority < bestPriority {
+			bestPkg = pkg
+			bestPriority = priority
+		}
+	}
+
+	return bestPkg
+}


### PR DESCRIPTION
This should help reduce confusion when a system package manager handles language/application level packages. 

I haven't been able to figure out what the names are for python/node packages that are handled by brew, but research will continue there.

Additionally, these duplicate packages will soon be multi-origin when they are displayed.