### PR TITLE
Refactor: Pacman install history

### DIFF
--- a/internal/origins/drivers/pacman/constants.go
+++ b/internal/origins/drivers/pacman/constants.go
@@ -26,4 +26,11 @@ const (
 
 	pacmanDbDir   = "/var/lib/pacman/local"
 	pacmanLogPath = "/var/log/pacman.log"
+
+	etcMachineId = "/etc/machine-id"
+	etcHostname  = "/etc/machine-id"
+	bootLinux    = "/boot/vmlinuz-linux"
+	binPacman    = "/usr/bin/pacman"
+	etcPasswd    = "/etc/passwd"
+	etcGroup     = "/etc/group"
 )

--- a/internal/origins/drivers/pacman/fetch.go
+++ b/internal/origins/drivers/pacman/fetch.go
@@ -109,24 +109,23 @@ func fetchPackages(origin string, cacheRoot string) ([]*pkgdata.PkgInfo, error) 
 
 func getSystemInstallTime() (int64, error) {
 	systemPaths := []string{
-		"/etc/machine-id",
-		"/etc/hostname",
-		"/boot/vmlinuz-linux",
-		"/usr/bin/pacman",
-		"/var/lib/pacman",
-		"/etc/passwd",
-		"/etc/group",
+		etcMachineId,
+		etcHostname,
+		bootLinux,
+		binPacman,
+		etcPasswd,
+		etcGroup,
 	}
 
 	var oldestTime int64 = math.MaxInt64
-	foundAny := false
+	found := false
 
 	for _, path := range systemPaths {
 		if fileInfo, err := os.Stat(path); err == nil {
 			if birthTime, _, err := shared.GetCreationTime(path); err == nil {
 				if birthTime < oldestTime {
 					oldestTime = birthTime
-					foundAny = true
+					found = true
 				}
 
 				continue
@@ -135,12 +134,12 @@ func getSystemInstallTime() (int64, error) {
 			modTime := fileInfo.ModTime().Unix()
 			if modTime < oldestTime {
 				oldestTime = modTime
-				foundAny = true
+				found = true
 			}
 		}
 	}
 
-	if !foundAny {
+	if !found {
 		return 0, fmt.Errorf("could not determine system install time")
 	}
 


### PR DESCRIPTION
A minor refactor to pull the magic strings out of getSystemInstallTime. This function may be made more general for use by other drivers as well.