### PR TITLE
Fix: Date filter always in UTC timezone

### DIFF
--- a/internal/pipeline/filtering/date.go
+++ b/internal/pipeline/filtering/date.go
@@ -54,7 +54,7 @@ func parseDateMatch(dateInput string, defaultDate int64) (int64, error) {
 }
 
 func parseValidDate(dateInput string) (int64, error) {
-	parsedDate, err := time.Parse(consts.DateOnlyFormat, dateInput)
+	parsedDate, err := time.ParseInLocation(consts.DateOnlyFormat, dateInput, time.Local)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/pipeline/filtering/matchers.go
+++ b/internal/pipeline/filtering/matchers.go
@@ -11,12 +11,12 @@ type RangeMatcher map[bool]map[consts.MatchType]func(start int64, end int64) Ran
 
 var DateMatchers = RangeMatcher{
 	true: {
-		consts.MatchFuzzy: func(start, _ int64) RangeFilter {
+		consts.MatchFuzzy: func(start int64, _ int64) RangeFilter {
 			return func(value int64) bool {
 				return pkgdata.FuzzyDate(value, start)
 			}
 		},
-		consts.MatchStrict: func(start, _ int64) RangeFilter {
+		consts.MatchStrict: func(start int64, _ int64) RangeFilter {
 			return func(value int64) bool {
 				return pkgdata.StrictDate(value, start)
 			}
@@ -24,12 +24,12 @@ var DateMatchers = RangeMatcher{
 	},
 
 	false: {
-		consts.MatchFuzzy: func(start, end int64) RangeFilter {
+		consts.MatchFuzzy: func(start int64, end int64) RangeFilter {
 			return func(value int64) bool {
 				return pkgdata.FuzzyDateRange(value, start, end)
 			}
 		},
-		consts.MatchStrict: func(start, end int64) RangeFilter {
+		consts.MatchStrict: func(start int64, end int64) RangeFilter {
 			return func(value int64) bool {
 				return pkgdata.StrictDateRange(value, start, end)
 			}


### PR DESCRIPTION
Input dates were timezones were always in UTC, now they are in the machine's timezone.

Previously:
```
> qp limit 3   
UPDATED     NAME    REASON      SIZE
2025-07-21  qp      explicit    9.57 MB
2025-07-21  snapd   explicit    49.29 MB
2025-07-21  core24  dependency  66.79 MB
>
qp > qp where updated=2025-07-21
No packages to display.
```

Post-bugfix:
```
> qp where updated=2025-07-21
UPDATED     NAME    REASON      SIZE
2025-07-21  qp      explicit    9.57 MB
2025-07-21  snapd   explicit    49.29 MB
2025-07-21  core24  dependency  66.79 MB
```