### PR TITLE
Feature: Add flatpak origin

### DIFF
--- a/internal/consts/origins.go
+++ b/internal/consts/origins.go
@@ -1,11 +1,12 @@
 package consts
 
 const (
-	OriginPacman = "pacman"
-	OriginBrew   = "brew"
-	OriginDeb    = "deb"
-	OriginOpkg   = "opkg"
-	OriginNpm    = "npm"
-	OriginPipx   = "pipx"
-	OriginRpm    = "rpm"
+	OriginBrew    = "brew"
+	OriginDeb     = "deb"
+	OriginFlatpak = "flatpak"
+	OriginNpm     = "npm"
+	OriginPacman  = "pacman"
+	OriginPipx    = "pipx"
+	OriginOpkg    = "opkg"
+	OriginRpm     = "rpm"
 )

--- a/internal/origins/drivers/flatpak/constants.go
+++ b/internal/origins/drivers/flatpak/constants.go
@@ -1,0 +1,42 @@
+package flatpak
+
+const (
+	systemInstallDir = "/var/lib/flatpak/"
+	userInstallDir   = ".local/share/flatpak/"
+
+	appsSubdir     = "app"
+	runtimeSubdir  = "runtime"
+	repoSubdir     = "repo"
+	metadataSubdir = "metadata"
+
+	scopeSystem = "system"
+	scopeUser   = "user"
+
+	remotesDir    = "repo/refs/remotes/"
+	remoteUnknown = "unknown"
+
+	metadataFile = "metadata"
+	activeFile   = "active"
+
+	sectionApplication = "Application"
+	sectionRuntime     = "Runtime"
+	sectionExtension   = "Extension "
+	fieldName          = "name"
+	fieldVersion       = "version"
+	fieldRuntime       = "runtime"
+	fieldBranch        = "branch"
+	fieldArch          = "arch"
+
+	fieldDirectory = "directory"
+	fieldLocale    = "locale"
+
+	metainfoDir    = "files/share/metainfo/"
+	appdataDir     = "files/share/appdata/"
+	dotMetainfoXml = ".metainfo.xml"
+	dotAppdataXml  = ".appdata.xml"
+
+	applicationsDir = "files/share/applications/"
+	dotDesktop      = ".desktop"
+
+	appdataVersion = "appdata-version"
+)

