### PR TITLE
Refactor: Remove unused progress bar functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,6 @@ qp [command] [args] [options]
 
 - `--no-headers`: omit column headers in table output (useful for scripting)
 - `--full-timestamp`: display the full timestamp (date and time) of package update/build instead of just the date
-- `--no-progress`: force no progress bar outside of non-interactive environments
 - `--no-cache`: disable cache loading/saving and force fresh package data loading
 - `--regen-cache`: disable cache loading, force fresh package data loading, and save fresh cache
 - `--cache-only`: update cache only and nothing else. specify origin ('pacman', 'brew', 'deb', etc.) or all.
@@ -668,7 +667,7 @@ output format:
 
   boolean flags can be explicitly set using `--<option>=true` or `--<option>=false`:
   ```
-  qp --no-headers=true --no-progress=true
+  qp --no-headers=true
   ```
 
   arguments to queries can be quoted if they contain special characters or spaces:
@@ -680,9 +679,6 @@ output format:
   ```
   qp --no-headers select name,size | awk '{print $1, $2}'
   ```
-
-  **note**: `--no-progress` is automatically set to `true` in non-interactive environments, so you can pipe into programs like `cat`, `grep`, or `less` without issue.
-
 
 ### examples
 

--- a/cmd/qp/main.go
+++ b/cmd/qp/main.go
@@ -39,7 +39,6 @@ func mainWithConfig(configProvider config.ConfigProvider) error {
 		return rebuildCache(cfg.CacheWorker)
 	}
 
-	isInteractive := isInteractive(cfg.DisableProgress)
 	cacheBaseDir, err := storage.GetCachePath()
 	if err != nil {
 		out.WriteLine(fmt.Sprintf("WARNING: failed to set up cache dir: %v", err))
@@ -91,7 +90,7 @@ func mainWithConfig(configProvider config.ConfigProvider) error {
 	}
 
 	if len(allPkgs) == 0 {
-		if isInteractive {
+		if isInteractive() {
 			out.WriteLine("No packages to display.")
 		}
 
@@ -112,6 +111,6 @@ func mainWithConfig(configProvider config.ConfigProvider) error {
 	return nil
 }
 
-func isInteractive(disableProgress bool) bool {
-	return term.IsTerminal(int(os.Stdout.Fd())) && !disableProgress
+func isInteractive() bool {
+	return term.IsTerminal(int(os.Stdout.Fd()))
 }

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -8,7 +8,10 @@ import (
 	"github.com/spf13/pflag"
 )
 
-const internalCacheWorker = "internal-cache-worker"
+const (
+	internalCacheWorker = "internal-cache-worker"
+	noProgress          = "no-progress"
+)
 
 func ParseFlags(args []string) (Config, error) {
 	var cfg Config
@@ -51,13 +54,14 @@ func registerCommonFlags(cfg *Config) {
 	pflag.BoolVarP(&cfg.ShowHelp, "help", "h", false, "Show help")
 	pflag.BoolVar(&cfg.ShowVersion, "version", false, "Show version")
 	pflag.BoolVar(&cfg.ShowFullTimestamp, "full-timestamp", false, "Show full timestamp")
-	pflag.BoolVar(&cfg.DisableProgress, "no-progress", false, "Disable progress bar")
+	pflag.BoolVar(&cfg.DisableProgress, noProgress, false, "Disable progress bar")
 	pflag.BoolVar(&cfg.NoCache, "no-cache", false, "Disable cache")
 	pflag.BoolVar(&cfg.RegenCache, "regen-cache", false, "Force fresh cache")
 	pflag.StringVar(&cfg.CacheOnly, "cache-only", "", "Update cache only for specifed origin.")
 	pflag.StringVar(&cfg.CacheWorker, internalCacheWorker, "", "Internal flag for background cache operations - do not use directly")
 
 	_ = pflag.CommandLine.MarkHidden(internalCacheWorker)
+	_ = pflag.CommandLine.MarkHidden(noProgress)
 
 	var legacyJSON bool
 	pflag.BoolVar(&legacyJSON, "json", false, "")

--- a/internal/display/output_manager.go
+++ b/internal/display/output_manager.go
@@ -48,10 +48,6 @@ func PrintProgress(phase string, progress int, description string) {
 	manager.printProgress(phase, progress, description)
 }
 
-func ClearProgress() {
-	manager.clearProgress()
-}
-
 func RenderTable(
 	pkgPtrs []*pkgdata.PkgInfo,
 	fields []consts.FieldType,
@@ -86,10 +82,6 @@ func (o *OutputManager) printProgress(phase string, progress int, description st
 
 	o.write("\r\033[K" + msg)
 	o.lastMsgLength = len(msg)
-}
-
-func (o *OutputManager) clearProgress() {
-	o.clearPrevMsg(0)
 }
 
 func (o *OutputManager) formatProgessMsg(phase string, progress int, description string) string {

--- a/internal/display/render_kv.go
+++ b/internal/display/render_kv.go
@@ -14,8 +14,6 @@ type kvEntry struct {
 }
 
 func (o *OutputManager) renderKeyValue(pkgs []*pkgdata.PkgInfo, fields []consts.FieldType) {
-	o.clearProgress()
-
 	dateFormat := consts.DateTimeFormat
 	ctx := tableContext{DateFormat: dateFormat}
 

--- a/internal/display/render_table.go
+++ b/internal/display/render_table.go
@@ -53,8 +53,6 @@ func (o *OutputManager) renderTable(
 	showFullTimestamp bool,
 	hasNoHeaders bool,
 ) {
-	o.clearProgress()
-
 	dateFormat := consts.DateOnlyFormat
 	if showFullTimestamp {
 		dateFormat = consts.DateTimeFormat

--- a/qp.1
+++ b/qp.1
@@ -68,9 +68,6 @@ Omit column headers (useful in scripts).
 .B \-\-full-timestamp
 Show full date+time for install/build timestamps.
 .TP
-.B \-\-no-progress
-Disable progress bar.
-.TP
 .B \-\-no-cache
 Skip using cache, force fresh data load.
 .TP


### PR DESCRIPTION
In preparation to convert the ProgressMessage API into a logging API, we're removing the (now) unused functions for clearing the progress bar.