### PR TITLE
Feature: Improve other-env resolution

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,10 @@ linters:
     - govet
     - staticcheck
     - errcheck
+    - lll
   settings:
+    lll:
+      line-length: 95
     revive:
       rules:
         - name: var-naming

--- a/internal/pkgdata/enrichment.go
+++ b/internal/pkgdata/enrichment.go
@@ -45,12 +45,12 @@ func EnrichAcrossOrigins(pkgs []*PkgInfo) []*PkgInfo {
 					continue
 				}
 
-				if otherPkg.Origin != pkg.Origin {
+				if pkg.Origin != otherPkg.Origin {
 					otherOrigins = append(otherOrigins, otherPkg.Origin)
 					continue
 				}
 
-				if pkg.Env != "" {
+				if pkg.Env != "" && pkg.Title == otherPkg.Title {
 					otherEnvs = append(otherEnvs, otherPkg.Env)
 				}
 			}


### PR DESCRIPTION
Flatpaks can share the same id but can have separate titles, this allows cross-origin enrichment to handle that.