--- a/internal/origins/drivers/flatpak/discover.go
+++ b/internal/origins/drivers/flatpak/discover.go
@@ -1,0 +1,295 @@
+package flatpak
+
+import (
+	"os"
+	"path/filepath"
+	"qp/internal/origins/worker"
+	"qp/internal/pkgdata"
+	"strings"
+	"sync"
+)
+
+type PkgRef struct {
+	Pkg          *pkgdata.PkgInfo
+	Name         string
+	Type         string
+	Arch         string
+	Branch       string
+	Remote       string
+	Scope        string
+	CommitDir    string
+	NameDir      string
+	MetadataPath string
+	MetainfoPath string
+	DesktopPath  string
+}
+
+type PackageLocation struct {
+	InstallDir string
+	PkgType    string
+	PkgDir     string
+}
+
+type PackageCommit struct {
+	InstallDir string
+	PkgType    string
+	Name       string
+	Arch       string
+	Branch     string
+	CommitDir  string
+}
+
+func discoverPackages(
+	installDirs []string,
+	estimatedCount int,
+	errChan chan<- error,
+	errGroup *sync.WaitGroup,
+) <-chan *PkgRef {
+	jobChan := make(chan PackageLocation, len(installDirs)*2)
+
+	for _, installDir := range installDirs {
+		jobChan <- PackageLocation{
+			InstallDir: installDir,
+			PkgType:    appsSubdir,
+			PkgDir:     filepath.Join(installDir, appsSubdir),
+		}
+
+		jobChan <- PackageLocation{
+			InstallDir: installDir,
+			PkgType:    runtimeSubdir,
+			PkgDir:     filepath.Join(installDir, runtimeSubdir),
+		}
+	}
+	close(jobChan)
+
+	stage1Out := worker.RunWorkers(
+		jobChan,
+		errChan,
+		errGroup,
+		scanPackageDirectory,
+		0,
+		len(installDirs)*2,
+	)
+
+	commitChan := flattenCommits(stage1Out, estimatedCount)
+
+	stage2Out := worker.RunWorkers(
+		commitChan,
+		errChan,
+		errGroup,
+		validatePackageCommit,
+		0,
+		estimatedCount,
+	)
+
+	stage3Out := worker.RunWorkers(
+		stage2Out,
+		errChan,
+		errGroup,
+		findPackageFiles,
+		0,
+		estimatedCount,
+	)
+
+	stage4Out := worker.RunWorkers(
+		stage3Out,
+		errChan,
+		errGroup,
+		determinePackageRemote,
+		0,
+		estimatedCount,
+	)
+
+	return stage4Out
+}
+
+func scanPackageDirectory(loc PackageLocation) ([]PackageCommit, error) {
+	var commits []PackageCommit
+
+	nameEntries, err := os.ReadDir(loc.PkgDir)
+	if err != nil {
+		return nil, nil // dir doesn't exist, not an error
+	}
+
+	for _, nameEntry := range nameEntries {
+		if !nameEntry.IsDir() {
+			continue
+		}
+
+		nameDir := filepath.Join(loc.PkgDir, nameEntry.Name())
+
+		archEntries, err := os.ReadDir(nameDir)
+		if err != nil {
+			continue
+		}
+
+		for _, archEntry := range archEntries {
+			if !archEntry.IsDir() {
+				continue
+			}
+
+			archDir := filepath.Join(nameDir, archEntry.Name())
+
+			branchEntries, err := os.ReadDir(archDir)
+			if err != nil {
+				continue
+			}
+
+			for _, branchEntry := range branchEntries {
+				if !branchEntry.IsDir() {
+					continue
+				}
+
+				branchDir := filepath.Join(archDir, branchEntry.Name())
+
+				commitEntries, err := os.ReadDir(branchDir)
+				if err != nil {
+					continue
+				}
+
+				for _, commitEntry := range commitEntries {
+					if !commitEntry.IsDir() {
+						continue
+					}
+
+					commits = append(commits, PackageCommit{
+						InstallDir: loc.InstallDir,
+						PkgType:    loc.PkgType,
+						Name:       nameEntry.Name(),
+						Arch:       archEntry.Name(),
+						Branch:     branchEntry.Name(),
+						CommitDir:  filepath.Join(branchDir, commitEntry.Name()),
+					})
+				}
+			}
+		}
+	}
+
+	return commits, nil
+}
+
+func flattenCommits(commitSlices <-chan []PackageCommit, bufferSize int) <-chan PackageCommit {
+	out := make(chan PackageCommit, bufferSize)
+
+	go func() {
+		defer close(out)
+		for commits := range commitSlices {
+			for _, commit := range commits {
+				out <- commit
+			}
+		}
+	}()
+
+	return out
+}
+
+func validatePackageCommit(commit PackageCommit) (*PkgRef, error) {
+	metadataPath := filepath.Join(commit.CommitDir, metadataFile)
+	if _, err := os.Stat(metadataPath); err != nil {
+		return nil, worker.ErrSkip // no metadata, skip commit
+	}
+
+	if commit.PkgType == appsSubdir {
+		activePath := filepath.Join(filepath.Dir(commit.CommitDir), activeFile)
+		target, err := filepath.EvalSymlinks(activePath)
+
+		if err != nil || target != commit.CommitDir {
+			return nil, worker.ErrSkip // not the active version
+		}
+	}
+
+	scope := scopeSystem
+	if strings.Contains(commit.InstallDir, userInstallDir) {
+		scope = scopeUser
+	}
+
+	return &PkgRef{
+		Name:         commit.Name,
+		Type:         commit.PkgType,
+		Arch:         commit.Arch,
+		Branch:       commit.Branch,
+		Scope:        scope,
+		CommitDir:    commit.CommitDir,
+		NameDir:      filepath.Join(commit.InstallDir, commit.PkgType, commit.Name),
+		MetadataPath: metadataPath,
+	}, nil
+}
+
+func findPackageFiles(ref *PkgRef) (*PkgRef, error) {
+	metainfoSearchPaths := []string{
+		filepath.Join(ref.CommitDir, metainfoDir, ref.Name+dotMetainfoXml),
+		filepath.Join(ref.CommitDir, metainfoDir, ref.Name+dotAppdataXml),
+		filepath.Join(ref.CommitDir, appdataDir, ref.Name+dotAppdataXml),
+	}
+
+	for _, path := range metainfoSearchPaths {
+		if info, err := os.Stat(path); err == nil && !info.IsDir() {
+			ref.MetainfoPath = path
+			break
+		}
+	}
+
+	desktopPath := filepath.Join(ref.CommitDir, applicationsDir, ref.Name+dotDesktop)
+	if info, err := os.Stat(desktopPath); err == nil && !info.IsDir() {
+		ref.DesktopPath = desktopPath
+	}
+
+	return ref, nil
+}
+
+func determinePackageRemote(ref *PkgRef) (*PkgRef, error) {
+	pathParts := strings.Split(ref.CommitDir, string(filepath.Separator))
+	var installDir string
+
+	for i, part := range pathParts {
+		if part == ref.Type && i >= 1 {
+			installDir = filepath.Join(pathParts[:i]...)
+			break
+		}
+	}
+
+	if installDir == "" {
+		ref.Remote = remoteUnknown
+		return ref, nil
+	}
+
+	remotesDir := filepath.Join(installDir, remotesDir)
+	remoteEntries, err := os.ReadDir(remotesDir)
+	if err != nil {
+		ref.Remote = remoteUnknown
+		return ref, nil
+	}
+
+	refPath := filepath.Join(ref.Type, ref.Name, ref.Arch, ref.Branch)
+
+	for _, remoteEntry := range remoteEntries {
+		if !remoteEntry.IsDir() {
+			continue
+		}
+
+		remoteRefPath := filepath.Join(remotesDir, remoteEntry.Name(), refPath)
+		if _, err := os.Stat(remoteRefPath); err == nil {
+			ref.Remote = remoteEntry.Name()
+			return ref, nil
+		}
+	}
+
+	ref.Remote = remoteUnknown
+	return ref, nil
+}
+
+func estimatePackageCount(installDirs []string) int {
+	estimate := 0
+
+	for _, installDir := range installDirs {
+		for _, pkgType := range []string{appsSubdir, runtimeSubdir} {
+			baseDir := filepath.Join(installDir, pkgType)
+			if entries, err := os.ReadDir(baseDir); err == nil {
+				// TODO: perhaps we should use 1.5 and round the result
+				estimate += len(entries) * 2 // 1-2 commits per package on average
+			}
+		}
+	}
+
+	return max(estimate, 32)
+}

