### PR TITLE
Feature: Add pkgtool origin (Slackware support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **qp** queries over 6x faster than native package searching while returning more comprehensive metadata than native package search solutions.
 
-Query packages from `apk`, `brew`, `pacman`, `apt`, `flatpak`, `snap`, `npm`, `pipx`, `dnf`, and `opkg`. Ecosystems are added frequently!
+Query packages from `apk`, `brew`, `pacman`, `apt`, `flatpak`, `snap`, `npm`, `pipx`, `dnf`, `pkgtool`, and `opkg`. Ecosystems are added frequently!
 
 **qp** supports querying with full boolean logic for package metadata, dependency relations, and more.
 
@@ -54,7 +54,8 @@ This package is compatible with the following platforms and distributions:
  - [Mabox Linux](https://maboxlinux.org/)
  - [Zorin OS](https://zorin.com/os/)
  - [elementary OS](https://elementary.io/)
- - The 50 other Arch, Debian, and Fedora-based distros, as long as they have `apk`, `apt`/`dpkg`, `brew`, `pacman`, `flatpak`, `dnf`/`yum`, or `opkg` installed.
+ - [Slackware](http://www.slackware.com/)
+ - The 50 other Arch, Debian, and Fedora-based distros, as long as they have `apk`, `apt`/`dpkg`, `brew`, `pacman`, `flatpak`, `dnf`/`yum`, `pkgtool`, or `opkg` installed.
 
 **qp** also detects and queries other system level package managers like `flatpak`, `snap`, `npm`, and `pipx` for globally installed applications, expanding package discovery beyond traditional system package management.
 
@@ -66,7 +67,7 @@ This package is compatible with the following platforms and distributions:
 * Compatible with MacOS, Arch, Debian, OpenWrt, and over 60 distros
   * Supports multiple ecosystems:
     * System package managers:
-      * `apk`, `pacman`, `brew`, `apt`/`dpkg`, `dnf`/`yum`, and `opkg`
+      * `apk`, `pacman`, `brew`, `apt`/`dpkg`, `dnf`/`yum`, `pkgtool`, and `opkg`
     * Application package managers:
       * `flatpak`, `snap`, `npm`, and `pipx`
 * Query packages using an expressive query language
@@ -197,6 +198,7 @@ Learn about installation [here](#Installation).
 | - | log levels | ✓ | chunked cache (70% speed boost) |
 | ✓ | apk origin (alpine linux support) | ✓ | optimize creation-time validation |
 | - | package for apk (alpine) | - | log file |  
+| ✓ | pkgtool origin (slackware support) | ✓ | multi-line queries |
 
 ## Installation
 
@@ -349,6 +351,7 @@ The `pkgtype` field indicates the type or category of package within each ecosys
 | deb | none | - |
 | rpm | none | - |
 | opkg | none | - |
+| pkgtool | none | - |
 | pipx | none | - |
 | npm | none | - |
 

--- a/internal/consts/origins.go
+++ b/internal/consts/origins.go
@@ -8,6 +8,7 @@ const (
 	OriginNpm     = "npm"
 	OriginOpkg    = "opkg"
 	OriginPacman  = "pacman"
+	OriginPkgtool = "pkgtool"
 	OriginPipx    = "pipx"
 	OriginRpm     = "rpm"
 	OriginSnap    = "snap"
@@ -21,6 +22,7 @@ var ValidOrigins = []string{
 	OriginNpm,
 	OriginOpkg,
 	OriginPacman,
+	OriginPkgtool,
 	OriginPipx,
 	OriginRpm,
 	OriginSnap,

--- a/internal/origins/drivers/pkgtool/constants.go
+++ b/internal/origins/drivers/pkgtool/constants.go
@@ -1,0 +1,10 @@
+package pkgtool
+
+const (
+	packagesDbPath = "/var/log/packages"
+
+	fieldPackageName        = "PACKAGE NAME"
+	fieldUncompressedSize   = "UNCOMPRESSED PACKAGE SIZE"
+	fieldPackageDescription = "PACKAGE DESCRIPTION"
+	fieldFileList           = "FILE LIST"
+)

--- a/internal/origins/drivers/pkgtool/driver.go
+++ b/internal/origins/drivers/pkgtool/driver.go
@@ -1,0 +1,41 @@
+package pkgtool
+
+import (
+	"os"
+	"qp/internal/consts"
+	"qp/internal/origins/shared"
+	"qp/internal/pkgdata"
+	"qp/internal/storage"
+)
+
+type PkgtoolDriver struct{}
+
+func (d *PkgtoolDriver) Name() string {
+	return consts.OriginPkgtool
+}
+
+func (d *PkgtoolDriver) Detect() bool {
+	_, err := os.Stat(packagesDbPath)
+
+	return err == nil
+}
+
+func (d *PkgtoolDriver) Load(_ string) ([]*pkgdata.PkgInfo, error) {
+	return fetchPackages(d.Name())
+}
+
+func (d *PkgtoolDriver) ResolveDeps(pkgs []*pkgdata.PkgInfo) ([]*pkgdata.PkgInfo, error) {
+	return pkgdata.ResolveDependencyGraph(pkgs, nil)
+}
+
+func (d *PkgtoolDriver) LoadCache(cacheRoot string) ([]*pkgdata.PkgInfo, error) {
+	return storage.LoadProtoCache(cacheRoot)
+}
+
+func (d *PkgtoolDriver) SaveCache(cacheRoot string, pkgs []*pkgdata.PkgInfo) error {
+	return storage.SaveProtoCache(cacheRoot, pkgs)
+}
+
+func (d *PkgtoolDriver) IsCacheStale(cacheMtime int64) (bool, error) {
+	return shared.BfsStale(packagesDbPath, cacheMtime, 1)
+}

--- a/internal/origins/drivers/pkgtool/fetch.go
+++ b/internal/origins/drivers/pkgtool/fetch.go
@@ -1,0 +1,51 @@
+package pkgtool
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"qp/internal/pkgdata"
+	"qp/internal/worker"
+	"sync"
+)
+
+func fetchPackages(origin string) ([]*pkgdata.PkgInfo, error) {
+	entries, err := os.ReadDir(packagesDbPath)
+	if err != nil {
+		return []*pkgdata.PkgInfo{}, fmt.Errorf("failed to read package install directories: %w", err)
+	}
+
+	inputChan := make(chan string, len(entries))
+	errChan := make(chan error, worker.DefaultBufferSize)
+	var errGroup sync.WaitGroup
+
+	var pkgs []*pkgdata.PkgInfo
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			inputChan <- filepath.Join(packagesDbPath, entry.Name())
+			pkg, _ := parsePackageFile(filepath.Join(packagesDbPath, entry.Name()), origin)
+			pkgs = append(pkgs, pkg)
+		}
+	}
+
+	close(inputChan)
+
+	resultChan := worker.RunWorkers(
+		inputChan,
+		errChan,
+		&errGroup,
+		func(packagePath string) (*pkgdata.PkgInfo, error) {
+			return parsePackageFile(packagePath, origin)
+		},
+		0,
+		len(entries),
+	)
+
+	go func() {
+		errGroup.Wait()
+		close(errChan)
+	}()
+
+	return worker.CollectOutput(resultChan, errChan)
+}

--- a/internal/origins/drivers/pkgtool/fetch.go
+++ b/internal/origins/drivers/pkgtool/fetch.go
@@ -19,13 +19,9 @@ func fetchPackages(origin string) ([]*pkgdata.PkgInfo, error) {
 	errChan := make(chan error, worker.DefaultBufferSize)
 	var errGroup sync.WaitGroup
 
-	var pkgs []*pkgdata.PkgInfo
-
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			inputChan <- filepath.Join(packagesDbPath, entry.Name())
-			pkg, _ := parsePackageFile(filepath.Join(packagesDbPath, entry.Name()), origin)
-			pkgs = append(pkgs, pkg)
 		}
 	}
 

--- a/internal/origins/drivers/pkgtool/parser.go
+++ b/internal/origins/drivers/pkgtool/parser.go
@@ -1,0 +1,101 @@
+package pkgtool
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"qp/internal/consts"
+	"qp/internal/pkgdata"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+func parsePackageFile(packagePath string, origin string) (*pkgdata.PkgInfo, error) {
+	data, err := os.ReadFile(packagePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open package metadata: %w", err)
+	}
+
+	pkg := &pkgdata.PkgInfo{
+		Origin: origin,
+		Reason: consts.ReasonExplicit,
+	}
+
+	inDesc := false
+	var description []string
+
+	for line := range bytes.SplitSeq(data, []byte("\n")) {
+		parts := strings.SplitN(string(line), ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		key, value := parts[0], parts[1]
+
+		switch key {
+		case fieldPackageName:
+			extractMetadata(value, pkg)
+		case fieldUncompressedSize:
+			pkg.Size = extractSize(value)
+		case fieldPackageDescription:
+			inDesc = true
+		case fieldFileList:
+			// exit metadata file
+			break
+		default:
+			if inDesc {
+				description = append(description, strings.TrimSpace(value))
+			}
+
+		}
+	}
+
+	fileInfo, _ := os.Stat(packagePath)
+	pkg.UpdateTimestamp = fileInfo.ModTime().Unix()
+	pkg.Description = strings.Join(description, " ")
+
+	return pkg, nil
+}
+
+func extractMetadata(value string, pkg *pkgdata.PkgInfo) {
+	trimmed := strings.TrimSpace(value)
+	parts := strings.Split(trimmed, "-")
+	if len(parts) < 4 {
+		return
+	}
+
+	pkg.Arch = parts[len(parts)-2]
+	pkg.Version = parts[len(parts)-3]
+	pkg.Name = strings.Join(parts[:len(parts)-3], "-")
+}
+
+func extractSize(value string) int64 {
+	sizeStr := strings.TrimSpace(value)
+	firstLetterIdx := strings.IndexFunc(sizeStr, func(char rune) bool {
+		return unicode.IsLetter(char)
+	})
+
+	rawSize, err := strconv.ParseFloat(sizeStr[:firstLetterIdx], 64)
+	if err != nil {
+		return 0
+	}
+
+	unit := sizeStr[firstLetterIdx:]
+	var size int64
+
+	switch unit {
+	case "G":
+		size = int64(rawSize * consts.GB)
+	case "M":
+		size = int64(rawSize * consts.MB)
+	case "K":
+		size = int64(rawSize * consts.KB)
+	case "B":
+		fallthrough
+	default:
+		size = int64(rawSize)
+	}
+
+	return size
+}

--- a/internal/origins/registry.go
+++ b/internal/origins/registry.go
@@ -10,6 +10,7 @@ import (
 	"qp/internal/origins/drivers/opkg"
 	"qp/internal/origins/drivers/pacman"
 	"qp/internal/origins/drivers/pipx"
+	"qp/internal/origins/drivers/pkgtool"
 	"qp/internal/origins/drivers/rpm"
 	"qp/internal/origins/drivers/snap"
 )
@@ -22,6 +23,7 @@ var registeredDrivers = []driver.Driver{
 	&opkg.OpkgDriver{},
 	&npm.NpmDriver{},
 	&pacman.PacmanDriver{},
+	&pkgtool.PkgtoolDriver{},
 	&pipx.PipxDriver{},
 	&rpm.RpmDriver{},
 	&snap.SnapDriver{},

--- a/qp.1
+++ b/qp.1
@@ -8,7 +8,7 @@ qp \- query packages. A CLI utility for querying installed packages across multi
 
 .SH DESCRIPTION
 .B qp
-is a fast, flexible, and standalone CLI utility for querying installed packages across multiple package ecosystems and operating systems. It supports Arch Linux (pacman), Debian/Ubuntu (apt/dpkg), Homebrew (brew), OpenWrt (opkg), Fedora/RHEL (dnf/yum), Alpine Linux (apk), and application-level ecosystems like pipx, npm, snap, + flatpak.
+is a fast, flexible, and standalone CLI utility for querying installed packages across multiple package ecosystems and operating systems. It supports Arch Linux (pacman), Debian/Ubuntu (apt/dpkg), Homebrew (brew), OpenWrt (opkg), Fedora/RHEL (dnf/yum), Alpine Linux (apk), pkgtool (Slackware), and application-level ecosystems like pipx, npm, snap, + flatpak.
 
 Features include:
 - Cross-platform package discovery


### PR DESCRIPTION
Users can now query for packages on Slackware installed via `pkgtool` or `slackpkg`.

```
> qp select default,origin
UPDATED     NAME          REASON    SIZE       ORIGIN
2025-08-18  gawk          explicit  4.60 MB    pkgtool
2025-08-18  gettext       explicit  2.70 MB    pkgtool
2025-08-18  libcgroup     explicit  1.40 MB    pkgtool
2025-08-18  patch         explicit  320.00 KB  pkgtool
2025-08-18  sysfsutils    explicit  200.00 KB  pkgtool
2025-08-18  time          explicit  90.00 KB   pkgtool
2025-08-18  tree          explicit  210.00 KB  pkgtool
2025-08-18  utempter      explicit  180.00 KB  pkgtool
2025-08-18  which         explicit  140.00 KB  pkgtool
2025-08-18  util-linux    explicit  26.00 MB   pkgtool
2025-08-18  elogind       explicit  5.40 MB    pkgtool
2025-08-18  libseccomp    explicit  470.00 KB  pkgtool
2025-08-18  mpfr          explicit  1.10 MB    pkgtool
2025-08-18  libunistring  explicit  2.90 MB    pkgtool
2025-08-18  diffutils     explicit  1.80 MB    pkgtool
2025-08-18  procps-ng     explicit  4.80 MB    pkgtool
2025-08-18  net-tools     explicit  530.00 KB  pkgtool
2025-08-18  findutils     explicit  2.10 MB    pkgtool
2025-08-18  iproute2      explicit  4.30 MB    pkgtool
2025-08-18  openssl       explicit  18.00 MB   pkgtool
```