### PR TITLE
Fix: Default provider depth

### DIFF
--- a/internal/pkgdata/dependency_resolution.go
+++ b/internal/pkgdata/dependency_resolution.go
@@ -220,7 +220,12 @@ func resolveProvisions(
 		return provisions
 	}
 
-	return []Relation{{Name: displayName, Version: version, Operator: operator}}
+	return []Relation{{
+		Name:     displayName,
+		Version:  version,
+		Operator: operator,
+		Depth:    1,
+	}}
 }
 
 // TODO: we can memoize this. we can also paralellize as well.


### PR DESCRIPTION
The default case not returning the default depth can create bugs where they'll show up as not installed.