--- a/internal/origins/drivers/flatpak/driver.go
+++ b/internal/origins/drivers/flatpak/driver.go
@@ -1,0 +1,78 @@
+package flatpak
+
+import (
+	"os"
+	"path/filepath"
+	"qp/internal/consts"
+	"qp/internal/origins/shared"
+	"qp/internal/pkgdata"
+	"qp/internal/storage"
+)
+
+type FlatpakDriver struct {
+	installDirs []string
+}
+
+func (d *FlatpakDriver) Name() string {
+	return consts.OriginFlatpak
+}
+
+func (d *FlatpakDriver) Detect() bool {
+	if _, err := os.Stat(systemInstallDir); err == nil {
+		d.installDirs = append(d.installDirs, systemInstallDir)
+	}
+
+	home, err := os.UserHomeDir()
+	if err == nil {
+		userPath := filepath.Join(home, userInstallDir)
+		if _, err := os.Stat(userPath); err == nil {
+			d.installDirs = append(d.installDirs, userPath)
+		}
+	}
+
+	if len(d.installDirs) == 0 {
+		return false
+	}
+
+	return true
+}
+
+func (d *FlatpakDriver) Load(cacheRoot string) ([]*pkgdata.PkgInfo, error) {
+	return fetchPackages(d.Name(), d.installDirs)
+}
+
+func (d *FlatpakDriver) ResolveDeps(pkgs []*pkgdata.PkgInfo) ([]*pkgdata.PkgInfo, error) {
+	return pkgdata.ResolveDependencyGraph(mergeExtensions(pkgs), nil)
+}
+
+func (d *FlatpakDriver) LoadCache(cacheRoot string) ([]*pkgdata.PkgInfo, error) {
+	return storage.LoadProtoCache(cacheRoot)
+}
+
+func (d *FlatpakDriver) SaveCache(cacheRoot string, pkgs []*pkgdata.PkgInfo) error {
+	return storage.SaveProtoCache(cacheRoot, pkgs)
+}
+
+func (d *FlatpakDriver) IsCacheStale(cacheMtime int64) (bool, error) {
+	for _, installDir := range d.installDirs {
+		appDir := filepath.Join(installDir, appsSubdir)
+		runtimeDir := filepath.Join(installDir, runtimeSubdir)
+
+		for _, dir := range []string{appDir, runtimeDir} {
+			if _, err := os.Stat(dir); err != nil {
+				continue
+			}
+
+			isStale, err := shared.BfsStale(dir, cacheMtime, 2)
+			if err != nil {
+				return false, err
+			}
+
+			if isStale {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}

--- a/internal/origins/drivers/flatpak/fetch.go
+++ b/internal/origins/drivers/flatpak/fetch.go
@@ -1,0 +1,98 @@
+package flatpak
+
+import (
+	"fmt"
+	"path/filepath"
+	"qp/internal/origins/shared"
+	"qp/internal/origins/worker"
+	"qp/internal/pkgdata"
+	"sync"
+)
+
+func fetchPackages(origin string, installDirs []string) ([]*pkgdata.PkgInfo, error) {
+	estimatedCount := estimatePackageCount(installDirs)
+
+	errChan := make(chan error, worker.DefaultBufferSize)
+	var errGroup sync.WaitGroup
+
+	pkgRefChan := discoverPackages(installDirs, estimatedCount, errChan, &errGroup)
+
+	stage1Out := worker.RunWorkers(
+		pkgRefChan,
+		errChan,
+		&errGroup,
+		func(pkgRef *PkgRef) (*PkgRef, error) {
+			return parseMetadata(pkgRef)
+		},
+		0,
+		estimatedCount,
+	)
+
+	stage2Out := worker.RunWorkers(
+		stage1Out,
+		errChan,
+		&errGroup,
+		func(pkgRef *PkgRef) (*PkgRef, error) {
+			parseMetainfo(pkgRef)
+			if pkgRef.Pkg.Title == "" {
+				parseDesktopFile(pkgRef)
+			}
+
+			if err := applyTimestamps(pkgRef); err != nil {
+				return nil, err
+			}
+
+			return pkgRef, nil
+		},
+		0,
+		estimatedCount,
+	)
+
+	stage3Out := worker.RunWorkers(
+		stage2Out,
+		errChan,
+		&errGroup,
+		func(pkgRef *PkgRef) (*PkgRef, error) {
+			deployPath := filepath.Join(pkgRef.CommitDir, "deploy")
+			version, err := extractVersion(deployPath)
+			if err != nil {
+				fmt.Println(err)
+			}
+
+			pkgRef.Pkg.Version = version
+
+			return pkgRef, nil
+		},
+		0,
+		estimatedCount,
+	)
+
+	stage4Out := worker.RunWorkers(
+		stage3Out,
+		errChan,
+		&errGroup,
+		func(pkgRef *PkgRef) (*pkgdata.PkgInfo, error) {
+			pkg := pkgRef.Pkg
+			size, err := shared.GetInstallSize(pkgRef.CommitDir)
+			if err != nil {
+				return nil, err
+			}
+
+			pkg.PkgType = pkgRef.Type
+			pkg.Env = fmt.Sprintf("%s (%s)", pkgRef.Scope, pkgRef.Branch)
+			pkg.Size = size
+			pkg.Origin = origin
+
+			return pkg, nil
+		},
+		0,
+		estimatedCount,
+	)
+
+	go func() {
+		errGroup.Wait()
+		close(errChan)
+	}()
+
+	return worker.CollectOutput(stage4Out, errChan)
+}

--- a/internal/origins/drivers/flatpak/history.go
+++ b/internal/origins/drivers/flatpak/history.go
@@ -1,0 +1,25 @@
+package flatpak
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func applyTimestamps(pkgRef *PkgRef) error {
+	activePath := filepath.Join(
+		pkgRef.NameDir,
+		pkgRef.Arch,
+		pkgRef.Branch,
+		"active",
+	)
+
+	info, err := os.Lstat(activePath)
+	if err != nil {
+		return fmt.Errorf("failed to stat activePath at %s: %w", activePath, err)
+	}
+
+	pkgRef.Pkg.UpdateTimestamp = info.ModTime().Unix()
+	// TODO: add creation time, once one of our packages updates so we can actually test it
+	return nil
+}

--- a/internal/origins/drivers/flatpak/merge.go
+++ b/internal/origins/drivers/flatpak/merge.go
@@ -1,0 +1,43 @@
+package flatpak
+
+import (
+	"qp/internal/pkgdata"
+)
+
+func mergeExtensions(pkgs []*pkgdata.PkgInfo) []*pkgdata.PkgInfo {
+	pkgMap := make(map[string]*pkgdata.PkgInfo)
+	results := make([]*pkgdata.PkgInfo, 0, len(pkgs))
+
+	for _, pkg := range pkgs {
+		uniqueKey := pkg.Name + "|" + pkg.Env
+		pkgMap[uniqueKey] = pkg
+	}
+
+	for _, pkg := range pkgs {
+		if pkg, exists := pkgMap[pkg.Name+"|"+pkg.Env]; exists {
+			optDepRels := []pkgdata.Relation{}
+
+			for _, optDepRel := range pkg.OptDepends {
+				if optDepRel.PkgType == pkg.Name {
+					optKey := optDepRel.Name + "|" + pkg.Env
+					if optDepPkg, exists := pkgMap[optKey]; exists {
+						pkg.Size += optDepPkg.Size
+					}
+
+					delete(pkgMap, optKey)
+					continue
+				}
+
+				optDepRels = append(optDepRels, optDepRel)
+			}
+
+			pkg.OptDepends = optDepRels
+		}
+	}
+
+	for _, pkg := range pkgMap {
+		results = append(results, pkg)
+	}
+
+	return results
+}

--- a/internal/origins/drivers/flatpak/parse_desktop.go
+++ b/internal/origins/drivers/flatpak/parse_desktop.go
@@ -1,0 +1,42 @@
+package flatpak
+
+import (
+	"bytes"
+	"os"
+	"strings"
+)
+
+const sectionDesktopEntry = "[Desktop Entry]"
+
+func parseDesktopFile(pkgRef *PkgRef) {
+	if pkgRef.DesktopPath == "" {
+		return
+	}
+
+	data, err := os.ReadFile(pkgRef.DesktopPath)
+	if err != nil {
+	}
+
+	var currentSection string
+	for rawLine := range bytes.SplitSeq(data, []byte("\n")) {
+		if len(rawLine) > 0 {
+			line := strings.TrimSpace(string(rawLine))
+			if line == sectionDesktopEntry {
+				currentSection = line
+				continue
+			}
+
+			if currentSection == sectionDesktopEntry {
+				parts := strings.Split(line, "=")
+				if len(parts) != 2 {
+					continue
+				}
+
+				key, value := parts[0], parts[1]
+				if key == "Name" {
+					pkgRef.Pkg.Title = strings.TrimSpace(value)
+				}
+			}
+		}
+	}
+}

--- a/internal/origins/drivers/flatpak/parse_metadata.go
+++ b/internal/origins/drivers/flatpak/parse_metadata.go
@@ -1,0 +1,122 @@
+package flatpak
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"qp/internal/consts"
+	"qp/internal/pkgdata"
+	"strings"
+)
+
+func parseMetadata(pkgRef *PkgRef) (*PkgRef, error) {
+	file, err := os.Open(pkgRef.MetadataPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open %s metadta file %s: %w", pkgRef.Name, pkgRef.MetadataPath, err)
+	}
+
+	defer file.Close()
+
+	pkg := &pkgdata.PkgInfo{
+		Name:   pkgRef.Name,
+		Arch:   pkgRef.Arch,
+		Reason: consts.ReasonExplicit,
+	}
+
+	scanner := bufio.NewScanner(file)
+
+	var currentSection string
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			currentSection = strings.Trim(line, "[]")
+			if strings.HasPrefix(currentSection, sectionExtension) {
+				applyExtensionSection(pkg, currentSection)
+			}
+
+			continue
+		}
+
+		if strings.Contains(line, "=") {
+			key, value := parseKeyValue(line)
+			applyMetadataField(pkg, currentSection, key, value)
+			continue
+		}
+	}
+
+	pkgRef.Pkg = pkg
+	return pkgRef, nil
+}
+
+func parseKeyValue(line string) (string, string) {
+	parts := strings.SplitN(line, "=", 2)
+	if len(parts) != 2 {
+		return "", ""
+	}
+
+	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+}
+
+func applyMetadataField(
+	pkg *pkgdata.PkgInfo,
+	section string,
+	key string,
+	value string,
+) {
+	switch section {
+	case sectionApplication:
+		applyApplicationField(pkg, key, value)
+	default:
+		// TODO: extension
+	}
+}
+
+func applyApplicationField(pkg *pkgdata.PkgInfo, key string, value string) {
+	switch key {
+	case fieldRuntime:
+		rel, err := parseRuntime(value)
+		if err == nil {
+			pkg.Depends = append(pkg.Depends, rel)
+		}
+	}
+}
+
+func applyExtensionSection(pkg *pkgdata.PkgInfo, section string) {
+	sectionParts := strings.SplitN(section, " ", 2)
+	if len(sectionParts) != 2 {
+		return
+	}
+
+	extPart := sectionParts[1]
+	lastDot := strings.LastIndex(extPart, ".")
+	baseName := extPart[:lastDot]
+
+	if baseName == pkg.Name {
+		extType := extPart[lastDot:]
+
+		switch extType {
+		case ".Locale", ".Debug", ".Source":
+			pkg.OptDepends = append(pkg.OptDepends, pkgdata.Relation{Name: extPart, PkgType: pkg.Name})
+			return
+		}
+	}
+
+	pkg.OptDepends = append(pkg.OptDepends, pkgdata.Relation{Name: extPart})
+}
+
+func parseRuntime(runtimeDir string) (pkgdata.Relation, error) {
+	parts := strings.SplitN(runtimeDir, string(os.PathSeparator), 3)
+	if len(parts) != 3 {
+		return pkgdata.Relation{}, fmt.Errorf("malformed runtime value: %s", runtimeDir)
+	}
+
+	name := parts[0]
+	version := parts[len(parts)-1]
+
+	return pkgdata.Relation{Name: name, Version: version, Operator: pkgdata.OpEqual}, nil
+}

