### PR TITLE
Feature: Bash and Zsh autocompletions

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	DisableProgress   bool
 	NoCache           bool
 	RegenCache        bool
+	ShowCompletion    bool
 	CacheOnly         string
 	CacheWorker       string
 	OutputFormat      string

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -59,6 +59,7 @@ func registerCommonFlags(cfg *Config) {
 	pflag.BoolVar(&cfg.RegenCache, "regen-cache", false, "Force fresh cache")
 	pflag.StringVar(&cfg.CacheOnly, "cache-only", "", "Update cache only for specifed origin.")
 	pflag.StringVar(&cfg.CacheWorker, internalCacheWorker, "", "Internal flag for background cache operations - do not use directly")
+	pflag.BoolVar(&cfg.ShowCompletion, "completion", false, "Generate bash completion script")
 
 	_ = pflag.CommandLine.MarkHidden(internalCacheWorker)
 	_ = pflag.CommandLine.MarkHidden(noProgress)

--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"qp/internal/about"
+	"qp/internal/quipple"
 )
 
 func (c *CliConfigProvider) GetConfig() (*Config, error) {
@@ -18,6 +20,11 @@ func (c *CliConfigProvider) GetConfig() (*Config, error) {
 
 	if cfg.ShowVersion {
 		about.PrintVersionInfo()
+		os.Exit(0)
+	}
+
+	if cfg.ShowCompletion {
+		fmt.Print(quipple.GetBashCompletion())
 		os.Exit(0)
 	}
 

--- a/internal/consts/fields.go
+++ b/internal/consts/fields.go
@@ -108,17 +108,6 @@ const (
 )
 
 var FieldTypeLookup = map[string]FieldType{
-	"u":    FieldUpdated,
-	"n":    FieldName,
-	"r":    FieldReason,
-	"s":    FieldSize,
-	"v":    FieldVersion,
-	"D":    FieldDepends,
-	"R":    FieldRequiredBy,
-	"p":    FieldProvides,
-	"bd":   FieldBuilt,
-	"type": FieldPkgType,
-
 	"date":       FieldUpdated, // legacy field
 	"build-date": FieldBuilt,   // legacy field
 

--- a/internal/quipple/completions.go
+++ b/internal/quipple/completions.go
@@ -1,0 +1,173 @@
+package quipple
+
+import (
+	"fmt"
+	"qp/internal/consts"
+	"sort"
+	"strings"
+)
+
+func formatForBash(completions []string) string {
+	return strings.Join(completions, " ")
+}
+
+func formatForZsh(completions []string) string {
+	return "'" + strings.Join(completions, "' '") + "'"
+}
+
+func GetBashCompletion() string {
+	commands := []string{
+		CmdSelect, "s",
+		CmdWhere, "w",
+		CmdOrder, "o",
+		CmdLimit, "l",
+		CmdFormat, "f",
+	}
+	commandsStr := strings.Join(commands, " ")
+
+	var fieldNames []string
+	for fieldName := range consts.FieldTypeLookup {
+		fieldNames = append(fieldNames, fieldName)
+	}
+
+	selectCompletions := append(fieldNames, SelectMacros...)
+	sort.Strings(selectCompletions)
+
+	var whereFieldNames []string
+	for _, fieldName := range fieldNames {
+		whereFieldNames = append(whereFieldNames, fieldName+"=")
+	}
+	sort.Strings(whereFieldNames)
+
+	var whereCompletions []string
+	whereCompletions = append(whereCompletions, whereFieldNames...)
+	whereCompletions = append(whereCompletions, WhereMacros...)
+	sort.Strings(whereCompletions)
+
+	orderCompletions := fieldNames
+	limitCompletions := LimitMacros
+	formatCompletions := []string{consts.OutputTable, consts.OutputJSON, consts.OutputKeyValue}
+
+	selectBash := formatForBash(selectCompletions)
+	whereBash := formatForBash(whereCompletions)
+	orderBash := formatForBash(orderCompletions)
+	limitBash := formatForBash(limitCompletions)
+	formatBash := formatForBash(formatCompletions)
+
+	selectZsh := formatForZsh(selectCompletions)
+	whereZsh := formatForZsh(whereCompletions)
+	orderZsh := formatForZsh(orderCompletions)
+	limitZsh := formatForZsh(limitCompletions)
+	formatZsh := formatForZsh(formatCompletions)
+
+	return fmt.Sprintf(
+		`
+if [[ -n "$BASH_VERSION" ]]; then
+  _qp_completion() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD - 1]}"
+
+    case "${prev}" in
+    %s | s)
+      COMPREPLY=($(compgen -W "%s" -- "${cur}"))
+      return 0
+      ;;
+    %s | w)
+      COMPREPLY=($(compgen -W "%s" -- "${cur}"))
+      if [[ "${cur}" != *"=" ]] && [[ "${COMPREPLY[0]}" == *"=" ]]; then
+        compopt -o nospace 2>/dev/null || true
+      fi
+      return 0
+      ;;
+    %s | o)
+      COMPREPLY=($(compgen -W "%s" -- "${cur}"))
+      return 0
+      ;;
+    %s | l)
+      COMPREPLY=($(compgen -W "%s" -- "${cur}"))
+      return 0
+      ;;
+    %s | f)
+      COMPREPLY=($(compgen -W "%s" -- "${cur}"))
+      return 0
+      ;;
+    *)
+      COMPREPLY=($(compgen -W "%s" -- "${cur}"))
+      return 0
+      ;;
+    esac
+  }
+  complete -F _qp_completion qp
+fi
+
+if [[ -n "$ZSH_VERSION" ]]; then
+  _qp_completion() {
+    local curcontext="$curcontext" state line
+    typeset -A opt_args
+
+    case $words[1] in
+    qp)
+      case $words[2] in
+      select | s)
+        local -a fields
+        fields=(%s)
+        _describe -t fields 'fields' fields -S ','
+        ;;
+      where | w)
+        local -a where_opts
+        where_opts=(%s)
+        _describe -t where-options 'where options' where_opts -S ''
+        ;;
+      order | o)
+        local -a order_opts
+        order_opts=(%s)
+        _describe -t order-options 'order options' order_opts
+        ;;
+      limit | o)
+        local -a limit_opts
+        limit_opts=(%s)
+        _describe -t limit-options 'limit options' limit_opts
+        ;;
+      format | f)
+        local -a formats
+        formats=(%s)
+        _describe -t formats 'formats' formats
+        ;;
+      *)
+        _values 'commands' \
+          'select[Select fields to display]' \
+          's[Select fields (short)]' \
+          'where[Filter packages]' \
+          'w[Where (short)]' \
+          'order[Sort results]' \
+          'o[Order (short)]' \
+          'limit[Limit results]' \
+          'l[Limit (short)]' \
+          'format[Output format]' \
+          'f[Format (short)]'
+        ;;
+      esac
+      ;;
+    esac
+  }
+  compdef _qp_completion qp
+fi
+`,
+		CmdSelect,
+		selectBash,
+		CmdWhere,
+		whereBash,
+		CmdOrder,
+		orderBash,
+		CmdLimit,
+		limitBash,
+		CmdFormat,
+		formatBash,
+		commandsStr,
+		selectZsh,
+		whereZsh,
+		orderZsh,
+		limitZsh,
+		formatZsh,
+	)
+}

--- a/internal/quipple/constants.go
+++ b/internal/quipple/constants.go
@@ -34,3 +34,28 @@ var CmdNameLookup = map[CmdType]string{
 	BlockLimit:  CmdLimit,
 	BlockFormat: CmdFormat,
 }
+
+const (
+	MacroOrphan      = "orphan"
+	MacroSuperOrphan = "superorphan"
+	MacroHeavy       = "heavy"
+	MacroLight       = "light"
+	MacroAll         = "all"
+	MacroDefault     = "default"
+)
+
+var SelectMacros = []string{
+	MacroAll,
+	MacroDefault,
+}
+
+var WhereMacros = []string{
+	MacroOrphan,
+	MacroSuperOrphan,
+	MacroHeavy,
+	MacroLight,
+}
+
+var LimitMacros = []string{
+	MacroAll,
+}

--- a/internal/quipple/preprocess/macro_engine.go
+++ b/internal/quipple/preprocess/macro_engine.go
@@ -21,9 +21,9 @@ func macroExpansion(token string, cmd quipple.CmdType) ([]string, bool) {
 
 func expandSelectMacro(token string) ([]string, bool) {
 	switch token {
-	case "default":
+	case quipple.MacroDefault:
 		return fieldTypesToNames(consts.DefaultFields), true
-	case "all":
+	case quipple.MacroAll:
 		return fieldTypesToNames(consts.ValidFields), true
 	default:
 		return nil, false
@@ -45,13 +45,13 @@ func expandWhereMacro(token string) ([]string, bool) {
 	var expanded []string
 
 	switch token {
-	case "orphan":
+	case quipple.MacroOrphan:
 		expanded = []string{"no:required-by", "and", "reason=dependency"}
-	case "superorphan":
+	case quipple.MacroSuperOrphan:
 		expanded = []string{"no:required-by", "and", "reason=dependency", "and", "no:optional-for"}
-	case "heavy":
+	case quipple.MacroHeavy:
 		expanded = []string{"size=100MB:"}
-	case "light":
+	case quipple.MacroLight:
 		expanded = []string{"size=:1MB"}
 	default:
 		return nil, false
@@ -68,7 +68,7 @@ func expandLimitMacro(token string) ([]string, bool) {
 	}
 
 	switch token {
-	case "all":
+	case quipple.MacroAll:
 		return []string{prefix + "0"}, true
 	default:
 		return nil, false


### PR DESCRIPTION
This adds Bash and Zsh autocomplete for `qp`. Commands, fields, and macros can be autocompleted when tab is hit. 

Users can manually install via:
```
qp --completion > /tmp/qp_completion.bash && source /tmp/qp_completion.bash
```

This may be added into install scripts for packaging, but for now users will have to install this manually. Official documentation will follow.

More extensive autocomplete features such as value and direction completion are planned.