### PR TITLE
Feature: Add env field

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ learn about installation [here](#installation)
 | ✓ | cache-only option | ✓ | pacman hook |
 | - | brew hook | - | deb hook |
 | ✓ | npm origin (npm global packages) | - | nested dependencies |
-| ✓ | add also-in field (cross-origin managed) | - | add env field |
+| ✓ | add also-in field (cross-origin managed) | ✓ | add env field |
 | - | add other envs field | - | add support for multiple virtual environments (nvm/pyenv/etc.) |
 
 ## installation

--- a/internal/consts/fields.go
+++ b/internal/consts/fields.go
@@ -8,6 +8,7 @@ const (
 	FieldArch
 	FieldName
 	FieldOrigin
+	FieldEnv
 	FieldPkgType
 	FieldLicense
 	FieldPkgBase
@@ -52,7 +53,7 @@ func GetFieldPrim(field FieldType) FieldPrim {
 	case FieldName, FieldReason, FieldVersion,
 		FieldOrigin, FieldArch, FieldLicense,
 		FieldUrl, FieldDescription, FieldValidation,
-		FieldPkgType, FieldPkgBase, FieldPackager:
+		FieldEnv, FieldPkgType, FieldPkgBase, FieldPackager:
 		return FieldPrimStr
 
 	case FieldAlsoIn, FieldGroups:
@@ -82,6 +83,7 @@ const (
 	description = "description"
 	url         = "url"
 	validation  = "validation"
+	env         = "env"
 	pkgType     = "pkgtype"
 	pkgBase     = "pkgbase"
 	packager    = "packager"
@@ -125,6 +127,7 @@ var FieldTypeLookup = map[string]FieldType{
 	description: FieldDescription,
 	url:         FieldUrl,
 	validation:  FieldValidation,
+	env:         FieldEnv,
 	pkgType:     FieldPkgType,
 	pkgBase:     FieldPkgBase,
 	packager:    FieldPackager,
@@ -153,6 +156,7 @@ var FieldNameLookup = map[FieldType]string{
 	FieldDescription: description,
 	FieldUrl:         url,
 	FieldValidation:  validation,
+	FieldEnv:         env,
 	FieldPkgType:     pkgType,
 	FieldPkgBase:     pkgBase,
 	FieldPackager:    packager,
@@ -188,6 +192,7 @@ var (
 		FieldDescription,
 		FieldUrl,
 		FieldValidation,
+		FieldEnv,
 		FieldPkgType,
 		FieldPkgBase,
 		FieldPackager,

--- a/internal/display/render_json.go
+++ b/internal/display/render_json.go
@@ -23,6 +23,7 @@ type PkgInfoJSON struct {
 	Description        string   `json:"description,omitempty"`
 	Url                string   `json:"url,omitempty"`
 	Validation         string   `json:"validation,omitempty"`
+	Env                string   `json:"env,omitempty"`
 	PkgType            string   `json:"pkgtype,omitempty"`
 	PkgBase            string   `json:"pkgbase,omitempty"`
 	Packager           string   `json:"packager,omitempty"`
@@ -37,16 +38,16 @@ type PkgInfoJSON struct {
 	Provides           []string `json:"provides,omitempty"`
 }
 
-func (o *OutputManager) renderJSON(pkgPtrs []*pkgdata.PkgInfo, fields []consts.FieldType) {
+func (o *OutputManager) renderJSON(pkgs []*pkgdata.PkgInfo, fields []consts.FieldType) {
 	uniqueFields := getUniqueFields(fields)
-	filteredPkgPtrs := selectJsonFields(pkgPtrs, uniqueFields)
+	filteredPkgs := selectJsonFields(pkgs, uniqueFields)
 
 	var buffer bytes.Buffer
 	encoder := json.NewEncoder(&buffer)
 	encoder.SetEscapeHTML(false) // disable escaping of characters like `<`, `>`, perhaps this should be a user defined option
 	encoder.SetIndent("", "  ")
 
-	if err := encoder.Encode(filteredPkgPtrs); err != nil {
+	if err := encoder.Encode(filteredPkgs); err != nil {
 		o.writeLine(fmt.Sprintf("Error generating JSON output: %v", err))
 	}
 
@@ -68,74 +69,76 @@ func getUniqueFields(fields []consts.FieldType) []consts.FieldType {
 }
 
 func selectJsonFields(
-	pkgPtrs []*pkgdata.PkgInfo,
+	pkgs []*pkgdata.PkgInfo,
 	fields []consts.FieldType,
 ) []*PkgInfoJSON {
-	filteredPkgPtrs := make([]*PkgInfoJSON, len(pkgPtrs))
-	for i, pkg := range pkgPtrs {
-		filteredPkgPtrs[i] = getJsonValues(pkg, fields)
+	filteredPkgs := make([]*PkgInfoJSON, len(pkgs))
+	for i, pkg := range pkgs {
+		filteredPkgs[i] = getJsonValues(pkg, fields)
 	}
 
-	return filteredPkgPtrs
+	return filteredPkgs
 }
 
 func getJsonValues(pkg *pkgdata.PkgInfo, fields []consts.FieldType) *PkgInfoJSON {
-	filteredPackage := PkgInfoJSON{}
+	filteredPkg := PkgInfoJSON{}
 
 	for _, field := range fields {
 		switch field {
 		case consts.FieldInstalled:
-			filteredPackage.InstalledTimestamp = pkg.GetInt(field)
+			filteredPkg.InstalledTimestamp = pkg.GetInt(field)
 		case consts.FieldUpdated:
-			filteredPackage.UpdateTimestamp = pkg.GetInt(field)
+			filteredPkg.UpdateTimestamp = pkg.GetInt(field)
 		case consts.FieldBuilt:
-			filteredPackage.BuildTimestamp = pkg.GetInt(field)
+			filteredPkg.BuildTimestamp = pkg.GetInt(field)
 		case consts.FieldSize:
-			filteredPackage.Size = pkg.GetInt(field)
+			filteredPkg.Size = pkg.GetInt(field)
 		case consts.FieldName:
-			filteredPackage.Name = pkg.GetString(field)
+			filteredPkg.Name = pkg.GetString(field)
 		case consts.FieldReason:
-			filteredPackage.Reason = pkg.GetString(field)
+			filteredPkg.Reason = pkg.GetString(field)
 		case consts.FieldVersion:
-			filteredPackage.Version = pkg.GetString(field)
+			filteredPkg.Version = pkg.GetString(field)
 		case consts.FieldOrigin:
-			filteredPackage.Origin = pkg.GetString(field)
+			filteredPkg.Origin = pkg.GetString(field)
 		case consts.FieldArch:
-			filteredPackage.Arch = pkg.GetString(field)
+			filteredPkg.Arch = pkg.GetString(field)
 		case consts.FieldLicense:
-			filteredPackage.License = pkg.GetString(field)
+			filteredPkg.License = pkg.GetString(field)
 		case consts.FieldDescription:
-			filteredPackage.Description = pkg.GetString(field)
+			filteredPkg.Description = pkg.GetString(field)
 		case consts.FieldUrl:
-			filteredPackage.Url = pkg.GetString(field)
+			filteredPkg.Url = pkg.GetString(field)
 		case consts.FieldValidation:
-			filteredPackage.Validation = pkg.GetString(field)
+			filteredPkg.Validation = pkg.GetString(field)
+		case consts.FieldEnv:
+			filteredPkg.Env = pkg.GetString(field)
 		case consts.FieldPkgType:
-			filteredPackage.PkgType = pkg.GetString(field)
+			filteredPkg.PkgType = pkg.GetString(field)
 		case consts.FieldPkgBase:
-			filteredPackage.PkgBase = pkg.GetString(field)
+			filteredPkg.PkgBase = pkg.GetString(field)
 		case consts.FieldPackager:
-			filteredPackage.Packager = pkg.GetString(field)
+			filteredPkg.Packager = pkg.GetString(field)
 		case consts.FieldAlsoIn:
-			filteredPackage.AlsoIn = pkg.GetStrArr(field)
+			filteredPkg.AlsoIn = pkg.GetStrArr(field)
 		case consts.FieldGroups:
-			filteredPackage.Groups = pkg.GetStrArr(field)
+			filteredPkg.Groups = pkg.GetStrArr(field)
 		case consts.FieldConflicts:
-			filteredPackage.Conflicts = flattenRelations(pkg.GetRelations(field))
+			filteredPkg.Conflicts = flattenRelations(pkg.GetRelations(field))
 		case consts.FieldReplaces:
-			filteredPackage.Replaces = flattenRelations(pkg.GetRelations(field))
+			filteredPkg.Replaces = flattenRelations(pkg.GetRelations(field))
 		case consts.FieldDepends:
-			filteredPackage.Depends = flattenRelations(pkg.GetRelations(field))
+			filteredPkg.Depends = flattenRelations(pkg.GetRelations(field))
 		case consts.FieldOptDepends:
-			filteredPackage.OptDepends = flattenRelations(pkg.GetRelations(field))
+			filteredPkg.OptDepends = flattenRelations(pkg.GetRelations(field))
 		case consts.FieldRequiredBy:
-			filteredPackage.RequiredBy = flattenRelations(pkg.GetRelations(field))
+			filteredPkg.RequiredBy = flattenRelations(pkg.GetRelations(field))
 		case consts.FieldOptionalFor:
-			filteredPackage.OptionalFor = flattenRelations(pkg.GetRelations(field))
+			filteredPkg.OptionalFor = flattenRelations(pkg.GetRelations(field))
 		case consts.FieldProvides:
-			filteredPackage.Provides = flattenRelations(pkg.GetRelations(field))
+			filteredPkg.Provides = flattenRelations(pkg.GetRelations(field))
 		}
 	}
 
-	return &filteredPackage
+	return &filteredPkg
 }

--- a/internal/display/render_table.go
+++ b/internal/display/render_table.go
@@ -28,6 +28,7 @@ var columnHeaders = map[consts.FieldType]string{
 	consts.FieldDescription: "DESCRIPTION",
 	consts.FieldUrl:         "URL",
 	consts.FieldValidation:  "VALIDATION",
+	consts.FieldEnv:         "ENV",
 	consts.FieldPkgType:     "PKGTYPE",
 	consts.FieldPackager:    "PACKAGER",
 	consts.FieldAlsoIn:      "ALSO IN",

--- a/internal/pkgdata/packageinfo.go
+++ b/internal/pkgdata/packageinfo.go
@@ -122,6 +122,8 @@ func (pkg *PkgInfo) GetString(field consts.FieldType) string {
 		return pkg.Url
 	case consts.FieldValidation:
 		return pkg.Validation
+	case consts.FieldEnv:
+		return pkg.Env
 	case consts.FieldPkgType:
 		return pkg.PkgType
 	case consts.FieldPkgBase:


### PR DESCRIPTION
Users can now list the environment of packages in origins that support virtual environments with `qp select env` or or `qp s all`.

Example:
```
> qp s all w name=svg-term-cli --output kv
UPDATED     : 2025-03-05 01:57:34 AM UTC
SIZE        : 20.83 MB
NAME        : svg-term-cli
REASON      : explicit
VERSION     : 2.1.1
ORIGIN      : npm
ARCH        : any
LICENSE     : MIT
DESCRIPTION : Share terminal sessions as razor-sharp animated SVG
              everywhere
URL         : https://github.com/marionebl/svg-term-cli#readme
ENV         : node
PACKAGER    : Mario Nebl <hello@mario-nebl.de>
```

Note: This field is not currently populated by any origins, this is just an example. The next PR will populate this field for NPM.