### PR TITLE
Feature: Deprecate alphabetical order alias

### DIFF
--- a/internal/consts/fields.go
+++ b/internal/consts/fields.go
@@ -119,9 +119,8 @@ var FieldTypeLookup = map[string]FieldType{
 	"bd":   FieldBuilt,
 	"type": FieldPkgType,
 
-	"date":         FieldUpdated, // legacy field
-	"build-date":   FieldBuilt,   // legacy field
-	"alphabetical": FieldName,    // legacy flag, to be deprecated
+	"date":       FieldUpdated, // legacy field
+	"build-date": FieldBuilt,   // legacy field
 
 	installed:   FieldInstalled,
 	updated:     FieldUpdated,


### PR DESCRIPTION
The "alphabetical" alias for "name" has been deprecated in preparation for adding autocomplete.