--- a/internal/origins/drivers/flatpak/parse_metainfo.go
+++ b/internal/origins/drivers/flatpak/parse_metainfo.go
@@ -1,0 +1,79 @@
+package flatpak
+
+import (
+	"encoding/xml"
+	"os"
+	"qp/internal/pkgdata"
+	"strings"
+)
+
+type MetainfoXml struct {
+	XmlName xml.Name `xml:"component"`
+	Id      string   `xml:"id"`
+	Names   []struct {
+		XmlLang string `xml:"xml:lang,attr"`
+		Name    string `xml:",chardata"`
+	} `xml:"name"`
+	Summaries []struct {
+		XmlLang string `xml:"xml:lang,attr"`
+		Summary string `xml:",chardata"`
+	} `xml:"summary"`
+	Description struct {
+		Paragraphs []string `xml:"p"`
+	} `xml:"description"`
+	ProjectLicense string `xml:"project_license"`
+	DeveloperName  string `xml:"developer_name"`
+	Urls           []struct {
+		Type string `xml:"type,attr"`
+		Url  string `xml:",chardata"`
+	} `xml:"url"`
+}
+
+func parseMetainfo(pkgRef *PkgRef) {
+	if pkgRef.MetainfoPath == "" {
+		return
+	}
+
+	data, err := os.ReadFile(pkgRef.MetainfoPath)
+	if err != nil {
+		// return nil, fmt.Errorf("failed to read metainfo xml at %s: %w", pkgRef.MetainfoPath)
+	}
+
+	var component MetainfoXml
+
+	if err = xml.Unmarshal(data, &component); err != nil {
+	}
+
+	applyMetainfo(pkgRef.Pkg, component)
+}
+
+func applyMetainfo(pkg *pkgdata.PkgInfo, metainfo MetainfoXml) {
+	for _, summary := range metainfo.Summaries {
+		if summary.XmlLang == "" {
+			pkg.Description = summary.Summary
+			break
+		}
+	}
+
+	for _, name := range metainfo.Names {
+		if name.XmlLang == "" {
+			pkg.Title = name.Name
+			break
+		}
+	}
+
+	if metainfo.ProjectLicense != "" {
+		pkg.License = strings.TrimSpace(metainfo.ProjectLicense)
+	}
+
+	if metainfo.DeveloperName != "" {
+		pkg.Packager = metainfo.DeveloperName
+	}
+
+	for _, url := range metainfo.Urls {
+		if url.Type == "homepage" {
+			pkg.Url = url.Url
+			break
+		}
+	}
+}

