### PR TITLE
Refactor: Flatpak origin

### DIFF
--- a/internal/origins/drivers/flatpak/constants.go
+++ b/internal/origins/drivers/flatpak/constants.go
@@ -4,8 +4,8 @@ const (
 	systemInstallDir = "/var/lib/flatpak/"
 	userInstallDir   = ".local/share/flatpak/"
 
-	appsSubdir     = "app"
-	runtimeSubdir  = "runtime"
+	typeApp        = "app"
+	typeRuntime    = "runtime"
 	repoSubdir     = "repo"
 	metadataSubdir = "metadata"
 

--- a/internal/origins/drivers/flatpak/discover.go
+++ b/internal/origins/drivers/flatpak/discover.go
@@ -50,14 +50,14 @@ func discoverPackages(
 	for _, installDir := range installDirs {
 		jobChan <- PackageLocation{
 			InstallDir: installDir,
-			PkgType:    appsSubdir,
-			PkgDir:     filepath.Join(installDir, appsSubdir),
+			PkgType:    typeApp,
+			PkgDir:     filepath.Join(installDir, typeApp),
 		}
 
 		jobChan <- PackageLocation{
 			InstallDir: installDir,
-			PkgType:    runtimeSubdir,
-			PkgDir:     filepath.Join(installDir, runtimeSubdir),
+			PkgType:    typeRuntime,
+			PkgDir:     filepath.Join(installDir, typeRuntime),
 		}
 	}
 	close(jobChan)
@@ -189,7 +189,7 @@ func validatePackageCommit(commit PackageCommit) (*PkgRef, error) {
 		return nil, worker.ErrSkip // no metadata, skip commit
 	}
 
-	if commit.PkgType == appsSubdir {
+	if commit.PkgType == typeApp {
 		activePath := filepath.Join(filepath.Dir(commit.CommitDir), activeFile)
 		target, err := filepath.EvalSymlinks(activePath)
 
@@ -282,7 +282,7 @@ func estimatePackageCount(installDirs []string) int {
 	estimate := 0
 
 	for _, installDir := range installDirs {
-		for _, pkgType := range []string{appsSubdir, runtimeSubdir} {
+		for _, pkgType := range []string{typeApp, typeRuntime} {
 			baseDir := filepath.Join(installDir, pkgType)
 			if entries, err := os.ReadDir(baseDir); err == nil {
 				// TODO: perhaps we should use 1.5 and round the result

--- a/internal/origins/drivers/flatpak/driver.go
+++ b/internal/origins/drivers/flatpak/driver.go
@@ -55,8 +55,8 @@ func (d *FlatpakDriver) SaveCache(cacheRoot string, pkgs []*pkgdata.PkgInfo) err
 
 func (d *FlatpakDriver) IsCacheStale(cacheMtime int64) (bool, error) {
 	for _, installDir := range d.installDirs {
-		appDir := filepath.Join(installDir, appsSubdir)
-		runtimeDir := filepath.Join(installDir, runtimeSubdir)
+		appDir := filepath.Join(installDir, typeApp)
+		runtimeDir := filepath.Join(installDir, typeRuntime)
 
 		for _, dir := range []string{appDir, runtimeDir} {
 			if _, err := os.Stat(dir); err != nil {

--- a/internal/origins/drivers/flatpak/fetch.go
+++ b/internal/origins/drivers/flatpak/fetch.go
@@ -54,10 +54,7 @@ func fetchPackages(origin string, installDirs []string) ([]*pkgdata.PkgInfo, err
 		&errGroup,
 		func(pkgRef *PkgRef) (*PkgRef, error) {
 			deployPath := filepath.Join(pkgRef.CommitDir, "deploy")
-			version, err := extractVersion(deployPath)
-			if err != nil {
-				fmt.Println(err)
-			}
+			version, _ := extractVersion(deployPath)
 
 			pkgRef.Pkg.Version = version
 

--- a/internal/origins/drivers/flatpak/parse_metadata.go
+++ b/internal/origins/drivers/flatpak/parse_metadata.go
@@ -17,10 +17,15 @@ func parseMetadata(pkgRef *PkgRef) (*PkgRef, error) {
 
 	defer file.Close()
 
+	reason := consts.ReasonExplicit
+	if pkgRef.Type == typeRuntime {
+		reason = consts.ReasonDependency
+	}
+
 	pkg := &pkgdata.PkgInfo{
 		Name:   pkgRef.Name,
 		Arch:   pkgRef.Arch,
-		Reason: consts.ReasonExplicit,
+		Reason: reason,
 	}
 
 	scanner := bufio.NewScanner(file)


### PR DESCRIPTION
Minor refactor of the flatpak origin. Runtimes are set as dependencies and version extraction does not print errors.