--- a/internal/origins/drivers/flatpak/version.go
+++ b/internal/origins/drivers/flatpak/version.go
@@ -1,0 +1,40 @@
+package flatpak
+
+import (
+	"bytes"
+	"os"
+)
+
+func extractVersion(deployPath string) (string, error) {
+	data, err := os.ReadFile(deployPath)
+	if err != nil {
+		return "", err
+	}
+
+	pattern := []byte(appdataVersion)
+	index := bytes.Index(data, pattern)
+	if index == -1 {
+		return "", nil
+	}
+
+	start := index + len(pattern)
+	if start >= len(data) {
+		return "", nil
+	}
+
+	if start < len(data) && data[start] == 0 {
+		start++
+	}
+
+	var version []byte
+	for i := start; i < len(data); i++ {
+		b := data[i]
+		if b == 0 || b < 32 || b > 126 {
+			break
+		}
+
+		version = append(version, b)
+	}
+
+	return string(version), nil
+}

--- a/internal/origins/registry.go
+++ b/internal/origins/registry.go
@@ -4,6 +4,7 @@ import (
 	"qp/api/driver"
 	"qp/internal/origins/drivers/brew"
 	"qp/internal/origins/drivers/deb"
+	"qp/internal/origins/drivers/flatpak"
 	"qp/internal/origins/drivers/npm"
 	"qp/internal/origins/drivers/opkg"
 	"qp/internal/origins/drivers/pacman"
@@ -12,12 +13,13 @@ import (
 )
 
 var registeredDrivers = []driver.Driver{
-	&opkg.OpkgDriver{},
-	&deb.DebDriver{},
 	&brew.BrewDriver{},
+	&deb.DebDriver{},
+	&flatpak.FlatpakDriver{},
+	&opkg.OpkgDriver{},
+	&npm.NpmDriver{},
 	&pacman.PacmanDriver{},
 	&pipx.PipxDriver{},
-	&npm.NpmDriver{},
 	&rpm.RpmDriver{},
 }
 

--- a/internal/storage/constants.go
+++ b/internal/storage/constants.go
@@ -1,7 +1,7 @@
 package storage
 
 const (
-	cacheVersion   = 29 // bump when updating structure of PkgInfo/Relation/pkginfo.proto OR when dependency resolution is updated
+	cacheVersion   = 30 // bump when updating structure of PkgInfo/Relation/pkginfo.proto OR when dependency resolution is updated
 	historyVersion = 3
 
 	xdgCacheHomeEnv = "XDG_CACHE_HOME"


### PR DESCRIPTION
We now have flatpak support. Flatpak was quite a bit more complex than expected, but all the expected metadata is here, including quite a bit of metadata that `flatpak list --all` does not offer. We may use the remote (flatpak origin) instead of the author as the packager, as that could be misleading. Author could possibly be a different field.

```
> qp select all where origin=flatpak --output kv
UPDATED     : 2025-06-10 06:53:36 PM MDT
SIZE        : 27.93 MB
FREEABLE    : 27.93 MB
FOOTPRINT   : 859.82 MB
NAME        : de.haeckerfelix.Shortwave
TITLE       : Shortwave
REASON      : explicit
VERSION     : 5.0.0
ORIGIN      : flatpak
ARCH        : x86_64
LICENSE     : GPL-3.0-or-later
DESCRIPTION : Listen to internet radio
URL         : https://apps.gnome.org/Shortwave/
ENV         : system (stable)
PKGTYPE     : app
PACKAGER    : Фелікс Хекер (Felix Häcker)
DEPENDS     : org.gnome.Platform=48

UPDATED     : 2025-06-14 04:36:20 PM MDT
SIZE        : 442.62 MB
FREEABLE    : 442.62 MB
FOOTPRINT   : 442.62 MB
NAME        : org.freedesktop.Platform.GL.default
TITLE       : Mesa
REASON      : explicit
VERSION     : 25.1.3
ORIGIN      : flatpak
ARCH        : x86_64
LICENSE     : MIT
DESCRIPTION : Mesa - The 3D Graphics Library
URL         : https://freedesktop-sdk.gitlab.io/
ENV         : system (24.08)
PKGTYPE     : runtime
OTHER ENVS  : system (23.08), system (23.08-extra), system (24.08extra)
```